### PR TITLE
Http lambda crate doc updates

### DIFF
--- a/lambda-http/examples/basic.rs
+++ b/lambda-http/examples/basic.rs
@@ -6,7 +6,7 @@ use log::{self, error};
 use simple_logger;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    simple_logger::init_with_level(log::Level::Debug).unwrap();
+    simple_logger::init_with_level(log::Level::Debug)?;
     lambda!(my_handler);
 
     Ok(())

--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -48,12 +48,9 @@ pub enum PayloadError {
 /// as well as `{"x":1, "y":2}` respectively.
 ///
 /// ```rust,no_run
-/// #[macro_use] extern crate lambda_http;
-/// extern crate lambda_runtime as lambda;
-/// #[macro_use] extern crate serde_derive;
-///
-/// use lambda::{Context, error::HandlerError};
-/// use lambda_http::{Body, Request, Response, RequestExt};
+/// use lambda_runtime::{Context, error::HandlerError};
+/// use lambda_http::{lambda, Body, Request, Response, RequestExt};
+/// use serde_derive::Deserialize;
 ///
 /// #[derive(Debug,Deserialize,Default)]
 /// struct Args {
@@ -69,7 +66,7 @@ pub enum PayloadError {
 ///
 /// fn handler(
 ///   request: Request,
-///   ctx: lambda::Context
+///   ctx: Context
 /// ) -> Result<Response<Body>, HandlerError> {
 ///   let args: Args = request.payload()
 ///     .unwrap_or_else(|_parse_err| None)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

two things that where bothering me.

1) the doc example was teaching unwrap which sets a bad example for those new to rust 🙅

2) one of the doc examples where teaching rust 2015 instead of 2018 edition. For examples that are tailored for cut & pasting,  I consider that harmful.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
