### PR TITLE
add parity to the lambda macro to support handler closure impl

### DIFF
--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -29,6 +29,27 @@
 //!   )
 //! }
 //! ```
+//!
+//! You can also provide a closure directly to the `lambda!` macro
+//!
+//! ```rust,no_run
+//! #[macro_use] extern crate lambda_http;
+//!
+//! use lambda_http::{Request, RequestExt};
+//!
+//! fn main() {
+//!   lambda!(
+//!     |request: Request, context| Ok(
+//!       format!(
+//!         "hello {}",
+//!         request.query_string_parameters()
+//!           .get("name")
+//!           .unwrap_or_else(|| "stranger")
+//!       )
+//!     )
+//!   )
+//! }
+//! ```
 extern crate base64;
 extern crate failure;
 #[macro_use]
@@ -105,6 +126,12 @@ where
 /// A macro for starting new handler's poll for API Gateway events
 #[macro_export]
 macro_rules! lambda {
+    ($handler:expr) => {
+        $crate::start($handler, None)
+    };
+    ($handler:expr, $runtime:expr) => {
+        $crate::start($handler, Some($runtime))
+    };
     ($handler:ident) => {
         $crate::start($handler, None)
     };

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -39,6 +39,42 @@
 //!     })
 //! }
 //! ```
+//!
+//! You can also provide a closure directly to the `lambda!` macro
+//!
+//! ```rust,no_run
+//! #[macro_use]
+//! extern crate serde_derive;
+//! #[macro_use]
+//! extern crate lambda_runtime;
+//!
+//! use lambda_runtime::{Context, error::HandlerError};
+//!
+//!
+//! #[derive(Deserialize, Clone)]
+//! struct CustomEvent {
+//!     first_name: String,
+//!     last_name: String,
+//! }
+//!
+//! #[derive(Serialize, Clone)]
+//! struct CustomOutput {
+//!     message: String,
+//! }
+//!
+//! fn main() {
+//!     lambda!(
+//!       |e: CustomEvent, ctx: Context| {
+//!          if e.first_name == "" {
+//!             return Err(ctx.new_error("Missing first name!"));
+//!          }
+//!          Ok(CustomOutput{
+//!             message: format!("Hello, {}!", e.first_name),
+//!          })
+//!       }
+//!     );
+//! }
+//! ```
 #[macro_use]
 extern crate log;
 

--- a/lambda-runtime/src/runtime.rs
+++ b/lambda-runtime/src/runtime.rs
@@ -50,6 +50,12 @@ macro_rules! lambda {
     ($handler:ident, $runtime:expr) => {
         $crate::start($handler, Some($runtime))
     };
+    ($handler:expr) => {
+        $crate::start($handler, None)
+    };
+    ($handler:expr, $runtime:expr) => {
+        $crate::start($handler, Some($runtime))
+    };
 }
 
 /// Internal implementation of the start method that receives a config provider. This method


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a follow up to #19 to add support for the new closure style handlers with the `lambda!` macro. I made attempt to hit to birds (docs and tests) with on doctest coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
