### PR TITLE
Migrate lambda-runtime to Rust 2018

### DIFF
--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lambda_runtime"
 version = "0.1.0"
 authors = ["Stefano Buliani", "David Barsky"]
+edition = "2018"
 description = "Rust runtime for AWS Lambda"
 keywords = ["AWS", "Lambda", "Runtime", "Rust"]
 license = "Apache-2.0"

--- a/lambda-runtime/examples/basic.rs
+++ b/lambda-runtime/examples/basic.rs
@@ -1,12 +1,9 @@
-extern crate lambda_runtime as lambda;
-extern crate log;
-extern crate serde_derive;
-extern crate simple_logger;
-
-use lambda::{error::HandlerError, lambda};
-use log::error;
-use serde_derive::{Deserialize, Serialize};
 use std::error::Error;
+
+use lambda_runtime::{error::HandlerError, lambda, Context};
+use log::{self, error};
+use serde_derive::{Deserialize, Serialize};
+use simple_logger;
 
 #[derive(Deserialize)]
 struct CustomEvent {
@@ -26,7 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn my_handler(e: CustomEvent, c: lambda::Context) -> Result<CustomOutput, HandlerError> {
+fn my_handler(e: CustomEvent, c: Context) -> Result<CustomOutput, HandlerError> {
     if e.first_name == "" {
         error!("Empty first name in request {}", c.aws_request_id);
         return Err(c.new_error("Empty first name"));

--- a/lambda-runtime/examples/with_custom_runtime.rs
+++ b/lambda-runtime/examples/with_custom_runtime.rs
@@ -1,13 +1,9 @@
-extern crate lambda_runtime as lambda;
-extern crate log;
-extern crate serde_derive;
-extern crate simple_logger;
-extern crate tokio;
-
-use lambda::{error::HandlerError, lambda};
-use log::error;
-use serde_derive::{Deserialize, Serialize};
 use std::error::Error;
+
+use lambda_runtime::{error::HandlerError, lambda, Context};
+use log::{self, error};
+use serde_derive::{Deserialize, Serialize};
+use simple_logger;
 use tokio::runtime::Runtime;
 
 #[derive(Deserialize, Clone)]
@@ -30,7 +26,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn my_handler(e: CustomEvent, c: lambda::Context) -> Result<CustomOutput, HandlerError> {
+fn my_handler(e: CustomEvent, c: Context) -> Result<CustomOutput, HandlerError> {
     if e.first_name == "" {
         error!("Empty first name in request {}", c.aws_request_id);
         return Err(c.new_error("Empty first name"));

--- a/lambda-runtime/src/context.rs
+++ b/lambda-runtime/src/context.rs
@@ -1,11 +1,11 @@
 use std::env;
 
-use chrono::Utc;
-
 use backtrace;
-use env as lambda_env;
-use error::HandlerError;
+use chrono::Utc;
 use lambda_runtime_client;
+
+use crate::env as lambda_env;
+use crate::error::HandlerError;
 
 /// The Lambda function execution context. The values in this struct
 /// are populated using the [Lambda environment variables](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)
@@ -110,7 +110,7 @@ impl Context {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use env::{self, ConfigProvider};
+    use crate::env::{self, ConfigProvider};
     use std::{thread::sleep, time};
 
     fn get_deadline(timeout_secs: i64) -> i64 {

--- a/lambda-runtime/src/env.rs
+++ b/lambda-runtime/src/env.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use error::RuntimeError;
+use crate::error::RuntimeError;
 
 /// The name of the environment variable in the Lambda execution
 /// environment for the Runtime APIs endpoint. The value of this
@@ -88,8 +88,8 @@ impl ConfigProvider for EnvConfigProvider {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use env::*;
-    use error;
+    use crate::env::*;
+    use crate::error;
     use std::{env, error::Error};
 
     pub(crate) struct MockConfigProvider {
@@ -146,7 +146,7 @@ pub(crate) mod tests {
         unset_env_vars();
         set_endpoint_env_var();
         set_lambda_env_vars();
-        let config_provider: &ConfigProvider = &EnvConfigProvider {};
+        let config_provider: &dyn ConfigProvider = &EnvConfigProvider {};
         let env_settings = config_provider.get_function_settings();
         assert_eq!(
             env_settings.is_err(),

--- a/lambda-runtime/src/error.rs
+++ b/lambda-runtime/src/error.rs
@@ -77,7 +77,7 @@ impl error::RuntimeApiError for RuntimeError {
 }
 
 impl fmt::Display for RuntimeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.msg)
     }
 }
@@ -88,7 +88,7 @@ impl Error for RuntimeError {
         &self.msg
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         // Generic error, underlying cause isn't tracked.
         None
     }
@@ -125,7 +125,7 @@ pub struct HandlerError {
 }
 
 impl fmt::Display for HandlerError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.msg)
     }
 }
@@ -136,7 +136,7 @@ impl Error for HandlerError {
         &self.msg
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         // Generic error, underlying cause isn't tracked.
         None
     }

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -42,18 +42,11 @@
 #[macro_use]
 extern crate log;
 
-extern crate backtrace;
-extern crate chrono;
-extern crate lambda_runtime_client;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio;
-
 mod context;
 mod env;
 pub mod error;
-pub use error::HandlerError;
 mod runtime;
 
-pub use context::*;
-pub use runtime::*;
+pub use crate::context::*;
+pub use crate::error::HandlerError;
+pub use crate::runtime::*;

--- a/lambda-runtime/src/runtime.rs
+++ b/lambda-runtime/src/runtime.rs
@@ -1,13 +1,13 @@
 use std::{error::Error, marker::PhantomData, result};
 
+use lambda_runtime_client::RuntimeClient;
 use serde;
 use serde_json;
-
-use context::Context;
-use env::{ConfigProvider, EnvConfigProvider, FunctionSettings};
-use error::{HandlerError, RuntimeError};
-use lambda_runtime_client::RuntimeClient;
 use tokio::runtime::Runtime as TokioRuntime;
+
+use crate::context::Context;
+use crate::env::{ConfigProvider, EnvConfigProvider, FunctionSettings};
+use crate::error::{HandlerError, RuntimeError};
 
 const MAX_RETRIES: i8 = 3;
 
@@ -301,7 +301,7 @@ where
 
                         (ev, handler_ctx)
                     }
-                    Err(mut e) => {
+                    Err(e) => {
                         error!("Could not parse event to type: {}", e);
                         let mut runtime_err = RuntimeError::from(e);
                         runtime_err.request_id = Option::from(invocation_ctx.aws_request_id);
@@ -317,13 +317,13 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use context;
-    use env;
+    use crate::context;
+    use crate::env;
     use lambda_runtime_client::RuntimeClient;
 
     #[test]
     fn runtime_invokes_handler() {
-        let config: &env::ConfigProvider = &env::tests::MockConfigProvider { error: false };
+        let config: &dyn env::ConfigProvider = &env::tests::MockConfigProvider { error: false };
         let client = RuntimeClient::new(
             config
                 .get_runtime_api_endpoint()


### PR DESCRIPTION
*Description of changes:*
Migrate lambda-runtime to Rust 2018.

This includes:
1. Running `cargo fix --edition`
2. Adding `edition = "2018"` to `Cargo.toml`
3. Running `cargo fix --edition-idioms --broken-code`
4. Some manual touch-ups.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.