### PR TITLE
fix lambda-http deps

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -20,7 +20,7 @@ http = "0.1"
 serde = "^1"
 serde_json = "^1"
 serde_derive = "^1"
-lambda_runtime = { path = "../lambda-runtime", version = "^0.2" }
+lambda = { path = "../lambda" }
 tokio = "^0.1"
 base64 = "0.10"
 failure = "0.1"


### PR DESCRIPTION
When cargo get dependencies it parses all Cargo.toml which it finds.
Because of that you can't just add to your Cargo.toml
`lambda = {git = "https://github.com/awslabs/aws-lambda-rust-runtime", branch = "async-await"}`
cargo will stop with error:
```
$ cargo check
    Updating git repository `https://github.com/awslabs/aws-lambda-rust-runtime.git`
error: failed to load source for a dependency on `lambda`

Caused by:
  Unable to update https://github.com/awslabs/aws-lambda-rust-runtime.git?branch=async-await

Caused by:
  Could not find `Cargo.toml` in `/Users/user/.cargo/git/checkouts/aws-lambda-rust-runtime-7c865cce90132439/1b95ac1/lambda-runtime`
```


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
