### PR TITLE
When constructing a Context from a HeaderMap, fill in the env_config field

### DIFF
--- a/lambda/src/lib.rs
+++ b/lambda/src/lib.rs
@@ -204,7 +204,8 @@ where
         let event = event?;
         let (parts, body) = event.into_parts();
 
-        let ctx: Context = Context::try_from(parts.headers)?;
+        let mut ctx: Context = Context::try_from(parts.headers)?;
+        ctx.env_config = Config::from_env()?;
         let body = hyper::body::to_bytes(body).await?;
         let body = serde_json::from_slice(&body)?;
 


### PR DESCRIPTION
*Description of changes:* Currently this just produces a useless env_config.


By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
