### PR TITLE
automate publishing to crates.io on pushes to tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,3 +88,33 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc
+
+  # automate publishing to crates.io on pushes to tags
+  publish-crates:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: [build, fmt]
+    steps:
+      - name: Set up Rust
+        uses: hecrj/setup-rust-action@v1
+      - uses: actions/checkout@v2
+      - name: Publish
+        if: env.CRATES_TOKEN
+        run: |
+          pushd lambda-attributes
+          cargo publish --token ${{ secrets.CRATES_TOKEN }}
+          popd
+          # eventual consistency in crates.io dictates we wait a bit before publishing
+          # so that lambda-attributes is available for resolution
+          sleep 20
+          pushd lambda
+          cargo publish --token ${{ secrets.CRATES_TOKEN }}
+          popd
+          # eventual consistency in crates.io dictates we wait a bit before publishing
+          # so that lambda is available for resolution
+          sleep 20
+          pushd lambda-http
+          cargo publish --token ${{ secrets.CRATES_TOKEN }}
+          popd
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

strawman: It's possible to automate the crates.io publishing process with GitHub actions which in theory lowers the bar of effort for publishing consistent releases. I've done this with good success in a few other projects. 

The trick here is to generate an crates.io api key [here](https://crates.io/me) and store it in your GitHub repositories secrets under `https://github.com/:owner/:repo/settings/secrets`. These secrets, much like like travis secrets, will not be printed in build logs.

The thing to consider when publishing workspaces projects is that crates.io will not let you publish a crate unless its dependencies are available in crates.io so you have to wait a bit between publishes. 

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
