### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/lambda-runtime-client/src/error.rs
+++ b/lambda-runtime-client/src/error.rs
@@ -40,7 +40,8 @@ impl ErrorResponse {
     ///
     /// # Arguments
     ///
-    /// * `message` The error message to be returned to the APIs. Normally the error description()
+    /// * `message` The error message to be returned to the APIs. Normally the error `Display`
+    ///   representation
     /// * `err_type` An error type that identifies the root cause. Normally populated by the
     ///   `error_type()` method in the `LambdaErrorExt` trait.
     /// * `backtrace` The stack trace for the error

--- a/lambda-runtime-core/src/env.rs
+++ b/lambda-runtime-core/src/env.rs
@@ -90,7 +90,7 @@ impl ConfigProvider for EnvConfigProvider {
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::{env::*, error};
-    use std::{env, error::Error};
+    use std::env;
 
     pub(crate) struct MockConfigProvider {
         pub(crate) error: bool,
@@ -152,7 +152,7 @@ pub(crate) mod tests {
             env_settings.is_err(),
             false,
             "Env settings returned an error: {}",
-            env_settings.err().unwrap().description()
+            env_settings.err().unwrap()
         );
         let settings = env_settings.unwrap();
         assert_eq!(
@@ -165,7 +165,7 @@ pub(crate) mod tests {
             endpoint.is_err(),
             false,
             "Env endpoint returned an error: {}",
-            endpoint.err().unwrap().description()
+            endpoint.err().unwrap()
         );
 
         unset_env_vars();

--- a/lambda-runtime-core/src/error.rs
+++ b/lambda-runtime-core/src/error.rs
@@ -72,20 +72,11 @@ impl fmt::Display for RuntimeError {
 }
 
 // This is important for other errors to wrap this one.
-impl Error for RuntimeError {
-    fn description(&self) -> &str {
-        &self.msg
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
-        // Generic error, underlying cause isn't tracked.
-        None
-    }
-}
+impl Error for RuntimeError {}
 
 impl From<env::VarError> for RuntimeError {
     fn from(e: env::VarError) -> Self {
-        RuntimeError::unrecoverable(e.description())
+        RuntimeError::unrecoverable(&e.to_string())
     }
 }
 


### PR DESCRIPTION
*Description of changes:*

`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes the implementation of `description` in `RuntimeError::Error`
- Removes all usage of `description` 

Related PR: https://github.com/rust-lang/rust/pull/66919

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
