### PR TITLE
Add note to README.md build for Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ $ rustup target add x86_64-unknown-linux-musl
 ```
 
 
-  * **Note:** If you are running on Mac OS you'll need to install the linker for the target platform. You do this using the `musl-cross` tap from [Homebrew](https://brew.sh/) which provides a complete cross-compilation toolchain for Mac OS. Once `musl-cross` is installed we will also need to inform cargo of the newely installed linker when building for the `x86_64-unknown-linux-musl` platform.
+  * **Note:** If you are running on Mac OS you'll need to install the linker for the target platform. You do this using the `musl-cross` tap from [Homebrew](https://brew.sh/) which provides a complete cross-compilation toolchain for Mac OS. Once `musl-cross` is installed we will also need to inform cargo of the newly installed linker when building for the `x86_64-unknown-linux-musl` platform.
 ```bash
-        $ brew install filosottile/musl-cross/musl-cross
-        $ mkdir .cargo
-        $ echo $'[target.x86_64-unknown-linux-musl]\nlinker = "x86_64-linux-musl-gcc"' > .cargo/config
+$ brew install filosottile/musl-cross/musl-cross
+$ mkdir .cargo
+$ echo $'[target.x86_64-unknown-linux-musl]\nlinker = "x86_64-linux-musl-gcc"' > .cargo/config
 ```
 
 Compile one of the examples as a _release_ with a specific _target_ for deployment to AWS:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Run this script once to add the new target:
 $ rustup target add x86_64-unknown-linux-musl
 ```
 
+
+  * **Note:** If you are running on Mac OS you'll need to install the linker for the target platform. You do this using the `musl-cross` tap from [Homebrew](https://brew.sh/) which provides a complete cross-compilation toolchain for Mac OS. Once `musl-cross` is installed we will also need to inform cargo of the newely installed linker when building for the `x86_64-unknown-linux-musl` platform.
+```bash
+        $ brew install filosottile/musl-cross/musl-cross
+        $ mkdir .cargo
+        $ echo $'[target.x86_64-unknown-linux-musl]\nlinker = "x86_64-linux-musl-gcc"' > .cargo/config
+```
+
 Compile one of the examples as a _release_ with a specific _target_ for deployment to AWS:
 ```bash
 $ cargo build -p lambda --example hello --release --target x86_64-unknown-linux-musl


### PR DESCRIPTION
If you follow the directions here on Mac OS you get the following error:

```
= note: clang: warning: argument unused during compilation: '-static-pie' [-Wunused-command-line-argument]
          ld: unknown option: --as-needed
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Following the steps [here](https://aws.amazon.com/blogs/opensource/rust-runtime-for-aws-lambda/) resolved the issue for me, which was basically just installing and using the linker from filosottile/musl-cross/musl-cross.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
