### PR TITLE
Upgrade http to 0.2

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "awslabs/aws-lambda-rust-runtime" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-http = "0.1"
+http = "0.2"
 serde = "^1"
 serde_json = "^1"
 serde_derive = "^1"


### PR DESCRIPTION
*Description of changes:* Bumps the http crate to version 0.2

closes #196 

change log: https://github.com/hyperium/http/releases/tag/v0.2.0

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
