### PR TITLE
documented better developer experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ $ cat output.json  # Prints: {"message":"Hello, world!"}
 You can optionally skip all of the manual building, renaming, and deploying steps above and use the [Serverless framework Rust plugin](https://github.com/softprops/serverless-rust). You can find an example
 getting started template application [here](https://github.com/softprops/serverless-aws-rust).
 
-To get started just run the following to create a new lambda Rust application
+Serverless application templates exist for a minimal [echo function](https://github.com/softprops/serverless-aws-rust), [http function](https://github.com/softprops/serverless-aws-rust-http), and [multi function service](https://github.com/softprops/serverless-aws-multi).
+
+To get started, just run the following commands to create a new lambda Rust application
 and install project level dependencies.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Deploy it using the standard serverless workflow
 ```bash
 # install npm dependencies (only needs ran once)
 $ npm install --silent
-# deploy service
+# build, package, and deploy service to aws lambda
 $ npx serverless deploy
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,19 +102,23 @@ To get started just run the following to create a new lambda Rust application
 ```bash
 $ serverless install \
   --url https://github.com/softprops/serverless-aws-rust \
-  --name my-new-app
+  --name my-new-app \
+  && cd my-new-app
 ```
 
-Deploy it using either make-based workflow or `npx serverless` commands directly
+Deploy it using the standard serverless workflow
 
 ```bash
-$ AWS_PROFILE=prod make dependencies deploy
+# install npm dependencies (only needs ran once)
+$ npm install --silent
+# deploy service
+$ npx serverless deploy
 ```
 
 Invoke it using serverless framework or a configured AWS integrated trigger source
 
 ```bash
-$ AWS_PROFILE=prod npx serverless invoke --stage prod -f hello -d '{"foo":"bar"}'
+$ npx serverless invoke -f hello -d '{"foo":"bar"}'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ fn my_handler(event: GreetingEvent, ctx: Context) -> Result<GreetingResponse, Ha
 
 The code above is the same as the [basic example](https://github.com/awslabs/aws-lambda-rust-runtime/tree/master/lambda-runtime/examples/basic.rs) in the `lambda-runtime` crate.
 
-### deployment
+### Deployment
 
-#### aws cli
+There are currently multiple ways of building this package: manually, and the [Serverless framework](https://serverless.com/framework/).
 
-To deploy the basic sample as a Lambda function using the aws cli, we first need to build it with `cargo`. Since Lambda uses Amazon Linux, you'll need to target your executable for an `x86_64-linux` platform.
+#### AWS CLI
+
+To deploy the basic sample as a Lambda function using the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html), we first need to manually build it with [`cargo`](https://doc.rust-lang.org/cargo/). Since Lambda uses Amazon Linux, you'll need to target your executable for an `x86_64-linux` platform.
 
 ```bash
 $ cargo build -p lambda_runtime --example basic --release
@@ -92,18 +94,21 @@ $ aws lambda invoke --function-name rustTest \
 $ cat output.json  # Prints: {"message":"Hello, world!"}
 ```
 
-#### serverless framework
+#### Serverless Framework
 
-You can optionally skip all of the manual building, renaming, and deploying steps above and use the [Serverless framework Rust plugin](https://github.com/softprops/serverless-rust). You can find an example
-getting started template application [here](https://github.com/softprops/serverless-aws-rust).
+Alternatively, you can build a Rust-based Lambda function declaratively using the [Serverless framework Rust plugin](https://github.com/softprops/serverless-rust).
 
-Serverless application templates exist for a minimal [echo function](https://github.com/softprops/serverless-aws-rust), [http function](https://github.com/softprops/serverless-aws-rust-http), and [multi function service](https://github.com/softprops/serverless-aws-rust-multi).
+A number of getting started Serverless application templates exist to get you up and running quickly
 
-To get started, just run the following commands to create a new lambda Rust application
+* a minimal [echo function](https://github.com/softprops/serverless-aws-rust) to demonstrate what the smallest Rust function setup looks like
+* a minimal [http function](https://github.com/softprops/serverless-aws-rust-http) to demonstrate how to interface with API Gateway using Rust's native [http](https://crates.io/crates/http) crate (note this will a git dependency until 0.2 is published)
+* a combination [multi function service](https://github.com/softprops/serverless-aws-rust-multi) to demonstrate how to set up a services with multiple independent functions
+
+Assuming your host machine has a relatively recent version of node, you [won't need to install any host-wide serverless dependencies](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner). To get started, run the following commands to create a new lambda Rust application
 and install project level dependencies.
 
 ```bash
-$ serverless install \
+$ npx serverless install \
   --url https://github.com/softprops/serverless-aws-rust \
   --name my-new-app \
   && cd my-new-app \

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ cat output.json  # Prints: {"message":"Hello, world!"}
 You can optionally skip all of the manual building, renaming, and deploying steps above and use the [Serverless framework Rust plugin](https://github.com/softprops/serverless-rust). You can find an example
 getting started template application [here](https://github.com/softprops/serverless-aws-rust).
 
-Serverless application templates exist for a minimal [echo function](https://github.com/softprops/serverless-aws-rust), [http function](https://github.com/softprops/serverless-aws-rust-http), and [multi function service](https://github.com/softprops/serverless-aws-multi).
+Serverless application templates exist for a minimal [echo function](https://github.com/softprops/serverless-aws-rust), [http function](https://github.com/softprops/serverless-aws-rust-http), and [multi function service](https://github.com/softprops/serverless-aws-rust-multi).
 
 To get started, just run the following commands to create a new lambda Rust application
 and install project level dependencies.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ getting started template application [here](https://github.com/softprops/serverl
 
 To get started just run the following to create a new lambda Rust application
 
-```sh
+```bash
 $ serverless install \
   --url https://github.com/softprops/serverless-aws-rust \
   --name my-new-app
@@ -107,13 +107,13 @@ $ serverless install \
 
 Deploy it using either make-based workflow or `npx serverless` commands directly
 
-```sh
-AWS_PROFILE=prod make dependencies deploy
+```bash
+$ AWS_PROFILE=prod make dependencies deploy
 ```
 
 Invoke it using serverless framework or a configured AWS integrated trigger source
 
-```sh
+```bash
 $ AWS_PROFILE=prod npx serverless invoke --stage prod -f hello -d '{"foo":"bar"}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ fn my_handler(event: GreetingEvent, ctx: Context) -> Result<GreetingResponse, Ha
 }
 ```
 
-The code above is the same as the [basic example](https://github.com/awslabs/aws-lambda-rust-runtime/tree/master/lambda-runtime/examples/basic.rs) in the `lambda-runtime` crate. To deploy the basic sample as a Lambda function, we first build it with `cargo`. Since Lambda uses Amazon Linux, you'll need to target your executable for an `x86_64-linux` platform.
+The code above is the same as the [basic example](https://github.com/awslabs/aws-lambda-rust-runtime/tree/master/lambda-runtime/examples/basic.rs) in the `lambda-runtime` crate.
+
+### deployment
+
+#### aws cli
+
+To deploy the basic sample as a Lambda function using the aws cli, we first need to build it with `cargo`. Since Lambda uses Amazon Linux, you'll need to target your executable for an `x86_64-linux` platform.
 
 ```bash
 $ cargo build -p lambda_runtime --example basic --release
@@ -85,6 +91,32 @@ $ aws lambda invoke --function-name rustTest \
   output.json
 $ cat output.json  # Prints: {"message":"Hello, world!"}
 ```
+
+#### serverless framework
+
+You can optionally skip all of the manual building, renaming, and deploying steps above and use the [Serverless framework Rust plugin](https://github.com/softprops/serverless-rust). You can find an example
+getting started template application [here](https://github.com/softprops/serverless-aws-rust).
+
+To get started just run the following to create a new lambda Rust application
+
+```sh
+$ serverless install \
+  --url https://github.com/softprops/serverless-aws-rust \
+  --name my-new-app
+```
+
+Deploy it using either make-based workflow or `npx serverless` commands directly
+
+```sh
+AWS_PROFILE=prod make dependencies deploy
+```
+
+Invoke it using serverless framework or a configured AWS integrated trigger source
+
+```sh
+$ AWS_PROFILE=prod npx serverless invoke --stage prod -f hello -d '{"foo":"bar"}'
+```
+
 
 ## lambda-runtime-client
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Deploy it using the standard serverless workflow
 $ npx serverless deploy
 ```
 
-Invoke it using serverless framework or a configured AWS integrated trigger source
+Invoke it using serverless framework or a configured AWS integrated trigger source:
 
 ```bash
 $ npx serverless invoke -f hello -d '{"foo":"bar"}'

--- a/README.md
+++ b/README.md
@@ -98,19 +98,19 @@ You can optionally skip all of the manual building, renaming, and deploying step
 getting started template application [here](https://github.com/softprops/serverless-aws-rust).
 
 To get started just run the following to create a new lambda Rust application
+and install project level dependencies.
 
 ```bash
 $ serverless install \
   --url https://github.com/softprops/serverless-aws-rust \
   --name my-new-app \
-  && cd my-new-app
+  && cd my-new-app \
+  && npm install --silent
 ```
 
 Deploy it using the standard serverless workflow
 
 ```bash
-# install npm dependencies (only needs ran once)
-$ npm install --silent
 # build, package, and deploy service to aws lambda
 $ npx serverless deploy
 ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It's been noted in a few [open](https://github.com/awslabs/aws-lambda-rust-runtime/issues/25) [issues](https://github.com/awslabs/aws-lambda-rust-runtime/issues/17) that the developer experience for getting a basic rust function built and deployed is less that pleasant. This change incorporates documentation for a less manual workflow using the serverless framework for build/deployment quality life enhancements.

I split off deployment into its own doc section and created a subsection for manual building and setting up a local host and a subsection for using the serverless framework rust plugin which leverages the lambdaci project's provided docker images which faithfully reproduce the required build environment and wires some components together for a more seemless DX for those familiar with serverless framework workflows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
