### PR TITLE
send the runtime user agent when polling for events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime_client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -362,7 +362,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "lambda_runtime_client 0.2.2",
+ "lambda_runtime_client 0.2.3",
  "lambda_runtime_errors 0.1.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lambda-runtime-client/Cargo.toml
+++ b/lambda-runtime-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime_client"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Stefano Buliani", "David Barsky"]
 edition = "2018"
 description = "Client SDK for AWS Lambda's runtime APIs"

--- a/lambda-runtime-client/src/client.rs
+++ b/lambda-runtime-client/src/client.rs
@@ -171,12 +171,19 @@ impl<'ev> RuntimeClient {
     pub fn next_event(&self) -> Result<(Vec<u8>, EventContext), ApiError> {
         trace!("Polling for next event");
 
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(self.next_endpoint.clone())
+            .header(header::USER_AGENT, self.runtime_agent.clone())
+            .body(Body::from(""))
+            .unwrap();
+
         // We wait instead of processing the future asynchronously because AWS Lambda
         // itself enforces only one event per container at a time. No point in taking on
         // the additional complexity.
         let resp = self
             .http_client
-            .get(self.next_endpoint.clone())
+            .request(req)
             .wait()
             .context(ApiErrorKind::Unrecoverable("Could not fetch next event".to_string()))?;
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The user agent was only getting set [here](https://github.com/awslabs/aws-lambda-rust-runtime/blob/master/lambda-runtime-client/src/client.rs#L364) and [here](https://github.com/awslabs/aws-lambda-rust-runtime/blob/master/lambda-runtime-client/src/client.rs#L378). This means that Lambda is unable to know what the runtime version is when the function crashes or times out.

By submitting this pull request

- [ ✅] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ✅] I confirm that I've made a best effort attempt to update all relevant documentation.
