### PR TITLE
Change run loop to execute all invocations concurrently

### DIFF
--- a/lambda-runtime/src/client.rs
+++ b/lambda-runtime/src/client.rs
@@ -3,7 +3,7 @@ use http::{uri::Scheme, Request, Response, Uri};
 use hyper::{client::HttpConnector, Body};
 use std::fmt::Debug;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Client<C = HttpConnector> {
     pub(crate) base: Uri,
     pub(crate) client: hyper::Client<C>,

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -7,6 +7,7 @@
 //! to the the `lambda_runtime::run` function, which launches and runs the Lambda runtime.
 pub use crate::types::Context;
 use client::Client;
+use futures::stream::FuturesUnordered;
 use hyper::client::{connect::Connection, HttpConnector};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -145,8 +146,10 @@ where
         A: for<'de> Deserialize<'de> + Send + Sync + 'static,
         B: Serialize + Send + Sync + 'static,
     {
-        let client = &self.client;
+        let client = Arc::new(self.client.clone());
         let handler = Arc::new(handler);
+        let mut tasks = FuturesUnordered::new();
+
         tokio::pin!(incoming);
         while let Some(event) = incoming.next().await {
             trace!("New event arrived (run loop)");
@@ -160,16 +163,17 @@ where
             let body = serde_json::from_slice(&body)?;
 
             let handler = Arc::clone(&handler);
-            let request_id = &ctx.request_id.clone();
-            #[allow(clippy::async_yields_async)]
-            let task = tokio::spawn(async move { handler.call(body, ctx) });
+            let request_id = ctx.request_id.clone();
 
-            let req = match task.await {
-                Ok(response) => match response.await {
+            let client = client.clone();
+            let task = tokio::spawn(async move {
+                let req = handler.call(body, ctx).await;
+
+                let req = match req {
                     Ok(response) => {
                         trace!("Ok response from handler (run loop)");
                         EventCompletionRequest {
-                            request_id,
+                            request_id: &request_id,
                             body: response,
                         }
                         .into_req()
@@ -177,7 +181,7 @@ where
                     Err(err) => {
                         error!("{}", err); // logs the error in CloudWatch
                         EventErrorRequest {
-                            request_id,
+                            request_id: &request_id,
                             diagnostic: Diagnostic {
                                 error_type: type_name_of_val(&err).to_owned(),
                                 error_message: format!("{}", err), // returns the error to the caller via Lambda API
@@ -185,23 +189,16 @@ where
                         }
                         .into_req()
                     }
-                },
-                Err(err) if err.is_panic() => {
-                    error!("{:?}", err); // inconsistent with other log record formats - to be reviewed
-                    EventErrorRequest {
-                        request_id,
-                        diagnostic: Diagnostic {
-                            error_type: type_name_of_val(&err).to_owned(),
-                            error_message: format!("Lambda panicked: {}", err),
-                        },
-                    }
-                    .into_req()
-                }
-                Err(_) => unreachable!("tokio::task should not be canceled"),
-            };
-            let req = req?;
-            client.call(req).await.expect("Unable to send response to Runtime APIs");
+                };
+                let req = req.expect("Unable to process request");
+
+                client.call(req).await.expect("Unable to send response to Runtime APIs");
+            });
+
+            tasks.push(task);
         }
+
+        while tasks.next().await.is_some() {}
         Ok(())
     }
 }


### PR DESCRIPTION
closes #311 

This is my first past at running all invocations concurrently. This code as it exists has a pretty major flaw in that all calls to [next](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html) need to be resolved before we would start executing any of the handlers. We could conceive of a situation where we have a large number of invocations queued, and we would not be able start executing the requests until all calls to next were complete. This would likely reduce the overall response time for the set of invocations, but invocations early in the queue could would be eating the next calls of those later in the queue.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
