### PR TITLE
Migrate lambda-runtime-client to Rust 2018

### DIFF
--- a/lambda-runtime-client/Cargo.toml
+++ b/lambda-runtime-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lambda_runtime_client"
 version = "0.1.0"
 authors = ["Stefano Buliani", "David Barsky"]
+edition = "2018"
 description = "Client SDK for AWS Lambda's runtime APIs"
 keywords = ["AWS", "Lambda", "Runtime", "API", "Client"]
 license = "Apache-2.0"

--- a/lambda-runtime-client/src/error.rs
+++ b/lambda-runtime-client/src/error.rs
@@ -6,6 +6,7 @@ use std::{env, error::Error, fmt, io, num::ParseIntError, option::Option};
 use backtrace;
 use http::{header::ToStrError, uri::InvalidUri};
 use hyper;
+use serde_derive::Serialize;
 use serde_json;
 
 /// Error type description for the `ErrorResponse` event. This type should be returned
@@ -118,7 +119,7 @@ impl ApiError {
 }
 
 impl fmt::Display for ApiError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.msg)
     }
 }
@@ -129,7 +130,7 @@ impl Error for ApiError {
         &self.msg
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         // Generic error, underlying cause isn't tracked.
         None
     }

--- a/lambda-runtime-client/src/lib.rs
+++ b/lambda-runtime-client/src/lib.rs
@@ -58,17 +58,7 @@
 
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate serde_derive;
-
-extern crate backtrace;
-extern crate http;
-extern crate hyper;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio;
 
 mod client;
 pub mod error;
-
-pub use client::*;
+pub use crate::client::*;


### PR DESCRIPTION
*Description of changes:*
Migrate lambda-runtime-client to Rust 2018.

This includes:
1. Running `cargo fix --edition`
2. Adding `edition = "2018"` to `Cargo.toml`
3. Running `cargo fix --edition-idioms --broken-code`
4. Some manual touch-ups.

I've left `log` as an old-style `macro_use` import so that it is easily usable everywhere.

I'm not sure whether this is desired, just thought I'd give it a try. If yes, I'll do the other crates as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.