### PR TITLE
Making Error type public so that consumers don't have to create their own type alias

### DIFF
--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -17,9 +17,7 @@
 //! your function's execution path.
 //!
 //! ```rust,no_run
-//! use lambda_http::{handler, lambda_runtime};
-//!
-//! type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+//! use lambda_http::{handler, lambda_runtime::{self, Error}};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
@@ -36,9 +34,7 @@
 //! with the [`RequestExt`](trait.RequestExt.html) trait.
 //!
 //! ```rust,no_run
-//! use lambda_http::{handler, lambda_runtime::{self, Context}, IntoResponse, Request, RequestExt};
-//!
-//! type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+//! use lambda_http::{handler, lambda_runtime::{self, Context, Error}, IntoResponse, Request, RequestExt};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
@@ -67,6 +63,7 @@ extern crate maplit;
 
 pub use http::{self, Response};
 use lambda_runtime::Handler as LambdaHandler;
+use lambda_runtime::Error as Error;
 pub use lambda_runtime::{self, Context};
 
 mod body;
@@ -84,9 +81,6 @@ use std::{
     pin::Pin,
     task::{Context as TaskContext, Poll},
 };
-
-/// Error type that lambdas may result in
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Type alias for `http::Request`s with a fixed [`Body`](enum.Body.html) type
 pub type Request = http::Request<Body>;

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -62,9 +62,8 @@
 extern crate maplit;
 
 pub use http::{self, Response};
-use lambda_runtime::Handler as LambdaHandler;
-use lambda_runtime::Error as Error;
 pub use lambda_runtime::{self, Context};
+use lambda_runtime::{Error, Handler as LambdaHandler};
 
 mod body;
 pub mod ext;

--- a/lambda-runtime/examples/basic.rs
+++ b/lambda-runtime/examples/basic.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), lambda_runtime::Error> {
     Ok(())
 }
 
-pub(crate) async fn my_handler(event: Request, ctx: Context) -> Result<Response, Error> {
+pub(crate) async fn my_handler(event: Request, ctx: Context) -> Result<Response, lambda_runtime::Error> {
     // extract some useful info from the request
     let command = event.command;
 

--- a/lambda-runtime/examples/basic.rs
+++ b/lambda-runtime/examples/basic.rs
@@ -6,10 +6,6 @@ use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use simple_logger::SimpleLogger;
 
-/// A shorthand for `Box<dyn std::error::Error + Send + Sync + 'static>`
-/// type required by aws-lambda-rust-runtime.
-pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-
 /// This is also a made-up example. Requests come into the runtime as unicode
 /// strings in json format, which can map to any structure that implements `serde::Deserialize`
 /// The runtime pays no attention to the contents of the request payload.
@@ -29,7 +25,7 @@ struct Response {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), lambda_runtime::Error> {
     // required to enable CloudWatch error logging by the runtime
     // can be replaced with any other method of initializing `log`
     SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();

--- a/lambda-runtime/examples/basic.rs
+++ b/lambda-runtime/examples/basic.rs
@@ -1,7 +1,7 @@
 // This example requires the following input to succeed:
 // { "command": "do something" }
 
-use lambda_runtime::{handler_fn, Context};
+use lambda_runtime::{handler_fn, Context, Error};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use simple_logger::SimpleLogger;
@@ -25,7 +25,7 @@ struct Response {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), lambda_runtime::Error> {
+async fn main() -> Result<(), Error> {
     // required to enable CloudWatch error logging by the runtime
     // can be replaced with any other method of initializing `log`
     SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
@@ -35,7 +35,7 @@ async fn main() -> Result<(), lambda_runtime::Error> {
     Ok(())
 }
 
-pub(crate) async fn my_handler(event: Request, ctx: Context) -> Result<Response, lambda_runtime::Error> {
+pub(crate) async fn my_handler(event: Request, ctx: Context) -> Result<Response, Error> {
     // extract some useful info from the request
     let command = event.command;
 

--- a/lambda-runtime/examples/error-handling.rs
+++ b/lambda-runtime/examples/error-handling.rs
@@ -1,5 +1,5 @@
 /// See https://github.com/awslabs/aws-lambda-rust-runtime for more info on Rust runtime for AWS Lambda
-use lambda_runtime::handler_fn;
+use lambda_runtime::{handler_fn, Error};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -50,7 +50,7 @@ impl std::fmt::Display for CustomError {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), lambda_runtime::Error> {
+async fn main() -> Result<(), Error> {
     // The runtime logging can be enabled here by initializing `log` with `simple_logger`
     // or another compatible crate. The runtime is using `tracing` internally.
     // You can comment out the `simple_logger` init line and uncomment the following block to
@@ -75,7 +75,7 @@ async fn main() -> Result<(), lambda_runtime::Error> {
 }
 
 /// The actual handler of the Lambda request.
-pub(crate) async fn func(event: Value, ctx: lambda_runtime::Context) -> Result<Value, lambda_runtime::Error> {
+pub(crate) async fn func(event: Value, ctx: lambda_runtime::Context) -> Result<Value, Error> {
     // check what action was requested
     match serde_json::from_value::<Request>(event)?.event_type {
         EventType::SimpleError => {

--- a/lambda-runtime/examples/error-handling.rs
+++ b/lambda-runtime/examples/error-handling.rs
@@ -6,9 +6,6 @@ use serde_json::{json, Value};
 use simple_logger::SimpleLogger;
 use std::fs::File;
 
-/// A shorthand for `Box<dyn std::error::Error + Send + Sync + 'static>` type required by aws-lambda-rust-runtime.
-pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
-
 /// A simple Lambda request structure with just one field
 /// that tells the Lambda what is expected of it.
 #[derive(Deserialize)]
@@ -53,7 +50,7 @@ impl std::fmt::Display for CustomError {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), lambda_runtime::Error> {
     // The runtime logging can be enabled here by initializing `log` with `simple_logger`
     // or another compatible crate. The runtime is using `tracing` internally.
     // You can comment out the `simple_logger` init line and uncomment the following block to
@@ -78,7 +75,7 @@ async fn main() -> Result<(), Error> {
 }
 
 /// The actual handler of the Lambda request.
-pub(crate) async fn func(event: Value, ctx: lambda_runtime::Context) -> Result<Value, Error> {
+pub(crate) async fn func(event: Value, ctx: lambda_runtime::Context) -> Result<Value, lambda_runtime::Error> {
     // check what action was requested
     match serde_json::from_value::<Request>(event)?.event_type {
         EventType::SimpleError => {

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -31,7 +31,7 @@ use requests::{EventCompletionRequest, EventErrorRequest, IntoRequest, NextEvent
 use types::Diagnostic;
 
 /// Error type that lambdas may result in
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Configuration derived from environment variables.
 #[derive(Debug, Default, Clone, PartialEq)]


### PR DESCRIPTION
*Issue #, if available:* #297

*Description of changes:* The `Error` type alias was formerly public only to the lambda_runtime crate. Made this public and replace customer type aliases elsewhere.


By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
