### PR TITLE
point to basic.rs instead of hello

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ echo $'[target.x86_64-unknown-linux-musl]\nlinker = "x86_64-linux-musl-gcc"' >
 
 Compile one of the examples as a _release_ with a specific _target_ for deployment to AWS:
 ```bash
-$ cargo build -p lambda --example hello --release --target x86_64-unknown-linux-musl
+$ cargo build -p lambda --example basic --release --target x86_64-unknown-linux-musl
 ```
 
 For [a custom runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html), AWS Lambda looks for an executable called `bootstrap` in the deployment package zip. Rename the generated `basic` executable to `bootstrap` and add it to a zip archive.


### PR DESCRIPTION
using the parameter `hello` results in the following error.

```text
error: no example target named `hello`
```

changing it to basic *appears* to work in that it doesn't throw an error, but this is only my second ever time running `cargo build ...`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
