### PR TITLE
retire INVOCATION_CTX task local. 

### DIFF
--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -89,10 +89,6 @@ impl Config {
     }
 }
 
-tokio::task_local! {
-    pub static INVOCATION_CTX: types::Context;
-}
-
 /// A trait describing an asynchronous function `A` to `B.
 pub trait Handler<A, B> {
     /// Errors returned by this handler.
@@ -212,7 +208,7 @@ where
         let body = serde_json::from_slice(&body)?;
 
         let request_id = &ctx.request_id.clone();
-        let f = INVOCATION_CTX.scope(ctx.clone(), handler.call(body, ctx));
+        let f = handler.call(body, ctx);
 
         let req = match f.await {
             Ok(res) => EventCompletionRequest { request_id, body: res }.into_req()?,


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Context is now a fn argument and lexically scoped. The tokio task local isn't really adding meaningful value at this time.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
