### PR TITLE
adjust import to avoid compilation errors

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -10,10 +10,7 @@ use http::{
     header::{HeaderName, HeaderValue, HOST},
     HeaderMap, Method, Request as HttpRequest,
 };
-use serde::{
-    de::{Error as DeError, MapAccess, Visitor},
-    Deserialize, Deserializer,
-};
+use serde::de::{Deserialize, Deserializer, Error as DeError, MapAccess, Visitor};
 use serde_derive::Deserialize;
 use serde_json::Value;
 


### PR DESCRIPTION
Change the way we import traits in order to avoid compilation issues in some cases.

This issue was reported to `serde` (https://github.com/serde-rs/serde/issues/1441) and can be avoided with suggested changes.

With the current code (version 0.1.0) it is impossible to compile `lambda-http` with some other crates (like https://github.com/mitsuhiko/insta).

### Minimal example:
`main.rs`
```rust
use lambda_http::lambda;

fn main() {
    lambda!(|_, _| Ok(""));
}
```
`Cargo.toml`
```toml
[package]
name = "aws-lambda-http-bug"
version = "0.1.0"
authors = ["Aliaksandr Rahalevich <saksmlz@gmail.com>"]
edition = "2018"

[dependencies]
lambda_http = "0.1.0"
serde = { features = ["derive"] }
```
then compilation fails with:
```
   Compiling lambda_http v0.1.0
error[E0252]: the name `Deserialize` is defined multiple times
  --> /home/<USER>/.cargo/registry/src/github.com-1ecc6299db9ec823/lambda_http-0.1.0/src/request.rs:17:5
   |
15 |     Deserialize, Deserializer,
   |     ----------- previous import of the macro `Deserialize` here
16 | };
17 | use serde_derive::Deserialize;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ `Deserialize` reimported here
   |
   = note: `Deserialize` must be defined only once in the macro namespace of this module
help: you can use `as` to change the binding name of the import
   |
17 | use serde_derive::Deserialize as OtherDeserialize;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0252`.
error: Could not compile `lambda_http`.
```

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
