### PR TITLE
correct and expand on lambda-http RequestExt docs

### DIFF
--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -42,7 +42,10 @@ pub enum PayloadError {
 ///
 /// You can also access a request's body in deserialized format
 /// for payloads sent in `application/x-www-form-urlencoded` or
-/// `application/x-www-form-urlencoded` format
+/// `application/json` format.
+///
+/// The following handler will work an http request body of `x=1&y=2`
+/// as well as `{"x":1, "y":2}` respectively.
 ///
 /// ```rust,no_run
 /// #[macro_use] extern crate lambda_http;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I noticed while re-reading the apidocs for https://docs.rs/lambda_http/0.1.0/lambda_http/trait.RequestExt.html it mentioned the same content type twice. I corrected this as well as added some clarification in the example

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
