### PR TITLE
Fix markdown in HandlerError documentation

### DIFF
--- a/lambda-runtime-errors/src/lib.rs
+++ b/lambda-runtime-errors/src/lib.rs
@@ -120,7 +120,7 @@ where
 
 /// The `HandlerError` struct can be use to abstract any `Err` of the handler method `Result`.
 /// The `HandlerError` object can be generated `From` any object that supports `Display`,
-/// `Send, `Sync`, and `Debug`. This allows handler functions to return any error using
+/// `Send`, `Sync`, and `Debug`. This allows handler functions to return any error using
 /// the `?` syntax. For example `let _age_num: u8 = e.age.parse()?;` will return the
 /// `<F as FromStr>::Err` from the handler function.
 //pub type HandlerError = failure::Error;


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

I noticed that the `HandlerError` documentation looks strange in my editor:

<img width="672" alt="src_main_rs_—_tietajabot" src="https://user-images.githubusercontent.com/482561/61937033-a03fc600-af96-11e9-9589-d71f4e4fd874.png">

I found out that it was due to a missing closing backtick. This PR adds that missing backtick.

**Situation before as rendered by GitHub**

> The `HandlerError` struct can be use to abstract any `Err` of the handler method `Result`.
> The `HandlerError` object can be generated `From` any object that supports `Display`,
> `Send, `Sync`, and `Debug`. This allows handler functions to return any error using
> the `?` syntax. For example `let _age_num: u8 = e.age.parse()?;` will return the
> `<F as FromStr>::Err` from the handler function.

**Situation after fix as rendered by GitHub**

> The `HandlerError` struct can be use to abstract any `Err` of the handler method `Result`.
> The `HandlerError` object can be generated `From` any object that supports `Display`,
> `Send`, `Sync`, and `Debug`. This allows handler functions to return any error using
> the `?` syntax. For example `let _age_num: u8 = e.age.parse()?;` will return the
> `<F as FromStr>::Err` from the handler function.

---

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
