### PR TITLE
Allow mock methods to be used in external apps

### DIFF
--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -121,7 +121,6 @@ pub trait RequestExt {
     /// Configures instance with query string parameters under #[cfg(test)] configurations
     ///
     /// This is intended for use in mock testing contexts.
-    #[cfg(test)]
     fn with_query_string_parameters<Q>(self, parameters: Q) -> Self
     where
         Q: Into<StrMap>;
@@ -137,7 +136,6 @@ pub trait RequestExt {
     /// Configures instance with path parameters under #[cfg(test)] configurations
     ///
     /// This is intended for use in mock testing contexts.
-    #[cfg(test)]
     fn with_path_parameters<P>(self, parameters: P) -> Self
     where
         P: Into<StrMap>;
@@ -182,7 +180,6 @@ impl RequestExt for http::Request<Body> {
             .unwrap_or_default()
     }
 
-    #[cfg(test)]
     fn with_query_string_parameters<Q>(self, parameters: Q) -> Self
     where
         Q: Into<StrMap>,
@@ -199,7 +196,6 @@ impl RequestExt for http::Request<Body> {
             .unwrap_or_default()
     }
 
-    #[cfg(test)]
     fn with_path_parameters<P>(self, parameters: P) -> Self
     where
         P: Into<StrMap>,


### PR DESCRIPTION
Make mock api available

*Issue #, if available:* #252

*Description of changes:*
Make stub methods available for testing the API

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
