### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,50 @@ on: [push, pull_request]
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        rust:
+          - 1.31.0
+          - stable
+          - beta
+          # disable because github actions does not have ability to allow failure
+          # - nightly
+        target:
+          - ""
+          - x86_64-unknown-linux-musl
+        exclude:
+          - os: macOS-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            rust: 1.31.0
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            rust: beta
+            target: x86_64-unknown-linux-musl
+          - os: macOS-latest
+            rust: 1.31.0
+          - os: macOS-latest
+            rust: beta
+          #- os: macOS-latest
+          #  rust: nightly
     steps:
-    - uses: actions/checkout@v1
-    - name: Build
-      run: cargo build --all --verbose
-    - name: Run tests
-      run: cargo test --all --verbose
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Build
+        run: cargo build --all --verbose
+        env:
+          RUST_BACKTRACE: 1
+          TARGET: ${{ matrix.target }}
+      - name: Run tests
+        run: cargo test --all --verbose
+        env:
+          RUST_BACKTRACE: 1
+          TARGET: ${{ matrix.target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,18 @@ jobs:
         env:
           RUST_BACKTRACE: 1
           TARGET: ${{ matrix.target }}
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - id: component
+        uses: actions-rs/components-nightly@v1
+        with:
+          component: rustfmt
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ steps.component.outputs.toolchain }}
+          override: true
+          components: rustfmt
+      - name: Run fmt check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: cargo build --all --verbose
+    - name: Run tests
+      run: cargo test --all --verbose

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -468,5 +468,4 @@ mod tests {
             Test { foo: HashMap::new() }
         )
     }
-
 }

--- a/lambda-runtime-client/src/error.rs
+++ b/lambda-runtime-client/src/error.rs
@@ -106,7 +106,7 @@ pub enum ApiErrorKind {
 }
 
 impl Fail for ApiError {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 

--- a/lambda-runtime-core/src/error.rs
+++ b/lambda-runtime-core/src/error.rs
@@ -77,7 +77,7 @@ impl Error for RuntimeError {
         &self.msg
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         // Generic error, underlying cause isn't tracked.
         None
     }

--- a/lambda-runtime-errors-derive/tests/tests.rs
+++ b/lambda-runtime-errors-derive/tests/tests.rs
@@ -23,7 +23,7 @@ enum FailureErrorKind {
 }
 
 impl Fail for FailureCustomWithKind {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 


### PR DESCRIPTION
*Description of changes:*
* This adds GitHub actions for CI, which can replace TravisCI. A continuation of initial PR#155.
* additionally replace deprecated usage of traits with `dyn` to fix the CI
* additionally add fmt changes to fix the CI
* nightly was added but temporary disabled because there is no direct analogue of travis `ALLOW_FAILURES=1` feature

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
