### PR TITLE
Allow mocking lambda_http::Request extensions outside of crate

### DIFF
--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -6,18 +6,18 @@ use std::{error::Error, fmt};
 use crate::{request::RequestContext, strmap::StrMap, Body};
 
 /// ALB/API gateway pre-parsed http query string parameters
-pub(crate) struct QueryStringParameters(pub(crate) StrMap);
+pub struct QueryStringParameters(pub StrMap);
 
 /// API gateway pre-extracted url path parameters
 ///
 /// These will always be empty for ALB requests
-pub(crate) struct PathParameters(pub(crate) StrMap);
+pub struct PathParameters(pub StrMap);
 
 /// API gateway configured
 /// [stage variables](https://docs.aws.amazon.com/apigateway/latest/developerguide/stage-variables.html)
 ///
 /// These will always be empty for ALB requests
-pub(crate) struct StageVariables(pub(crate) StrMap);
+pub struct StageVariables(pub StrMap);
 
 /// Request payload deserialization errors
 ///

--- a/lambda-http/src/strmap.rs
+++ b/lambda-http/src/strmap.rs
@@ -13,7 +13,7 @@ use serde::{
 ///
 /// Internally data is always represented as many valued
 #[derive(Default, Debug, PartialEq)]
-pub struct StrMap(pub(crate) Arc<HashMap<String, Vec<String>>>);
+pub struct StrMap(pub Arc<HashMap<String, Vec<String>>>);
 
 impl StrMap {
     /// Return a named value where available.


### PR DESCRIPTION
*Description of changes:*

I have a use case, where I need to create a mock `lambda_http::Request` in a test function, and be able to pass a path parameter as part of the request. When the `lambda_http` crate parses a request from `LambdaRequest` to a `lambda_http::Request`, it appends the path parameters using `extension(PathParameters(path_parameters))`. However, the `PathParameters` can not be created outside of the crate, since they are not declared as public.  I also added the public scope to the other extensions, since this use pattern also applies to them.

Is there some better way to do this without having to declare the structs as public?

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
