### PR TITLE
Documentation fixes with some linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 /target
 /.cargo
 lambda-runtime/libtest.rmeta
+
+# Built AWS Lambda zipfile
+lambda.zip
+
+# output.json from example docs
+output.json

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Now that we have a deployment package (`lambda.zip`), we can use the [AWS CLI](h
 ```bash
 $ aws lambda create-function --function-name rustTest \
   --handler doesnt.matter \
-  --zip-file file://./lambda.zip \
+  --zip-file fileb://./lambda.zip \
   --runtime provided \
   --role arn:aws:iam::XXXXXXXXXXXXX:role/your_lambda_execution_role \
   --environment Variables={RUST_BACKTRACE=1} \
@@ -87,6 +87,7 @@ You can now test the function using the AWS CLI or the AWS Lambda console
 
 ```bash
 $ aws lambda invoke --function-name rustTest \
+  --cli-binary-format raw-in-base64-out \
   --payload '{"firstName": "world"}' \
   output.json
 $ cat output.json  # Prints: {"message":"Hello, world!"}

--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ You can now test the function using the AWS CLI or the AWS Lambda console
 
 ```bash
 $ aws lambda invoke --function-name rustTest \
-  --cli-binary-format raw-in-base64-out \
   --payload '{"firstName": "world"}' \
   output.json
 $ cat output.json  # Prints: {"message":"Hello, world!"}
 ```
+
+**Note:** `--cli-binary-format raw-in-base64-out` is a required
+  argument when using the AWS CLI version 2. [More Information](https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-binaryparam)
 
 #### Serverless Framework
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ There are currently multiple ways of building this package: manually, and the [S
 To deploy the basic sample as a Lambda function using the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html), we first need to manually build it with [`cargo`](https://doc.rust-lang.org/cargo/). Since Lambda uses Amazon Linux, you'll need to target your executable for an `x86_64-linux` platform.
 
 ```bash
-$ cargo build -p lambda_runtime --example basic --release
+$ cargo build -p lambda --example hello --release
 ```
 
 For a custom runtime, AWS Lambda looks for an executable called `bootstrap` in the deployment package zip. Rename the generated `basic` executable to `bootstrap` and add it to a zip archive.
 
 ```bash
-$ cp ./target/release/examples/basic ./bootstrap && zip lambda.zip bootstrap && rm bootstrap
+$ cp ./target/release/examples/hello ./bootstrap && zip lambda.zip bootstrap && rm bootstrap
 ```
 
 Now that we have a deployment package (`lambda.zip`), we can use the [AWS CLI](https://aws.amazon.com/cli/) to create a new Lambda function. Make sure to replace the execution role with an existing role in your account!

--- a/lambda/Cargo.toml
+++ b/lambda/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lambda"
 version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
-description = "AWS Lambda runtime client."
+description = "AWS Lambda runtime."
 edition = "2018"
 
 [features]

--- a/lambda/Cargo.toml
+++ b/lambda/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lambda"
 version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
-description = "AWS Lambda runtime."
+description = "AWS Lambda Runtime."
 edition = "2018"
 
 [features]

--- a/lambda/Cargo.toml
+++ b/lambda/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lambda"
 version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
+description = "AWS Lambda runtime client."
 edition = "2018"
 
 [features]

--- a/lambda/src/client.rs
+++ b/lambda/src/client.rs
@@ -111,7 +111,7 @@ async fn next_event(req: &Request<Body>) -> Result<Response<Body>, Error> {
 
     let rsp = NextEventResponse {
         request_id: "8476a536-e9f4-11e8-9739-2dfe598c3fcd",
-        deadline: 1542409706888,
+        deadline: 1_542_409_706_888,
         arn: "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime",
         trace_id: "Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419",
         body: serde_json::to_vec(&body)?,

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -6,13 +6,13 @@
 //! There are two mechanisms available for defining a Lambda function:
 //! 1. The `#[lambda]` attribute, which generates the boilerplate to
 //!    to launch and run a Lambda function.
-//! 
+//!
 //!    The `#[lambda]` attribute _must_ be placed on an asynchronous main function.
 //!    However, as asynchronous main functions are not legal valid Rust
 //!    this means that the main function must also be decorated using a
 //!    `#[tokio::main]` attribute macro. This is available from
 //!    the [tokio](https://github.com/tokio-rs/tokio) crate.
-//! 
+//!
 //! 2. A type that conforms to the [`Handler`] trait. This type can then be passed
 //!    to the the `lambda::run` function, which launches and runs the Lambda runtime.
 //!

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -3,13 +3,16 @@
 
 //! The official Rust runtime for AWS Lambda.
 //!
-//! There are two mechanisms of defining a Lambda function:
-//! 1. The `#[lambda]` attribute, which generates the boilerplate needed to
-//!    to launch and run a Lambda function. The `#[lambda]` attribute _must_
-//!    be placed on an asynchronous main function. However, asynchronous main
-//!    functions are not legal valid Rust, which means that a crate like
-//!    [Runtime](https://github.com/rustasync/runtime) must be used. A main function
-//!    decorated using a `#[lambda]` attribute macro.
+//! There are two mechanisms available for defining a Lambda function:
+//! 1. The `#[lambda]` attribute, which generates the boilerplate to
+//!    to launch and run a Lambda function.
+//! 
+//!    The `#[lambda]` attribute _must_ be placed on an asynchronous main function.
+//!    However, as asynchronous main functions are not legal valid Rust
+//!    this means that the main function must also be decorated using a
+//!    `#[tokio::main]` attribute macro. This is available from
+//!    the [tokio](https://github.com/tokio-rs/tokio) crate.
+//! 
 //! 2. A type that conforms to the [`Handler`] trait. This type can then be passed
 //!    to the the `lambda::run` function, which launches and runs the Lambda runtime.
 //!

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -49,7 +49,7 @@ use std::{
 mod client;
 mod requests;
 mod simulated;
-/// Types availible to a Lambda function.
+/// Types available to a Lambda function.
 mod types;
 
 use requests::{EventCompletionRequest, EventErrorRequest, IntoRequest, NextEventRequest};

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -6,10 +6,10 @@
 //! There are two mechanisms of defining a Lambda function:
 //! 1. The `#[lambda]` attribute, which generates the boilerplate needed to
 //!    to launch and run a Lambda function. The `#[lambda]` attribute _must_
-//!    be placed on an asynchronous main funtion. However, asynchronous main
-//!    funtions are not legal valid Rust, which means that a crate like
+//!    be placed on an asynchronous main function. However, asynchronous main
+//!    functions are not legal valid Rust, which means that a crate like
 //!    [Runtime](https://github.com/rustasync/runtime) must be used. A main function
-//!    decorated using `#[lamdba]`
+//!    decorated using `#[lambdas]`
 //! 2. A type that conforms to the [`Handler`] trait. This type can then be passed
 //!    to the the `lambda::run` function, which launches and runs the Lambda runtime.
 //!

--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -9,7 +9,7 @@
 //!    be placed on an asynchronous main function. However, asynchronous main
 //!    functions are not legal valid Rust, which means that a crate like
 //!    [Runtime](https://github.com/rustasync/runtime) must be used. A main function
-//!    decorated using `#[lambdas]`
+//!    decorated using a `#[lambda]` attribute macro.
 //! 2. A type that conforms to the [`Handler`] trait. This type can then be passed
 //!    to the the `lambda::run` function, which launches and runs the Lambda runtime.
 //!


### PR DESCRIPTION
*Description of changes:*

- Fixed documentation in `README.md` to work with existing code.
- Update awscli commands to work with version 2.
- Ensure files built when following `README.md` are ignored from `git`
- Remove Travis button as it's no longer used.
- Resolves https://github.com/awslabs/aws-lambda-rust-runtime/issues/84

Some code changes. I can revert this to make this PR cleaner if deemed more appropriate.

- Fixed minor typos in docstring.
- Minor linting.


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
