### PR TITLE
how to build and test with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,40 @@ Invoke it using serverless framework or a configured AWS integrated trigger sour
 $ npx serverless invoke -f hello -d '{"foo":"bar"}'
 ```
 
+#### Docker
+
+Alternatively, you can build a Rust-based Lambda function in a [docker mirror of the AWS Lambda provided runtime with the Rust toolchain preinstalled](https://github.com/softprops/lambda-rust).
+
+Running the following command will start a emphemeral docker container which will build your Rust application and produce a zip file containing its binary auto-renamed to `bootstrap` to meet the AWS Lamdbda's expectations for binaries under `target/lambda/release/{your-binary-name}.zip`, typically this is just the name of your crate if you are using the cargo default binary (i.e. `main.rs`)
+
+```bash
+# build and package deploy-ready artifact
+$ docker run --rm \
+    -v ${PWD}:/code \
+    -v ${HOME}/.cargo/registry:/root/.cargo/registry \
+    -v ${HOME}/.cargo/git:/root/.cargo/git \
+    softprops/lambda-rust
+```
+
+With your application build and packaged, it's ready to ship to production. You can also invoke it locally to verify is behavior using the [lambdaci :provided docker container](https://hub.docker.com/r/lambci/lambda/) which is also a mirror of the AWS Lambda provided runtime with build dependencies omitted.
+
+```bash
+# start a docker container replicating the "provided" lambda runtime
+# awaiting an event to be provided via stdin
+$ unzip -o \
+    target/lambda/release/{your-binary-name}.zip \
+    -d /tmp/lambda && \
+  docker run \
+    -i -e DOCKER_LAMBDA_USE_STDIN=1 \
+    --rm \
+    -v /tmp/lambda:/var/task \
+    lambci/lambda:provided
+
+# provide an event payload via stdin (typically a json blob)
+
+# Ctrl-D to yield control back to your function
+```
+
 
 ## lambda-runtime-client
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ $ npx serverless invoke -f hello -d '{"foo":"bar"}'
 
 Alternatively, you can build a Rust-based Lambda function in a [docker mirror of the AWS Lambda provided runtime with the Rust toolchain preinstalled](https://github.com/softprops/lambda-rust).
 
-Running the following command will start a emphemeral docker container which will build your Rust application and produce a zip file containing its binary auto-renamed to `bootstrap` to meet the AWS Lamdbda's expectations for binaries under `target/lambda/release/{your-binary-name}.zip`, typically this is just the name of your crate if you are using the cargo default binary (i.e. `main.rs`)
+Running the following command will start a emphemeral docker container which will build your Rust application and produce a zip file containing its binary auto-renamed to `bootstrap` to meet the AWS Lambda's expectations for binaries under `target/lambda/release/{your-binary-name}.zip`, typically this is just the name of your crate if you are using the cargo default binary (i.e. `main.rs`)
 
 ```bash
 # build and package deploy-ready artifact


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Expanding the documented options for building a deploy ready lambda artifact. For very simple testing you can use docker directly to both build and invoke your lambda in a local mirror of the AWS provided runtime environment. Like the serverless framework option, this also removes the any need for customizing your developer machine for those that aren't already using serverless framework. 

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
