### PR TITLE
fix: fix RequestExt.payload() for content-type with charset

### DIFF
--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -252,7 +252,7 @@ impl RequestExt for http::Request<Body> {
                     }
 
                     Ok(None)
-                },
+                }
                 _ => Ok(None),
             })
             .unwrap_or_else(|| Ok(None))

--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -240,12 +240,19 @@ impl RequestExt for http::Request<Body> {
         self.headers()
             .get(http::header::CONTENT_TYPE)
             .map(|ct| match ct.to_str() {
-                Ok("application/x-www-form-urlencoded") => serde_urlencoded::from_bytes::<D>(self.body().as_ref())
-                    .map_err(PayloadError::WwwFormUrlEncoded)
-                    .map(Some),
-                Ok("application/json") => serde_json::from_slice::<D>(self.body().as_ref())
-                    .map_err(PayloadError::Json)
-                    .map(Some),
+                Ok(content_type) => {
+                    if content_type.starts_with("application/x-www-form-urlencoded") {
+                        return serde_urlencoded::from_bytes::<D>(self.body().as_ref())
+                            .map_err(PayloadError::WwwFormUrlEncoded)
+                            .map(Some);
+                    } else if content_type.starts_with("application/json") {
+                        return serde_json::from_slice::<D>(self.body().as_ref())
+                            .map_err(PayloadError::Json)
+                            .map(Some);
+                    }
+
+                    Ok(None)
+                },
                 _ => Ok(None),
             })
             .unwrap_or_else(|| Ok(None))
@@ -314,6 +321,48 @@ mod tests {
         }
         let request = http::Request::builder()
             .header("Content-Type", "application/json")
+            .body(Body::from(r#"{"foo":"bar", "baz": 2}"#))
+            .expect("failed to build request");
+        let payload: Option<Payload> = request.payload().unwrap_or_default();
+        assert_eq!(
+            payload,
+            Some(Payload {
+                foo: "bar".into(),
+                baz: 2
+            })
+        );
+    }
+
+    #[test]
+    fn requests_match_form_post_content_type_with_charset() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Payload {
+            foo: String,
+            baz: usize,
+        }
+        let request = http::Request::builder()
+            .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+            .body(Body::from("foo=bar&baz=2"))
+            .expect("failed to build request");
+        let payload: Option<Payload> = request.payload().unwrap_or_default();
+        assert_eq!(
+            payload,
+            Some(Payload {
+                foo: "bar".into(),
+                baz: 2
+            })
+        );
+    }
+
+    #[test]
+    fn requests_match_json_content_type_with_charset() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct Payload {
+            foo: String,
+            baz: usize,
+        }
+        let request = http::Request::builder()
+            .header("Content-Type", "application/json; charset=UTF-8")
             .body(Body::from(r#"{"foo":"bar", "baz": 2}"#))
             .expect("failed to build request");
         let payload: Option<Payload> = request.payload().unwrap_or_default();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This performs a `starts_with()` check instead of exact string match for Content-Type when using the RequestExt.payload() for lambda_http as a Content-Type could contain a charset. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
