### PR TITLE
introduce lambda-http module based on lando to support apigateway

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "lambda_http"
+version = "0.1.0"
+authors = ["Doug Tangren"]
+description = "Rust API Gateway interfaces for AWS Lambda"
+keywords = ["AWS", "Lambda", "Runtime", "Rust"]
+license = "Apache-2.0"
+homepage = "https://github.com/awslabs/aws-lambda-rust-runtime"
+repository = "https://github.com/awslabs/aws-lambda-rust-runtime"
+documentation = "https://docs.rs/lambda_runtime"
+
+[dependencies]
+http = "0.1"
+serde = "^1"
+serde_json = "^1"
+serde_derive = "^1"
+lambda_runtime = { path = "../lambda-runtime", version = "^0.1" }
+tokio = "^0.1"
+base64 = "0.10"
+failure = "0.1"
+failure_derive = "0.1"
+serde_urlencoded = "0.5"

--- a/lambda-http/examples/basic.rs
+++ b/lambda-http/examples/basic.rs
@@ -1,0 +1,31 @@
+extern crate lambda_runtime as lambda;
+extern crate lambda_http;
+extern crate log;
+extern crate simple_logger;
+
+use lambda_http::{lambda, Request, Response};
+use lambda::{error::HandlerError, Context};
+
+use log::error;
+use serde_derive::{Deserialize, Serialize};
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    simple_logger::init_with_level(log::Level::Debug).unwrap();
+    lambda!(my_handler);
+
+    Ok(())
+}
+
+fn my_handler(e: Request, c: Context) -> Result<Response, HandlerError> {
+    let name = e.query_string_parameters().get("first_name");
+    Ok(match name {
+      Some(first_name) => {
+        Response::new(format!("Hello, {}!", first_name).into())
+      },
+      _ => {
+        error!("Empty first name in request {}", c.aws_request_id);
+        Response::builder(400).body("Empty first name").expect("failed to render response").into()
+      }
+    })
+}

--- a/lambda-http/src/body.rs
+++ b/lambda-http/src/body.rs
@@ -1,0 +1,241 @@
+//! Provides an API Gateway oriented request and response body entity interface
+
+use std::borrow::Cow;
+use std::ops::Deref;
+
+use base64::display::Base64Display;
+use serde::ser::{Error as SerError, Serialize, Serializer};
+
+/// Representation of http request and response bodies as supported
+/// by API Gateway.
+///
+/// These come in three flavors
+/// * `Empty` ( no body )
+/// * `Text` ( text data )
+/// * `Binary` ( binary data )
+///
+/// Body types can be `Deref` and `AsRef`'d into `[u8]` types much like the `hyper` crate
+///
+/// # Examples
+///
+/// Body types are inferred with `From` implementations.
+///
+/// ## Text
+///
+/// Types like `String`, `str` whose type reflects
+/// text produce `Body::Text` variants
+///
+/// ```
+/// assert!(match lambda_http::Body::from("text") {
+///   lambda_http::Body::Text(_) => true,
+///   _ => false
+/// })
+/// ```
+///
+/// ## Binary
+///
+/// Types like `Vec<u8>` and `&[u8]` whose types reflect raw bytes produce `Body::Binary` variants
+///
+/// ```
+/// assert!(match lambda_http::Body::from("text".as_bytes()) {
+///   lambda_http::Body::Binary(_) => true,
+///   _ => false
+/// })
+/// ```
+///
+/// `Binary` responses bodies will automatically get based64 encoded to meet API Gateway's response expectations.
+///
+/// ## Empty
+///
+/// The unit type ( `()` ) whose type represents an empty value produces `Body::Empty` variants
+///
+/// ```
+/// assert!(match lambda_http::Body::from(()) {
+///   lambda_http::Body::Empty => true,
+///   _ => false
+/// })
+/// ```
+///
+///
+/// For more information about API Gateway's body types,
+/// refer to [this documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html).
+#[derive(Debug, PartialEq)]
+pub enum Body {
+    /// An empty body
+    Empty,
+    /// A body containing string data
+    Text(String),
+    /// A body containing binary data
+    Binary(Vec<u8>),
+}
+
+impl Default for Body {
+    fn default() -> Self {
+        Body::Empty
+    }
+}
+
+impl From<()> for Body {
+    fn from(_: ()) -> Self {
+        Body::Empty
+    }
+}
+
+impl<'a> From<&'a str> for Body {
+    fn from(s: &'a str) -> Self {
+        Body::Text(s.into())
+    }
+}
+
+impl From<String> for Body {
+    fn from(b: String) -> Self {
+        Body::Text(b)
+    }
+}
+
+impl From<Cow<'static, str>> for Body {
+    #[inline]
+    fn from(cow: Cow<'static, str>) -> Body {
+        match cow {
+            Cow::Borrowed(b) => Body::from(b.to_owned()),
+            Cow::Owned(o) => Body::from(o),
+        }
+    }
+}
+
+impl From<Cow<'static, [u8]>> for Body {
+    #[inline]
+    fn from(cow: Cow<'static, [u8]>) -> Body {
+        match cow {
+            Cow::Borrowed(b) => Body::from(b),
+            Cow::Owned(o) => Body::from(o),
+        }
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(b: Vec<u8>) -> Self {
+        Body::Binary(b)
+    }
+}
+
+impl<'a> From<&'a [u8]> for Body {
+    fn from(b: &'a [u8]) -> Self {
+        Body::Binary(b.to_vec())
+    }
+}
+
+impl Deref for Body {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl AsRef<[u8]> for Body {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Body::Empty => &[],
+            Body::Text(ref bytes) => bytes.as_ref(),
+            Body::Binary(ref bytes) => bytes.as_ref(),
+        }
+    }
+}
+
+impl<'a> Serialize for Body {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Body::Text(data) => {
+                serializer.serialize_str(::std::str::from_utf8(data.as_ref()).map_err(S::Error::custom)?)
+            }
+            Body::Binary(data) => {
+                serializer.collect_str(&Base64Display::with_config(data, base64::STANDARD))
+            }
+            Body::Empty => serializer.serialize_unit(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn body_has_default() {
+        assert_eq!(Body::default(), Body::Empty);
+    }
+
+    #[test]
+    fn from_unit() {
+        assert_eq!(Body::from(()), Body::Empty);
+    }
+
+    #[test]
+    fn from_str() {
+        match Body::from(String::from("foo").as_str()) {
+            Body::Text(_) => (),
+            not => assert!(false, "expected Body::Text(...) got {:?}", not),
+        }
+    }
+
+    #[test]
+    fn from_string() {
+        match Body::from(String::from("foo")) {
+            Body::Text(_) => (),
+            not => assert!(false, "expected Body::Text(...) got {:?}", not),
+        }
+    }
+
+    #[test]
+    fn from_cow_str() {
+        match Body::from(Cow::from("foo")) {
+            Body::Text(_) => (),
+            not => assert!(false, "expected Body::Text(...) got {:?}", not),
+        }
+    }
+
+    #[test]
+    fn from_cow_bytes() {
+        match Body::from(Cow::from("foo".as_bytes())) {
+            Body::Binary(_) => (),
+            not => assert!(false, "expected Body::Binary(...) got {:?}", not),
+        }
+    }
+
+    #[test]
+    fn from_bytes() {
+        match Body::from("foo".as_bytes()) {
+            Body::Binary(_) => (),
+            not => assert!(false, "expected Body::Binary(...) got {:?}", not),
+        }
+    }
+
+    #[test]
+    fn serialize_text() {
+        let mut map = HashMap::new();
+        map.insert("foo", Body::from("bar"));
+        assert_eq!(serde_json::to_string(&map).unwrap(), r#"{"foo":"bar"}"#);
+    }
+
+    #[test]
+    fn serialize_binary() {
+        let mut map = HashMap::new();
+        map.insert("foo", Body::from("bar".as_bytes()));
+        assert_eq!(serde_json::to_string(&map).unwrap(), r#"{"foo":"YmFy"}"#);
+    }
+
+    #[test]
+    fn serialize_empty() {
+        let mut map = HashMap::new();
+        map.insert("foo", Body::Empty);
+        assert_eq!(serde_json::to_string(&map).unwrap(), r#"{"foo":null}"#);
+    }
+}

--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -1,0 +1,264 @@
+//! API Gateway extension methods for `http::Request` types
+
+use http::header::CONTENT_TYPE;
+use http::Request as HttpRequest;
+use serde::de::value::Error as SerdeError;
+use serde::Deserialize;
+use serde_json;
+use serde_urlencoded;
+
+use request::RequestContext;
+use strmap::StrMap;
+
+/// API gateway pre-parsed http query string parameters
+pub(crate) struct QueryStringParameters(pub(crate) StrMap);
+
+/// API gateway pre-extracted url path parameters
+pub(crate) struct PathParameters(pub(crate) StrMap);
+
+/// API gateway configured
+/// [stage variables](https://docs.aws.amazon.com/apigateway/latest/developerguide/stage-variables.html)
+pub(crate) struct StageVariables(pub(crate) StrMap);
+
+/// Payload deserialization errors
+#[derive(Debug, Fail)]
+pub enum PayloadError {
+    /// Returned when `application/json` bodies fail to deserialize a payload
+    #[fail(display = "failed to parse payload from application/json")]
+    Json(serde_json::Error),
+    /// Returned when `application/x-www-form-urlencoded` bodies fail to deserialize a payload
+    #[fail(display = "failed to parse payload application/x-www-form-urlencoded")]
+    WwwFormUrlEncoded(SerdeError),
+}
+
+/// Extentions for `lambda_http::Request` structs that
+/// provide access to [API gateway features](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format)
+///
+/// In addition, you can also access a request's body in deserialized format
+/// for payloads sent in `application/x-www-form-urlencoded` or
+/// `application/x-www-form-urlencoded` format
+///
+/// ```rust,no_run
+/// #[macro_use] extern crate lambda_http;
+/// extern crate lambda_runtime as lambda;
+/// #[macro_use] extern crate serde_derive;
+///
+/// use lambda::{Context, HandlerError};
+/// use lambda_http::{Request, Response, RequestExt};
+///
+/// #[derive(Debug,Deserialize,Default)]
+/// struct Args {
+///   #[serde(default)]
+///   x: usize,
+///   #[serde(default)]
+///   y: usize
+/// }
+///
+/// fn main() {
+///   lambda!(handler)
+/// }
+///
+/// fn handler(
+///   request: Request,
+///   ctx: lambda::Context
+/// ) -> Result<Response, lambda::HandlerError> {
+///   let args: Args = request.payload()
+///     .unwrap_or_else(|_parse_err| None)
+///     .unwrap_or_default();
+///   Ok(
+///      Response::new(
+///        format!(
+///          "{} + {} = {}",
+///          args.x,
+///          args.y,
+///          args.x + args.y
+///        ).into()
+///      )
+///   )
+/// }
+/// ```
+pub trait RequestExt {
+    /// Return pre-parsed http query string parameters, parameters
+    /// provided after the `?` portion of a url,
+    /// associated with the API gateway request. No query parameters
+    /// will yield an empty `StrMap`.
+    fn query_string_parameters(&self) -> StrMap;
+    /// Return pre-extracted path parameters, parameter provided in url placeholders
+    /// `/foo/{bar}/baz/{boom}`,
+    /// associated with the API gateway request. No path parameters
+    /// will yield an empty `StrMap`
+    fn path_parameters(&self) -> StrMap;
+    /// Return [stage variables](https://docs.aws.amazon.com/apigateway/latest/developerguide/stage-variables.html)
+    /// associated with the API gateway request. No stage parameters
+    /// will yield an empty `StrMap`
+    fn stage_variables(&self) -> StrMap;
+    /// Return request context data assocaited with the API gateway request
+    fn request_context(&self) -> RequestContext;
+
+    /// Return the Result of a payload parsed into a serde Deserializeable
+    /// type
+    ///
+    /// Currently only `application/x-www-form-urlencoded`
+    /// and `application/json` flavors of content type
+    /// are supported
+    ///
+    /// A [PayloadError](enum.PayloadError.html) will be returned for undeserializable
+    /// payloads. If no body is provided, `Ok(None)` will be returned.
+    fn payload<D>(&self) -> Result<Option<D>, PayloadError>
+    where
+        for<'de> D: Deserialize<'de>;
+}
+
+impl RequestExt for HttpRequest<super::Body> {
+    fn query_string_parameters(&self) -> StrMap {
+        self.extensions()
+            .get::<QueryStringParameters>()
+            .map(|ext| ext.0.clone())
+            .unwrap_or_default()
+    }
+    fn path_parameters(&self) -> StrMap {
+        self.extensions()
+            .get::<PathParameters>()
+            .map(|ext| ext.0.clone())
+            .unwrap_or_default()
+    }
+    fn stage_variables(&self) -> StrMap {
+        self.extensions()
+            .get::<StageVariables>()
+            .map(|ext| ext.0.clone())
+            .unwrap_or_default()
+    }
+
+    fn request_context(&self) -> RequestContext {
+        self.extensions()
+            .get::<RequestContext>()
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn payload<D>(&self) -> Result<Option<D>, PayloadError>
+    where
+        for<'de> D: Deserialize<'de>,
+    {
+        self.headers()
+            .get(CONTENT_TYPE)
+            .map(|ct| match ct.to_str() {
+                Ok("application/x-www-form-urlencoded") => {
+                    serde_urlencoded::from_bytes::<D>(self.body().as_ref())
+                        .map_err(PayloadError::WwwFormUrlEncoded)
+                        .map(Some)
+                }
+                Ok("application/json") => serde_json::from_slice::<D>(self.body().as_ref())
+                    .map_err(PayloadError::Json)
+                    .map(Some),
+                _ => Ok(None),
+            })
+            .unwrap_or_else(|| Ok(None))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::HeaderMap;
+    use http::Request as HttpRequest;
+    use std::collections::HashMap;
+    use {GatewayRequest, RequestExt, StrMap};
+
+    #[test]
+    fn requests_have_query_string_ext() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Host", "www.rust-lang.org".parse().unwrap());
+        let mut query = HashMap::new();
+        query.insert("foo".to_owned(), "bar".to_owned());
+        let gwr: GatewayRequest = GatewayRequest {
+            path: "/foo".into(),
+            headers,
+            query_string_parameters: StrMap(query.clone().into()),
+            ..GatewayRequest::default()
+        };
+        let actual = HttpRequest::from(gwr);
+        assert_eq!(
+            actual.query_string_parameters(),
+            StrMap(query.clone().into())
+        );
+    }
+
+    #[test]
+    fn requests_have_form_post_parseable_payloads() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Host", "www.rust-lang.org".parse().unwrap());
+        headers.insert(
+            "Content-Type",
+            "application/x-www-form-urlencoded".parse().unwrap(),
+        );
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Payload {
+            foo: String,
+            baz: usize,
+        }
+        let gwr: GatewayRequest = GatewayRequest {
+            path: "/foo".into(),
+            headers,
+            body: Some("foo=bar&baz=2".into()),
+            ..GatewayRequest::default()
+        };
+        let actual = HttpRequest::from(gwr);
+        let payload: Option<Payload> = actual.payload().unwrap_or_default();
+        assert_eq!(
+            payload,
+            Some(Payload {
+                foo: "bar".into(),
+                baz: 2
+            })
+        )
+    }
+
+    #[test]
+    fn requests_have_form_post_parseable_payloads_for_hashmaps() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Host", "www.rust-lang.org".parse().unwrap());
+        headers.insert(
+            "Content-Type",
+            "application/x-www-form-urlencoded".parse().unwrap(),
+        );
+        let gwr: GatewayRequest = GatewayRequest {
+            path: "/foo".into(),
+            headers,
+            body: Some("foo=bar&baz=2".into()),
+            ..GatewayRequest::default()
+        };
+        let actual = HttpRequest::from(gwr);
+        let mut expected = HashMap::new();
+        expected.insert("foo".to_string(), "bar".to_string());
+        expected.insert("baz".to_string(), "2".to_string());
+        let payload: Option<HashMap<String, String>> = actual.payload().unwrap_or_default();
+        assert_eq!(payload, Some(expected))
+    }
+
+    #[test]
+    fn requests_have_json_parseable_payloads() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Host", "www.rust-lang.org".parse().unwrap());
+        headers.insert("Content-Type", "application/json".parse().unwrap());
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Payload {
+            foo: String,
+            baz: usize,
+        }
+        let gwr: GatewayRequest = GatewayRequest {
+            path: "/foo".into(),
+            headers,
+            body: Some(r#"{"foo":"bar", "baz": 2}"#.into()),
+            ..GatewayRequest::default()
+        };
+        let actual = HttpRequest::from(gwr);
+        let payload: Option<Payload> = actual.payload().unwrap_or_default();
+        assert_eq!(
+            payload,
+            Some(Payload {
+                foo: "bar".into(),
+                baz: 2
+            })
+        )
+    }
+}

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -1,0 +1,103 @@
+#![warn(missing_docs)]
+//#![deny(warnings)]
+//! Enriches `lambda_runtime` with `http` types targeting API Gateway proxy events
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! #[macro_use] extern crate lambda_http;
+//! extern crate lambda_runtime as lambda;
+//!
+//! use lambda::{Context, HandlerError};
+//! use lambda_http::{Request, Response, RequestExt};
+//!
+//! fn main() {
+//!   lambda!(handler)
+//! }
+//!
+//! fn handler(
+//!   request: Request,
+//!   ctx: Context
+//! ) -> Result<Response, HandlerError> {
+//!   Ok(
+//!     Response::new(
+//!       format!(
+//!         "hello {}",
+//!         request.query_string_parameters()
+//!           .get("name")
+//!           .unwrap_or_else(|| "stranger")
+//!       ).into()
+//!     )
+//!   )
+//! }
+//! ```
+extern crate base64;
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
+extern crate http;
+extern crate lambda_runtime;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate serde_urlencoded;
+extern crate tokio;
+
+use lambda_runtime::{self as lambda, Context};
+use lambda_runtime::error::HandlerError;
+use http::{Request as HttpRequest, Response as HttpResponse};
+use tokio::runtime::Runtime as TokioRuntime;
+
+mod ext;
+pub mod request;
+mod response;
+mod body;
+mod strmap;
+
+use request::GatewayRequest;
+use response::GatewayResponse;
+pub use ext::RequestExt;
+pub use strmap::StrMap;
+pub use body::Body;
+
+/// Type alias for `http::Request`s with a fixed `lambda_http::Body` body
+pub type Request = HttpRequest<Body>;
+
+/// Type alias for `http::Response`s with a fixed `lambda_http::Body` body
+pub type Response = HttpResponse<Body>;
+
+/// Functions acting as API Gateway handlers must conform to this type.
+pub type Handler = fn(Request, Context) -> Result<Response, HandlerError>;
+
+/// lifts private internal (de)serializable API Gateway proxy event types into `http` types
+struct Lift(Handler);
+
+impl <'a> lambda::Handler<GatewayRequest<'a>, GatewayResponse> for Lift {
+    fn handle(&self, req: GatewayRequest, ctx: Context) -> Result<GatewayResponse, HandlerError> {
+        (self.0)(req.into(), ctx).map(GatewayResponse::from)
+    }
+}
+
+/// Creates a new `lambda_runtime::Runtime` and begins polling for API Gateway events
+///
+/// # Arguments
+///
+/// * `f` A type that conforms to the `Handler` interface.
+///
+/// # Panics
+/// The function panics if the Lambda environment variables are not set.
+pub fn start(f: Handler, runtime: Option<TokioRuntime>) {
+    lambda::start(Lift(f), runtime)
+}
+
+/// A macro for starting new handler's poll for API Gateway events
+#[macro_export]
+macro_rules! lambda {
+    ($handler:ident) => {
+        $crate::start($handler, None)
+    };
+    ($handler:ident, $runtime:expr) => {
+        $crate::start($handler, Some($runtime))
+    };
+}

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -1,0 +1,259 @@
+
+//! API Gateway request types. Typically these are exposed via the `request_context`
+//! request extension method provided by [lambda_http::RequestExt](trait.RequestExt.html)
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+use std::mem;
+
+use http::header::{HeaderValue, HOST};
+use http::Request as HttpRequest;
+use http::{self, HeaderMap, Method};
+use serde::{de::Error as DeError, de::MapAccess, de::Visitor, Deserialize, Deserializer};
+use serde_json::Value;
+
+use body::Body;
+use ext::{PathParameters, QueryStringParameters, StageVariables};
+use strmap::StrMap;
+
+/// Representation of an API Gateway proxy event data
+#[doc(hidden)]
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GatewayRequest<'a> {
+    pub(crate) path: Cow<'a, str>,
+    #[serde(deserialize_with = "deserialize_method")]
+    pub(crate) http_method: Method,
+    #[serde(deserialize_with = "deserialize_headers")]
+    pub(crate) headers: HeaderMap<HeaderValue>,
+    #[serde(deserialize_with = "nullable_default")]
+    pub(crate) query_string_parameters: StrMap,
+    #[serde(deserialize_with = "nullable_default")]
+    pub(crate) path_parameters: StrMap,
+    #[serde(deserialize_with = "nullable_default")]
+    pub(crate) stage_variables: StrMap,
+    pub(crate) body: Option<Cow<'a, str>>,
+    #[serde(default)]
+    pub(crate) is_base64_encoded: bool,
+    pub(crate) request_context: RequestContext,
+}
+
+/// API Gateway request context
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestContext {
+    //pub path: String,
+    pub account_id: String,
+    pub resource_id: String,
+    pub stage: String,
+    pub request_id: String,
+    pub resource_path: String,
+    pub http_method: String,
+    #[serde(default)]
+    pub authorizer: HashMap<String, Value>,
+    pub api_id: String,
+    pub identity: Identity,
+}
+
+/// Identity assoicated with request
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Identity {
+    pub source_ip: String,
+    pub cognito_identity_id: Option<String>,
+    pub cognito_identity_pool_id: Option<String>,
+    pub cognito_authentication_provider: Option<String>,
+    pub cognito_authentication_type: Option<String>,
+    pub account_id: Option<String>,
+    pub caller: Option<String>,
+    pub api_key: Option<String>,
+    pub user: Option<String>,
+    pub user_agent: Option<String>,
+    pub user_arn: Option<String>,
+}
+
+fn deserialize_method<'de, D>(deserializer: D) -> Result<Method, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct MethodVisitor;
+
+    impl<'de> Visitor<'de> for MethodVisitor {
+        type Value = Method;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a Method")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            v.parse().map_err(E::custom)
+        }
+    }
+
+    deserializer.deserialize_str(MethodVisitor)
+}
+
+fn deserialize_headers<'de, D>(deserializer: D) -> Result<HeaderMap<HeaderValue>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct HeaderVisitor;
+
+    impl<'de> Visitor<'de> for HeaderVisitor {
+        type Value = HeaderMap<HeaderValue>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "a HeaderMap<HeaderValue>")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            let mut headers = http::HeaderMap::new();
+            while let Some((key, value)) = map.next_entry::<Cow<str>, Cow<str>>()? {
+                let header_name = key
+                    .parse::<http::header::HeaderName>()
+                    .map_err(A::Error::custom)?;
+                let header_value =
+                    http::header::HeaderValue::from_shared(value.into_owned().into())
+                        .map_err(A::Error::custom)?;
+                headers.append(header_name, header_value);
+            }
+            Ok(headers)
+        }
+    }
+
+    deserializer.deserialize_map(HeaderVisitor)
+}
+
+/// deserializes (json) null values to their default values
+// https://github.com/serde-rs/serde/issues/1098
+fn nullable_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Default + Deserialize<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_else(T::default))
+}
+
+impl<'a> From<GatewayRequest<'a>> for HttpRequest<Body> {
+    fn from(value: GatewayRequest) -> Self {
+        let GatewayRequest {
+            path,
+            http_method,
+            headers,
+            query_string_parameters,
+            path_parameters,
+            stage_variables,
+            body,
+            is_base64_encoded,
+            request_context,
+        } = value;
+
+        // build an http::Request<lambda_http::Body> from a lambda_http::GatewayRequest
+        let mut builder = HttpRequest::builder();
+        builder.method(http_method);
+        builder.uri({
+            format!(
+                "https://{}{}",
+                headers
+                    .get(HOST)
+                    .map(|val| val.to_str().unwrap_or_default())
+                    .unwrap_or_default(),
+                path
+            )
+        });
+
+        builder.extension(QueryStringParameters(query_string_parameters));
+        builder.extension(PathParameters(path_parameters));
+        builder.extension(StageVariables(stage_variables));
+        builder.extension(request_context);
+
+        let mut req = builder
+            .body(match body {
+                Some(b) => {
+                    if is_base64_encoded {
+                        // todo: document failure behavior
+                        Body::from(::base64::decode(b.as_ref()).unwrap_or_default())
+                    } else {
+                        Body::from(b.into_owned())
+                    }
+                }
+                _ => Body::from(()),
+            })
+            .expect("failed to build request");
+
+        // no builder method that sets headers in batch
+        mem::replace(req.headers_mut(), headers);
+
+        req
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn requests_convert() {
+        let mut headers = HeaderMap::new();
+        headers.insert("Host", "www.rust-lang.org".parse().unwrap());
+        let gwr: GatewayRequest = GatewayRequest {
+            path: "/foo".into(),
+            headers,
+            ..GatewayRequest::default()
+        };
+        let expected = HttpRequest::get("https://www.rust-lang.org/foo")
+            .body(())
+            .unwrap();
+        let actual = HttpRequest::from(gwr);
+        assert_eq!(expected.method(), actual.method());
+        assert_eq!(expected.uri(), actual.uri());
+        assert_eq!(expected.method(), actual.method());
+    }
+
+    #[test]
+    fn deserializes_request_events() {
+        // from the docs
+        // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-api-gateway-request
+        let input = include_str!("../tests/data/proxy_request.json");
+        assert!(serde_json::from_str::<GatewayRequest>(&input).is_ok())
+    }
+
+    #[test]
+    fn implements_default() {
+        assert_eq!(
+            GatewayRequest {
+                path: "/foo".into(),
+                ..GatewayRequest::default()
+            }
+            .path,
+            "/foo"
+        )
+    }
+
+    #[test]
+    fn deserialize_with_null() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Test {
+            #[serde(deserialize_with = "nullable_default")]
+            foo: HashMap<String, String>,
+        }
+
+        assert_eq!(
+            serde_json::from_str::<Test>(r#"{"foo":null}"#).expect("failed to deserialize"),
+            Test {
+                foo: HashMap::new(),
+            }
+        )
+    }
+
+}

--- a/lambda-http/src/strmap.rs
+++ b/lambda-http/src/strmap.rs
@@ -1,0 +1,119 @@
+use std::collections::{hash_map::Keys, HashMap};
+use std::fmt;
+use std::sync::Arc;
+
+use serde::{de::MapAccess, de::Visitor, Deserialize, Deserializer};
+
+/// A read-only view into a map of string data
+#[derive(Default, Debug, PartialEq)]
+pub struct StrMap(pub(crate) Arc<HashMap<String, String>>);
+
+impl StrMap {
+    /// Return a named value where available
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(|value| value.as_ref())
+    }
+
+    /// Return true if the underlying map is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Return an iterator over keys and values
+    pub fn iter(&self) -> StrMapIter {
+        StrMapIter {
+            data: self,
+            keys: self.0.keys(),
+        }
+    }
+}
+
+impl Clone for StrMap {
+    fn clone(&self) -> Self {
+        // only clone the inner data
+        StrMap(self.0.clone())
+    }
+}
+impl From<HashMap<String, String>> for StrMap {
+    fn from(inner: HashMap<String, String>) -> Self {
+        StrMap(Arc::new(inner))
+    }
+}
+
+/// A read only reference to `StrMap` key and value slice pairings
+pub struct StrMapIter<'a> {
+    data: &'a StrMap,
+    keys: Keys<'a, String, String>,
+}
+
+impl<'a> Iterator for StrMapIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    #[inline]
+    fn next(&mut self) -> Option<(&'a str, &'a str)> {
+        self.keys
+            .next()
+            .and_then(|k| self.data.get(k).map(|v| (k.as_str(), v)))
+    }
+}
+
+impl<'de> Deserialize<'de> for StrMap {
+    fn deserialize<D>(deserializer: D) -> Result<StrMap, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StrMapVisitor;
+
+        impl<'de> Visitor<'de> for StrMapVisitor {
+            type Value = StrMap;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a StrMap")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut inner = HashMap::new();
+                while let Some((key, value)) = map.next_entry()? {
+                    inner.insert(key, value);
+                }
+                Ok(StrMap(Arc::new(inner)))
+            }
+        }
+
+        deserializer.deserialize_map(StrMapVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn str_map_default_is_empty() {
+        assert!(StrMap::default().is_empty())
+    }
+
+    #[test]
+    fn str_map_get() {
+        let mut data = HashMap::new();
+        data.insert("foo".into(), "bar".into());
+        let strmap = StrMap(data.into());
+        assert_eq!(strmap.get("foo"), Some("bar"));
+        assert_eq!(strmap.get("bar"), None);
+    }
+
+    #[test]
+    fn str_map_iter() {
+        let mut data = HashMap::new();
+        data.insert("foo".into(), "bar".into());
+        data.insert("baz".into(), "boom".into());
+        let strmap = StrMap(data.into());
+        let mut values = strmap.iter().map(|(_, v)| v).collect::<Vec<_>>();
+        values.sort();
+        assert_eq!(values, vec!["bar", "boom"]);
+    }
+}

--- a/lambda-http/tests/data/proxy_request.json
+++ b/lambda-http/tests/data/proxy_request.json
@@ -1,0 +1,55 @@
+{
+  "path": "/test/hello",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, lzma, sdch, br",
+    "Accept-Language": "en-US,en;q=0.8",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "wt6mne2s9k.execute-api.us-west-2.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+    "Via": "1.1 fb7cca60f0ecd82ce07790c9c5eef16c.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "nBsWBOrSHMgnaROZJK1wGCZ9PcRcSpq_oSXZNQwQ10OTZL4cimZo3g==",
+    "X-Forwarded-For": "192.168.100.1, 192.168.1.1",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "pathParameters": {
+    "proxy": "hello"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "us4z18",
+    "stage": "test",
+    "requestId": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
+    "identity": {
+      "cognitoIdentityPoolId": "",
+      "accountId": "",
+      "cognitoIdentityId": "",
+      "caller": "",
+      "apiKey": "",
+      "sourceIp": "192.168.100.1",
+      "cognitoAuthenticationType": "",
+      "cognitoAuthenticationProvider": "",
+      "userArn": "",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+      "user": ""
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "wt6mne2s9k"
+  },
+  "resource": "/{proxy+}",
+  "httpMethod": "GET",
+  "queryStringParameters": {
+    "name": "me"
+  },
+  "stageVariables": {
+    "stageVarName": "stageVarValue"
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

This attempts to address #13 

*Description of changes:*

## Motivation

With this project announced at reinvent, I saw an opportunity to rebase [lando](https://github.com/softprops/lando) a crate providing [http crate](https://crates.io/crates/http) interfaces for api gateway for deployment on lambda. I started working on that then I stumbled on #13. These crates seem to all serve the same purpose and landos goal from the start was to `not to replace tools but instead to work well with them`. I saw this work going down the path of fracturing when I'd rather push it forward.

## Impl

I just took what I was working on in lando's in migrating towards rebalancing on top of this project and moved into a module _in_ this project.

I took some steps to remove a few dependencies lando had that I think we're actually needed, but my first attempt forced a change to the `lambda_runtime::start` api which introduced a single allocation in order to support a serde deserializable => `http::Request` => `http::Response` => serde serializable transformation where the user space dealt only in terms of  `http::{Request, Response}`'s . I couldn't find a way to avoid it with the lambda_runtime's function pointer interface but I'm open to change/suggestions.

The `RequestExt` type contains one opinionated method `payload` which was lando's convenience for transparently deserializing request bodies from form encoded _or_ application/json content. I'm open to pulling this out but I wanted to get the temperature in the room before I did

There's also an opinionated dependency on the `failure` crate. the failure crate mainly facilitated removing Error definition boilerplate for the `payload` methods errors. I'm also open to ditching this dependency on impl the boilerplate by hand to keep the dependency tax low


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.  ✅ 
