### PR TITLE
Fix trait object for deprecations

### DIFF
--- a/lambda-runtime-client/src/error.rs
+++ b/lambda-runtime-client/src/error.rs
@@ -106,7 +106,7 @@ pub enum ApiErrorKind {
 }
 
 impl Fail for ApiError {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 

--- a/lambda-runtime-core/src/error.rs
+++ b/lambda-runtime-core/src/error.rs
@@ -77,7 +77,7 @@ impl Error for RuntimeError {
         &self.msg
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         // Generic error, underlying cause isn't tracked.
         None
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This error has occurred.

```
error: trait objects without an explicit `dyn` are deprecated
```
By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
