### PR TITLE
update out of date readme doc on runtime handler type

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,20 @@ For error reporting to the runtime APIs the library defines the `RuntimeApiError
 
 ## lambda-runtime
 
-This library makes it easy to create Rust executables for AWS lambda. The library defines a `lambda!()` macro. Call the `lambda!()` macro from your main method with a function that matches the `Handler` type:
+This library makes it easy to create Rust executables for AWS lambda. The library defines a `lambda!()` macro. Call the `lambda!()` macro from your main method with a implementation the `Handler` type:
 
-```rust,ignore
-pub type Handler<E, O> = fn(E, Context) -> Result<O, error::HandlerError>;
+```rust
+pub trait Handler<E, O> {
+    /// Run the handler.
+    fn run(
+        &mut self,
+        event: E,
+        ctx: Context
+    ) -> Result<O, HandlerError>;
+}
 ```
+
+`Handler` is provides a default implementation that enables you to provide a Rust closure or function pointer.
 
 Optionally, you can pass your own instance of Tokio runtime to the `lambda!()` macro. See our [`with_custom_runtime.rs` example](https://github.com/awslabs/aws-lambda-rust-runtime/tree/master/lambda-runtime/examples/with_custom_runtime.rs)
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For error reporting to the runtime APIs the library defines the `RuntimeApiError
 
 ## lambda-runtime
 
-This library makes it easy to create Rust executables for AWS lambda. The library defines a `lambda!()` macro. Call the `lambda!()` macro from your main method with a implementation the `Handler` type:
+This library makes it easy to create Rust executables for AWS lambda. The library defines a `lambda!()` macro. Call the `lambda!()` macro from your main method with an  implementation the `Handler` type:
 
 ```rust
 pub trait Handler<E, O> {
@@ -107,7 +107,7 @@ pub trait Handler<E, O> {
 }
 ```
 
-`Handler` is provides a default implementation that enables you to provide a Rust closure or function pointer.
+`Handler` provides a default implementation that enables you to provide a Rust closure or function pointer to the `lambda!()` macro.
 
 Optionally, you can pass your own instance of Tokio runtime to the `lambda!()` macro. See our [`with_custom_runtime.rs` example](https://github.com/awslabs/aws-lambda-rust-runtime/tree/master/lambda-runtime/examples/with_custom_runtime.rs)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated readme documentation on the runtime `Handler` type. This has been out of date since #19. It makes me wonder if the pr template should have checkbox for making sure any relevant documentation is updated. I feel that's reasonable given this project's [motivators for documentation](https://github.com/awslabs/aws-lambda-rust-runtime/blob/545f653b5ca5895e4c394e55509c35f9faa882c6/lambda-runtime/src/lib.rs#L1-L2) :)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
