### PR TITLE
Allow Context to be created outside of the Crate

### DIFF
--- a/lambda-runtime/src/context.rs
+++ b/lambda-runtime/src/context.rs
@@ -61,7 +61,7 @@ pub struct Context {
 
     /// The deadline for the current handler execution in milliseconds, based
     /// on a unix `MONOTONIC` clock.
-    pub(super) deadline: i64,
+    pub deadline: i64,
 }
 
 impl Context {


### PR DESCRIPTION
Resolves #33

The deadline property was restricted to the crate by the (super)
addition to the property. Removing it has no impact on the crate but
does allow users of the crate to create mock Contexts for testing their
lambda functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.