### PR TITLE
`ClientApplication` keys should be snake_case

### DIFF
--- a/lambda-runtime-client/src/client.rs
+++ b/lambda-runtime-client/src/client.rs
@@ -60,19 +60,14 @@ impl fmt::Display for LambdaHeaders {
 #[derive(Deserialize, Clone)]
 pub struct ClientApplication {
     /// The mobile app installation id
-    #[serde(rename = "installationId")]
     pub installation_id: String,
     /// The app title for the mobile app as registered with AWS' mobile services.
-    #[serde(rename = "appTitle")]
     pub app_title: String,
     /// The version name of the application as registered with AWS' mobile services.
-    #[serde(rename = "appVersionName")]
     pub app_version_name: String,
     /// The app version code.
-    #[serde(rename = "appVersionCode")]
     pub app_version_code: String,
     /// The package name for the mobile application invoking the function
-    #[serde(rename = "appPackageName")]
     pub app_package_name: String,
 }
 


### PR DESCRIPTION
See https://github.com/aws/aws-lambda-go/blob/9e3676ee8ca83aee500682f382e10b9d03660093/lambdacontext/context.go#L43-L48


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
