### PR TITLE
Binary files should use prefix fileb

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Now that we have a deployment package (`lambda.zip`), we can use the [AWS CLI](h
 ```bash
 $ aws lambda create-function --function-name rustTest \
   --handler doesnt.matter \
-  --zip-file file://./lambda.zip \
+  --zip-file fileb://./lambda.zip \
   --runtime provided \
   --role arn:aws:iam::XXXXXXXXXXXXX:role/your_lambda_execution_role \
   --environment Variables={RUST_BACKTRACE=1} \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update docs so example work on the aws cli

Fixes https://github.com/awslabs/aws-lambda-rust-runtime/issues/84


By submitting this pull request

- [X ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ X] I confirm that I've made a best effort attempt to update all relevant documentation.
