### PR TITLE
Add missing license fields in lambda and lambda-attributes crates

### DIFF
--- a/lambda-attributes/Cargo.toml
+++ b/lambda-attributes/Cargo.toml
@@ -3,6 +3,7 @@ name = "lambda-attributes"
 version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
 edition = "2018"
+license = "Apache-2.0"
 
 [lib]
 proc-macro = true

--- a/lambda/Cargo.toml
+++ b/lambda/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
 description = "AWS Lambda Runtime."
 edition = "2018"
+license = "Apache-2.0"
 
 [features]
 # no features by default


### PR DESCRIPTION
*Description of changes:* License isn't specified in the `lambda` and `lambda-attributes` `Cargo.toml` files. The repository contains the `LICENSE` file, so I have used "Apache-2.0" from that file.


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
