### PR TITLE
Migrate lambda-http to Rust 2018

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lambda_http"
 version = "0.1.0"
 authors = ["Doug Tangren"]
+edition = "2018"
 description = "Rust API Gateway proxy event interfaces for AWS Lambda"
 keywords = ["AWS", "Lambda", "APIGateway", "Rust", "API"]
 license = "Apache-2.0"

--- a/lambda-http/examples/basic.rs
+++ b/lambda-http/examples/basic.rs
@@ -1,13 +1,9 @@
-extern crate lambda_http as http;
-extern crate lambda_runtime as runtime;
-extern crate log;
-extern crate simple_logger;
-
-use http::{lambda, Body, IntoResponse, Request, RequestExt, Response};
-use runtime::{error::HandlerError, Context};
-
-use log::error;
 use std::error::Error;
+
+use lambda_http::{lambda, IntoResponse, Request, RequestExt, Response};
+use lambda_runtime::{error::HandlerError, Context};
+use log::{self, error};
+use simple_logger;
 
 fn main() -> Result<(), Box<dyn Error>> {
     simple_logger::init_with_level(log::Level::Debug).unwrap();

--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -1,12 +1,13 @@
 //! API Gateway extension methods for `http::Request` types
 
+use failure::Fail;
 use http::{header::CONTENT_TYPE, Request as HttpRequest};
 use serde::{de::value::Error as SerdeError, Deserialize};
 use serde_json;
 use serde_urlencoded;
 
-use request::RequestContext;
-use strmap::StrMap;
+use crate::request::RequestContext;
+use crate::strmap::StrMap;
 
 /// API gateway pre-parsed http query string parameters
 pub(crate) struct QueryStringParameters(pub(crate) StrMap);
@@ -153,10 +154,12 @@ impl RequestExt for HttpRequest<super::Body> {
 #[cfg(test)]
 mod tests {
     use http::{HeaderMap, Request as HttpRequest};
+    use serde_derive::Deserialize;
     use std::collections::HashMap;
-    use GatewayRequest;
-    use RequestExt;
-    use StrMap;
+
+    use crate::GatewayRequest;
+    use crate::RequestExt;
+    use crate::StrMap;
 
     #[test]
     fn requests_have_query_string_ext() {
@@ -164,7 +167,7 @@ mod tests {
         headers.insert("Host", "www.rust-lang.org".parse().unwrap());
         let mut query = HashMap::new();
         query.insert("foo".to_owned(), "bar".to_owned());
-        let gwr: GatewayRequest = GatewayRequest {
+        let gwr: GatewayRequest<'_> = GatewayRequest {
             path: "/foo".into(),
             headers,
             query_string_parameters: StrMap(query.clone().into()),
@@ -184,7 +187,7 @@ mod tests {
             foo: String,
             baz: usize,
         }
-        let gwr: GatewayRequest = GatewayRequest {
+        let gwr: GatewayRequest<'_> = GatewayRequest {
             path: "/foo".into(),
             headers,
             body: Some("foo=bar&baz=2".into()),
@@ -206,7 +209,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("Host", "www.rust-lang.org".parse().unwrap());
         headers.insert("Content-Type", "application/x-www-form-urlencoded".parse().unwrap());
-        let gwr: GatewayRequest = GatewayRequest {
+        let gwr: GatewayRequest<'_> = GatewayRequest {
             path: "/foo".into(),
             headers,
             body: Some("foo=bar&baz=2".into()),
@@ -230,7 +233,7 @@ mod tests {
             foo: String,
             baz: usize,
         }
-        let gwr: GatewayRequest = GatewayRequest {
+        let gwr: GatewayRequest<'_> = GatewayRequest {
             path: "/foo".into(),
             headers,
             body: Some(r#"{"foo":"bar", "baz": 2}"#.into()),

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -5,46 +5,28 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! #[macro_use] extern crate lambda_http;
-//! extern crate lambda_runtime as lambda;
-//!
-//! use lambda::{Context, HandlerError};
-//! use lambda_http::{Request, IntoResponse, RequestExt};
+//! use lambda_http::{lambda, IntoResponse, Request, RequestExt};
+//! use lambda_runtime::{Context, HandlerError};
 //!
 //! fn main() {
-//!   lambda!(handler)
+//!     lambda!(handler)
 //! }
 //!
 //! fn handler(
-//!   request: Request,
-//!   ctx: Context
+//!     request: Request,
+//!     _ctx: Context
 //! ) -> Result<impl IntoResponse, HandlerError> {
-//!   Ok(
-//!       format!(
+//!     Ok(format!(
 //!         "hello {}",
-//!         request.query_string_parameters()
-//!           .get("name")
-//!           .unwrap_or_else(|| "stranger")
-//!       )
-//!   )
+//!         request
+//!             .query_string_parameters()
+//!             .get("name")
+//!             .unwrap_or_else(|| "stranger")
+//!     ))
 //! }
 //! ```
-extern crate base64;
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
-/// re-export for convenient access in consumer crates
-pub extern crate http;
-extern crate lambda_runtime;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate serde_urlencoded;
-extern crate tokio;
 
-use http::Request as HttpRequest;
-pub use http::Response;
+pub use http::{self, Response};
 use lambda_runtime::{self as lambda, error::HandlerError, Context};
 use tokio::runtime::Runtime as TokioRuntime;
 
@@ -54,15 +36,15 @@ pub mod request;
 mod response;
 mod strmap;
 
-pub use body::Body;
-pub use ext::RequestExt;
-use request::GatewayRequest;
-use response::GatewayResponse;
-pub use response::IntoResponse;
-pub use strmap::StrMap;
+pub use crate::body::Body;
+pub use crate::ext::RequestExt;
+use crate::request::GatewayRequest;
+use crate::response::GatewayResponse;
+pub use crate::response::IntoResponse;
+pub use crate::strmap::StrMap;
 
 /// Type alias for `http::Request`s with a fixed `lambda_http::Body` body
-pub type Request = HttpRequest<Body>;
+pub type Request = http::Request<Body>;
 
 /// Functions acting as API Gateway handlers must conform to this type.
 pub trait Handler<R> {
@@ -94,7 +76,7 @@ where
     // handler requires a mutable ref
     let mut func = f;
     lambda::start(
-        |req: GatewayRequest, ctx: Context| {
+        |req: GatewayRequest<'_>, ctx: Context| {
             func.run(req.into(), ctx)
                 .map(|resp| GatewayResponse::from(resp.into_response()))
         },

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -11,8 +11,9 @@ use serde::{
     ser::{Error as SerError, SerializeMap},
     Serializer,
 };
+use serde_derive::Serialize;
 
-use body::Body;
+use crate::body::Body;
 
 /// Representation of API Gateway response
 #[derive(Serialize, Debug)]
@@ -125,7 +126,6 @@ impl IntoResponse for serde_json::Value {
 
 #[cfg(test)]
 mod tests {
-
     use super::{Body, GatewayResponse, IntoResponse};
     use serde_json::{self, json};
 

--- a/lambda-http/src/strmap.rs
+++ b/lambda-http/src/strmap.rs
@@ -25,7 +25,7 @@ impl StrMap {
     }
 
     /// Return an iterator over keys and values
-    pub fn iter(&self) -> StrMapIter {
+    pub fn iter(&self) -> StrMapIter<'_> {
         StrMapIter {
             data: self,
             keys: self.0.keys(),
@@ -70,7 +70,7 @@ impl<'de> Deserialize<'de> for StrMap {
         impl<'de> Visitor<'de> for StrMapVisitor {
             type Value = StrMap;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(formatter, "a StrMap")
             }
 


### PR DESCRIPTION
*Description of changes:*
Migrate lambda-http to Rust 2018.

This includes:
1. Running `cargo fix --edition`
2. Adding `edition = "2018"` to `Cargo.toml`
3. Running `cargo fix --edition-idioms --broken-code`
4. Some manual touch-ups.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.