### PR TITLE
ERROR_TYPE_UNHANDLED should be "Unhandled"

### DIFF
--- a/lambda-runtime-client/src/error.rs
+++ b/lambda-runtime-client/src/error.rs
@@ -13,7 +13,7 @@ use serde_json;
 pub const ERROR_TYPE_HANDLED: &str = "Handled";
 /// Error type description for the `ErrorResponse` event. This type is used for unhandled,
 /// unexpcted errors.
-pub const ERROR_TYPE_UNHANDLED: &str = "Handled";
+pub const ERROR_TYPE_UNHANDLED: &str = "Unhandled";
 
 /// This object is used to generate requests to the Lambda Runtime APIs.
 /// It is used for both the error response APIs and fail init calls.


### PR DESCRIPTION
*Description of changes:*
According to the [documentation](https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html) for `Invoke`, 
> If an error occurred this field will have one of two values; `Handled` or `Unhandled`

It looks to me that this was a copy paste error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
