### PR TITLE
Use default HTTP scheme for endpoint like "127.0.0.1:9001"

### DIFF
--- a/lambda/src/client.rs
+++ b/lambda/src/client.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bytes::buf::ext::BufExt;
 use futures::future;
-use http::{uri::PathAndQuery, HeaderValue, Method, Request, Response, StatusCode, Uri};
+use http::{uri::{PathAndQuery, Scheme}, HeaderValue, Method, Request, Response, StatusCode, Uri};
 use hyper::Body;
 use std::{
     convert::{TryFrom, TryInto},
@@ -40,7 +40,7 @@ where
     fn set_origin<B>(&self, req: Request<B>) -> Result<Request<B>, Err> {
         let (mut parts, body) = req.into_parts();
         let (scheme, authority) = {
-            let scheme = self.base.scheme().expect("Scheme not found");
+            let scheme = self.base.scheme().unwrap_or(&Scheme::HTTP);
             let authority = self.base.authority().expect("Authority not found");
             (scheme, authority)
         };

--- a/lambda/src/client.rs
+++ b/lambda/src/client.rs
@@ -5,7 +5,10 @@ use crate::{
 };
 use bytes::buf::ext::BufExt;
 use futures::future;
-use http::{uri::{PathAndQuery, Scheme}, HeaderValue, Method, Request, Response, StatusCode, Uri};
+use http::{
+    uri::{PathAndQuery, Scheme},
+    HeaderValue, Method, Request, Response, StatusCode, Uri,
+};
 use hyper::Body;
 use std::{
     convert::{TryFrom, TryInto},


### PR DESCRIPTION
AWS_LAMBDA_RUNTIME_API environment is equal to "127.0.0.1:9001".
http::Uri can't "guess" scheme from that string, so it's None and function Client::set_origin() always fails.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
