### PR TITLE
populate crates.io with useful information

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -8,6 +8,11 @@ license = "Apache-2.0"
 homepage = "https://github.com/awslabs/aws-lambda-rust-runtime"
 repository = "https://github.com/awslabs/aws-lambda-rust-runtime"
 documentation = "https://docs.rs/lambda_runtime"
+readme = "../README.md"
+
+[badges]
+travis-ci = { repository = "awslabs/aws-lambda-rust-runtime" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 http = "0.1"

--- a/lambda-runtime-client/Cargo.toml
+++ b/lambda-runtime-client/Cargo.toml
@@ -9,6 +9,11 @@ license = "Apache-2.0"
 homepage = "https://github.com/awslabs/aws-lambda-rust-runtime"
 repository = "https://github.com/awslabs/aws-lambda-rust-runtime"
 documentation = "https://docs.rs/lambda_runtime_client"
+readme = "../README.md"
+
+[badges]
+travis-ci = { repository = "awslabs/aws-lambda-rust-runtime" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 hyper = "0.12"

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -8,6 +8,11 @@ license = "Apache-2.0"
 homepage = "https://github.com/awslabs/aws-lambda-rust-runtime"
 repository = "https://github.com/awslabs/aws-lambda-rust-runtime"
 documentation = "https://docs.rs/lambda_runtime"
+readme = "../README.md"
+
+[badges]
+travis-ci = { repository = "awslabs/aws-lambda-rust-runtime" }
+maintenance = { status = "actively-developed" }
 
 [dependencies]
 serde = "^1"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To help users find what they are looking for faster, we should use the tools crates.io provides ( [cargo meta data](https://github.com/softprops/aws-lambda-rust-runtime/pull/new/cratesio-metadata) ) to help the discovery process.

This change adds a travis badge, actively developed badge and populates the description area of https://crates.io/crates/lambda_runtime with copy lifted from the readme cargo package attribute

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
