### PR TITLE
Remove sync from lambda-http handler

### DIFF
--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -100,7 +100,7 @@ pub trait Handler: Sized {
     /// The type of Response this Handler will return
     type Response: IntoResponse;
     /// The type of Future this Handler will return
-    type Fut: Future<Output = Result<Self::Response, Self::Error>> + Send + Sync + 'static;
+    type Fut: Future<Output = Result<Self::Response, Self::Error>> + Send + 'static;
     /// Function used to execute handler behavior
     fn call(&self, event: Request, context: Context) -> Self::Fut;
 }
@@ -115,7 +115,7 @@ impl<F, R, Fut> Handler for F
 where
     F: Fn(Request, Context) -> Fut,
     R: IntoResponse,
-    Fut: Future<Output = Result<R, Error>> + Send + Sync + 'static,
+    Fut: Future<Output = Result<R, Error>> + Send + 'static,
 {
     type Response = R;
     type Error = Error;
@@ -128,7 +128,7 @@ where
 #[doc(hidden)]
 pub struct TransformResponse<R, E> {
     request_origin: RequestOrigin,
-    fut: Pin<Box<dyn Future<Output = Result<R, E>> + Send + Sync>>,
+    fut: Pin<Box<dyn Future<Output = Result<R, E>> + Send>>,
 }
 
 impl<R, E> Future for TransformResponse<R, E>


### PR DESCRIPTION
Sync was added to the lambda http handler preventing handlers that used
non-sync traits.

Closes #287 

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
