### PR TITLE
Add `accessKey` to the request context `identity` in lambda-http

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -69,6 +69,7 @@ pub struct Identity {
     pub account_id: Option<String>,
     pub caller: Option<String>,
     pub api_key: Option<String>,
+    pub access_key: Option<String>,
     pub user: Option<String>,
     pub user_agent: Option<String>,
     pub user_arn: Option<String>,


### PR DESCRIPTION
It's also part of the API Gateway schema as per https://github.com/aws/aws-lambda-go/blob/9e3676ee8ca83aee500682f382e10b9d03660093/events/apigw.go#L50

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
