### PR TITLE
publish latest rustdocs to gh-pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,3 +68,23 @@ jobs:
           override: true
       - name: Run fmt check
         run: cargo fmt --all -- --check
+
+  # publish rustdoc to a gh-pages branch on pushes to master
+  # this can be helpful to those depending on the mainline branch
+  publish-docs:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Set up Rust
+        uses: hecrj/setup-rust-action@v1
+      - uses: actions/checkout@v2
+      - name: Generate Docs
+        run: |
+          cargo doc --no-deps
+          echo "<meta http-equiv=refresh content=0;url=`lambda/index.html>" > target/doc/index.html
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Provide constantly updated docs by publishing rustdocs to ghpages on pushes to master. docs.rs will still serve its purpose as a release docs host. This will serve as the latest docs for anyone depending on the latest version in git. This might help clear up some confusion between releases.

This was adapted from a setup I use to automate processes in some of my other crates. An example can be found [here](https://github.com/softprops/hubcaps/blob/master/.github/workflows/main.yml#L51-L67)

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
