### PR TITLE
Pass cookies from LambdaRequest::ApiGatewayV2 to Request

### DIFF
--- a/lambda-http/tests/data/apigw_v2_proxy_request.json
+++ b/lambda-http/tests/data/apigw_v2_proxy_request.json
@@ -3,7 +3,7 @@
     "routeKey": "$default",
     "rawPath": "/my/path",
     "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
-    "cookies": [ "cookie1", "cookie2" ],
+    "cookies": [ "cookie1=value1", "cookie2=value2" ],
     "headers": {
       "Header1": "value1",
       "Header2": "value2"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The cookies are available as separate field when `LambdaRequest::ApiGatewayV2` is deserialized, but they did not get passed into the `headers` field of `Request` and so couldn't be used in the lambda. 

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
