### PR TITLE
RFC: Support borrowed deserializaton

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           - os: macOS-latest
             target: x86_64-unknown-linux-musl
           - os: ubuntu-latest
-            rust: 1.40.0
+            rust: 1.51.0
             target: x86_64-unknown-linux-musl
           - os: ubuntu-latest
             rust: beta
@@ -34,7 +34,7 @@ jobs:
             rust: nightly
             target: x86_64-unknown-linux-musl
           - os: macOS-latest
-            rust: 1.40.0
+            rust: 1.51.0
           - os: macOS-latest
             rust: beta
           - os: macOS-latest

--- a/lambda-http/examples/hello-http.rs
+++ b/lambda-http/examples/hello-http.rs
@@ -1,14 +1,10 @@
-use lambda_http::{
-    handler,
-    lambda_runtime::{self, Context},
-    IntoResponse, Request, RequestExt, Response,
-};
+use lambda_http::{handler, lambda_runtime::Context, IntoResponse, Request, RequestExt, Response};
 
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    lambda_runtime::run(handler(func)).await?;
+    lambda_http::run(handler(func)).await?;
     Ok(())
 }
 

--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -66,7 +66,7 @@ impl Error for PayloadError {
 /// as well as `{"x":1, "y":2}` respectively.
 ///
 /// ```rust,no_run
-/// use lambda_http::{handler, lambda_runtime::{self, Context}, Body, IntoResponse, Request, Response, RequestExt};
+/// use lambda_http::{handler, lambda_runtime::Context, Body, IntoResponse, Request, Response, RequestExt};
 /// use serde::Deserialize;
 ///
 /// type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -81,7 +81,7 @@ impl Error for PayloadError {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Error> {
-///   lambda_runtime::run(handler(add)).await?;
+///   lambda_http::run(handler(add)).await?;
 ///   Ok(())
 /// }
 ///

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -17,13 +17,13 @@
 //! your function's execution path.
 //!
 //! ```rust,no_run
-//! use lambda_http::{handler, lambda_runtime::{self, Error}};
+//! use lambda_http::{handler, lambda_runtime::Error};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
 //!     // initialize dependencies once here for the lifetime of your
 //!     // lambda task
-//!     lambda_runtime::run(handler(|request, context| async { Ok("👋 world!") })).await?;
+//!     lambda_http::run(handler(|request, context| async { Ok("👋 world!") })).await?;
 //!     Ok(())
 //! }
 //! ```
@@ -34,11 +34,11 @@
 //! with the [`RequestExt`](trait.RequestExt.html) trait.
 //!
 //! ```rust,no_run
-//! use lambda_http::{handler, lambda_runtime::{self, Context, Error}, IntoResponse, Request, RequestExt};
+//! use lambda_http::{handler, lambda_runtime::{Context, Error}, IntoResponse, Request, RequestExt};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
-//!     lambda_runtime::run(handler(hello)).await?;
+//!     lambda_http::run(handler(hello)).await?;
 //!     Ok(())
 //! }
 //!
@@ -183,7 +183,7 @@ where
 ///
 /// # Example
 /// ```no_run
-/// use lambda_http::{run, Context};
+/// use lambda_http::{handler, Context, IntoResponse, Request, RequestExt};
 /// use serde_json::Value;
 ///
 /// type Error = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/lambda-runtime/examples/error-handling.rs
+++ b/lambda-runtime/examples/error-handling.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Error> {
 
     // call the actual handler of the request
     let func = handler_fn(func);
-    lambda_runtime::run(func).await?;
+    lambda_runtime::run::<Value, _, _>(func).await?;
     Ok(())
 }
 

--- a/lambda-runtime/src/client.rs
+++ b/lambda-runtime/src/client.rs
@@ -53,7 +53,6 @@ where
 
 #[cfg(test)]
 mod endpoint_tests {
-    use crate::Handler;
     use crate::{
         client::Client,
         incoming,
@@ -62,7 +61,7 @@ mod endpoint_tests {
         },
         simulated,
         types::Diagnostic,
-        Error, Runtime,
+        Error, Handler, Runtime,
     };
     use http::{uri::PathAndQuery, HeaderValue, Method, Request, Response, StatusCode, Uri};
     use hyper::{server::conn::Http, service::service_fn, Body};

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -305,7 +305,7 @@ where
 /// #[tokio::main]
 /// async fn main() -> Result<(), Error> {
 ///     let func = handler_fn(func);
-///     lambda_runtime::run(func).await?;
+///     lambda_runtime::run::<Value, _, _>(func).await?;
 ///     Ok(())
 /// }
 ///


### PR DESCRIPTION
*Description of changes:*

This PR allows the request passed to a handler to be deserialized with a lifetime `'de`, thus avoiding copies when deserializing. Due to the lack of higher kinded types in Rust, the implementation relies on GATs. This makes things ugly on the Lambda side. For example, calling `run()` for `DeserializeOwned` types now becomes:

```rust
lambda_runtime::run::<Request, _, _>(func).await?;
```

For borrowed deserialized types, this becomes:

```rust
struct BorrowedRequest {}
impl<'de> Deserializable<'de> for BorrowedRequest {
    type Deserialize = Request<'de>;
}
lambda_runtime::run::<BorrowedRequest, _, _>(func).await?;
```

This ugliness can be fixed by macros, like:

```rust
handler!(func).await?;
```

If the PR looks good, I can prepare a follow-up with the macro.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
