### PR TITLE
FunctionArn -> TraceID to get xray_trace_id

### DIFF
--- a/lambda-runtime-client/src/client.rs
+++ b/lambda-runtime-client/src/client.rs
@@ -387,7 +387,7 @@ impl RuntimeClient {
             }
         };
 
-        let xray_trace_id = match headers.get(LambdaHeaders::FunctionArn.to_string()) {
+        let xray_trace_id = match headers.get(LambdaHeaders::TraceId.to_string()) {
             Some(value) => value.to_str()?.to_owned(),
             None => {
                 error!("Response headers do not contain trace id header");


### PR DESCRIPTION
*Description of changes:*
When getting the `xray_trace_id`, the client is instead looking for the `function_arn` header, which is probably the result of copy pasting and not changing one extra place.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
