### PR TITLE
Make sure example handlers use a structured event type

### DIFF
--- a/lambda/examples/hello-with-ctx.rs
+++ b/lambda/examples/hello-with-ctx.rs
@@ -1,9 +1,10 @@
 use lambda::lambda;
+use serde_json::Value;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[lambda]
 #[tokio::main]
-async fn main(event: String) -> Result<String, Error> {
+async fn main(event: Value) -> Result<Value, Error> {
     Ok(event)
 }

--- a/lambda/examples/hello-without-macro.rs
+++ b/lambda/examples/hello-without-macro.rs
@@ -1,4 +1,5 @@
 use lambda::handler_fn;
+use serde_json::Value;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -9,6 +10,6 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn func(event: String) -> Result<String, Error> {
+async fn func(event: Value) -> Result<Value, Error> {
     Ok(event)
 }

--- a/lambda/examples/hello.rs
+++ b/lambda/examples/hello.rs
@@ -1,9 +1,10 @@
 use lambda::lambda;
+use serde_json::Value;
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[lambda]
 #[tokio::main]
-async fn main(event: String) -> Result<String, Error> {
+async fn main(event: Value) -> Result<Value, Error> {
     Ok(event)
 }

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -23,12 +23,13 @@
 //!
 //! ```no_run
 //! use lambda::lambda;
+//! use serde_json::Value;
 //!
 //! type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 //!
 //! #[lambda]
 //! #[tokio::main]
-//! async fn main(event: String) -> Result<String, Error> {
+//! async fn main(event: Value) -> Result<Value, Error> {
 //!     Ok(event)
 //! }
 //! ```
@@ -136,6 +137,7 @@ where
 /// # Example
 /// ```no_run
 /// use lambda::handler_fn;
+/// use serde_json::Value;
 ///
 /// type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 ///
@@ -146,8 +148,8 @@ where
 ///     Ok(())
 /// }
 ///
-/// async fn func(s: String) -> Result<String, Error> {
-///     Ok(s)
+/// async fn func(event: Value) -> Result<Value, Error> {
+///     Ok(event)
 /// }
 /// ```
 pub async fn run<A, B, F>(handler: F) -> Result<(), Err>


### PR DESCRIPTION
*Description of changes:*

This is a documentation (and examples) tweak to consider that lambda handlers need to use a structured type for their event data since Serde will try and deserialize a JSON document into that type and that won't work with a String type which the current examples use.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
