### PR TITLE
Display errors returned by handler in CloudWatch

### DIFF
--- a/lambda-runtime-core/src/runtime.rs
+++ b/lambda-runtime-core/src/runtime.rs
@@ -214,7 +214,7 @@ where
                     }
                 }
                 Err(e) => {
-                    debug!("Handler returned an error for {}: {}", request_id, e);
+                    error!("Handler returned an error for {}: {}", request_id, e);
                     debug!("Attempting to send error response to Runtime API for {}", request_id);
                     match self.runtime_client.event_error(&request_id, &ErrorResponse::from(e)) {
                         Ok(_) => info!("Error response for {} accepted by Runtime API", request_id),


### PR DESCRIPTION
*Issue #98*

*Description of changes:*

Change log level from `debug` to `error` for errors returned by handler. With this change, programs with default log level (`log::Level::Info`) will display error in CloudWatch.

(The log level is usually configured in fn main:)
```rust
fn main() -> Result<(), Box<dyn Error>> {
    simple_logger::init_with_level(log::Level::Info)?;
    lambda!(handler);
    Ok(())
}
```

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
