### PR TITLE
Fix HandlerError documentation

### DIFF
--- a/lambda-runtime-errors/src/lib.rs
+++ b/lambda-runtime-errors/src/lib.rs
@@ -120,7 +120,7 @@ where
 
 /// The `HandlerError` struct can be use to abstract any `Err` of the handler method `Result`.
 /// The `HandlerError` object can be generated `From` any object that supports `Display`,
-/// `Send, `Sync`, and `Debug`. This allows handler functions to return any error using
+/// `Send`, `Sync`, and `Debug`. This allows handler functions to return any error using
 /// the `?` syntax. For example `let _age_num: u8 = e.age.parse()?;` will return the
 /// `<F as FromStr>::Err` from the handler function.
 //pub type HandlerError = failure::Error;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a missing backtick in the HandlerError documentation that was messing up the rest of the paragraph.

Issue:

<img width="535" alt="image" src="https://user-images.githubusercontent.com/56045/71996360-b0c0c180-3201-11ea-862e-d19963677ff3.png">

Fixed:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/56045/71996432-d1891700-3201-11ea-84ba-8d1ab872a588.png">

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
