### PR TITLE
Wrote some minimal documentation for lambda macro

### DIFF
--- a/lambda-runtime/src/runtime.rs
+++ b/lambda-runtime/src/runtime.rs
@@ -45,6 +45,9 @@ where
 }
 
 #[macro_export]
+/// Starts an event listener which will parse incoming event into the even type requested by
+/// `handler` and will invoke `handler` on each incoming event. Can optionally by passed a Tokio
+/// `runtime` to build the listener on. If none is provided, it creates its own.
 macro_rules! lambda {
     ($handler:ident) => {
         $crate::start($handler, None)

--- a/lambda-runtime/src/runtime.rs
+++ b/lambda-runtime/src/runtime.rs
@@ -45,8 +45,8 @@ where
 }
 
 #[macro_export]
-/// Starts an event listener which will parse incoming event into the even type requested by
-/// `handler` and will invoke `handler` on each incoming event. Can optionally by passed a Tokio
+/// Starts an event listener which will parse incoming events into the even type requested by
+/// `handler` and will invoke `handler` on each incoming event. Can optionally be passed a Tokio
 /// `runtime` to build the listener on. If none is provided, it creates its own.
 macro_rules! lambda {
     ($handler:ident) => {


### PR DESCRIPTION
*Issue #, if available:*

There isn't an issue number for this yet, but the problem is that the build for `lambda_runtime` fails on nightly because of some missing documentation for a macro.

*Description of changes:*

Added some documentation.

Feel free to change it further -- I don't really know much about this crate, so I'm not really the best person for this job.


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
