### PR TITLE
impl PartialEq for HandlerError

### DIFF
--- a/lambda-runtime/src/error.rs
+++ b/lambda-runtime/src/error.rs
@@ -118,6 +118,9 @@ impl From<error::ApiError> for RuntimeError {
 /// The error type for functions that are used as the `Handler` type. New errors
 /// should be instantiated using the `new_error()` method  of the `runtime::Context`
 /// object passed to the handler function.
+///
+/// An implementation of `PartialEq` is provided and based it's comparison on the `msg`
+/// field.
 #[derive(Debug, Clone)]
 pub struct HandlerError {
     msg: String,

--- a/lambda-runtime/src/error.rs
+++ b/lambda-runtime/src/error.rs
@@ -1,6 +1,6 @@
 //! The error module defines the error types that can be returned
 //! by custom handlers as well as the runtime itself.
-use std::{env, error::Error, fmt};
+use std::{cmp, env, error::Error, fmt};
 
 use backtrace;
 use lambda_runtime_client::error;
@@ -124,6 +124,12 @@ pub struct HandlerError {
     backtrace: Option<backtrace::Backtrace>,
 }
 
+impl cmp::PartialEq for HandlerError {
+    fn eq(&self, other: &HandlerError) -> bool {
+        self.msg == other.msg
+    }
+}
+
 impl fmt::Display for HandlerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.msg)
@@ -167,5 +173,24 @@ impl error::RuntimeApiError for HandlerError {
             error_type: String::from(error::ERROR_TYPE_HANDLED),
             stack_trace: Option::from(backtrace.lines().map(|s| s.to_string()).collect::<Vec<String>>()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HandlerError;
+
+    #[test]
+    fn handler_error_impls_partialeq() {
+        assert_eq!(
+            HandlerError {
+                msg: "test".into(),
+                backtrace: Default::default()
+            },
+            HandlerError {
+                msg: "test".into(),
+                backtrace: Some(Default::default())
+            }
+        )
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While making some attempts to sketch out what unit testing might look like for this project I quickly realized that the core user interface, [Handler](https://github.com/awslabs/aws-lambda-rust-runtime/blob/70e7301fc7a778d011c95455ba099a9a88d46d32/lambda-runtime/src/runtime.rs#L14-L18), does not lend itself well to the out of the box testing interfaces, like `assert_eq!` because Handler results can yield HandlerErrors which do not implement PartialEq. I realize HandlerError is in a bit [in flux](https://github.com/awslabs/aws-lambda-rust-runtime/pull/26) but I think we should still have a basic store for unit testability with Rust's default toolchain.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
