### PR TITLE
Default Context Values for Local Containerized Testing

### DIFF
--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -119,8 +119,6 @@ pub struct Context {
 impl TryFrom<HeaderMap> for Context {
     type Error = Error;
     fn try_from(input_headers: HeaderMap) -> Result<Self, Self::Error> {
-        println!("Test with header generation:");
-        println!("{:?}", input_headers);
         let ctx = Context {
             request_id: input_headers["lambda-runtime-aws-request-id"]
                 .to_str()

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -118,22 +118,22 @@ pub struct Context {
 
 impl TryFrom<HeaderMap> for Context {
     type Error = Error;
-    fn try_from(headers: HeaderMap) -> Result<Self, Self::Error> {
-        println!("{:?}", headers);
+    fn try_from(input_headers: HeaderMap) -> Result<Self, Self::Error> {
+        println!("{:?}", input_headers);
         let ctx = Context {
-            request_id: headers["lambda-runtime-aws-request-id"]
+            request_id: input_headers["lambda-runtime-aws-request-id"]
                 .to_str()
                 .expect("Missing Request ID")
                 .to_owned(),
-            deadline: headers["lambda-runtime-deadline-ms"]
+            deadline: input_headers["lambda-runtime-deadline-ms"]
                 .to_str()?
                 .parse()
-                .expect("Missing Deadline")
-            invoked_function_arn: headers["lambda-runtime-invoked-function-arn"]
+                .expect("Missing deadline"),
+            invoked_function_arn: input_headers["lambda-runtime-invoked-function-arn"]
                 .to_str()
-                .unwrap_or("arn:test-instance")
                 .expect("Missing arn; this is a bug")
-            xray_trace_id: headers["lambda-runtime-trace-id"]
+                .to_owned(),
+            xray_trace_id: input_headers["lambda-runtime-trace-id"]
                 .to_str()
                 .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
                 .to_owned(),
@@ -142,4 +142,3 @@ impl TryFrom<HeaderMap> for Context {
         Ok(ctx)
     }
 }
-

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -121,22 +121,22 @@ impl TryFrom<HeaderMap> for Context {
     fn try_from(headers: HeaderMap) -> Result<Self, Self::Error> {
         let ctx = Context {
             request_id: headers.get("lambda-runtime-aws-request-id")
-                .unwrap_or(&HeaderValue::from_str("8476a536-e9f4-11e8-9739-2dfe598c3fcd").unwrap())
+                .unwrap_or(&HeaderValue::from_str("8476a536-e9f4-11e8-9739-2dfe598c3fcd")?)
                 .to_str()
                 .expect("Missing Request ID")
                 .to_owned(),
             deadline: headers.get("lambda-runtime-deadline-ms")
-                .unwrap_or(&HeaderValue::from_str("1542409706888").unwrap())
+                .unwrap_or(&HeaderValue::from_str("1542409706888")?)
                 .to_str()?
                 .parse()
                 .expect("Missing deadline"),
             invoked_function_arn: headers.get("lambda-runtime-invoked-function-arn")
-                .unwrap_or(&HeaderValue::from_str("arn:aws:lambda:us-east-2:123456789012:function:custom-runtime").unwrap())
+                .unwrap_or(&HeaderValue::from_str("arn:aws:lambda:us-east-2:123456789012:function:custom-runtime")?)
                 .to_str()
                 .expect("Missing arn; this is a bug")
                 .to_owned(),
             xray_trace_id: headers.get("lambda-runtime-trace-id")
-                .unwrap_or(&HeaderValue::from_str("Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1").unwrap())
+                .unwrap_or(&HeaderValue::from_str("Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1")?)
                 .to_str()
                 .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
                 .to_owned(),

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -119,6 +119,7 @@ pub struct Context {
 impl TryFrom<HeaderMap> for Context {
     type Error = Error;
     fn try_from(headers: HeaderMap) -> Result<Self, Self::Error> {
+        println!("{:?}", headers);
         let ctx = Context {
             request_id: headers["lambda-runtime-aws-request-id"]
                 .to_str()

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -120,23 +120,31 @@ impl TryFrom<HeaderMap> for Context {
     type Error = Error;
     fn try_from(headers: HeaderMap) -> Result<Self, Self::Error> {
         let ctx = Context {
-            request_id: headers.get("lambda-runtime-aws-request-id")
+            request_id: headers
+                .get("lambda-runtime-aws-request-id")
                 .unwrap_or(&HeaderValue::from_str("8476a536-e9f4-11e8-9739-2dfe598c3fcd")?)
                 .to_str()
                 .expect("Missing Request ID")
                 .to_owned(),
-            deadline: headers.get("lambda-runtime-deadline-ms")
+            deadline: headers
+                .get("lambda-runtime-deadline-ms")
                 .unwrap_or(&HeaderValue::from_str("1542409706888")?)
                 .to_str()?
                 .parse()
                 .expect("Missing deadline"),
-            invoked_function_arn: headers.get("lambda-runtime-invoked-function-arn")
-                .unwrap_or(&HeaderValue::from_str("arn:aws:lambda:us-east-2:123456789012:function:custom-runtime")?)
+            invoked_function_arn: headers
+                .get("lambda-runtime-invoked-function-arn")
+                .unwrap_or(&HeaderValue::from_str(
+                    "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime",
+                )?)
                 .to_str()
                 .expect("Missing arn; this is a bug")
                 .to_owned(),
-            xray_trace_id: headers.get("lambda-runtime-trace-id")
-                .unwrap_or(&HeaderValue::from_str("Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1")?)
+            xray_trace_id: headers
+                .get("lambda-runtime-trace-id")
+                .unwrap_or(&HeaderValue::from_str(
+                    "Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1",
+                )?)
                 .to_str()
                 .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
                 .to_owned(),

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -120,21 +120,23 @@ impl TryFrom<HeaderMap> for Context {
     type Error = Error;
     fn try_from(input_headers: HeaderMap) -> Result<Self, Self::Error> {
         let ctx = Context {
-            request_id: input_headers["lambda-runtime-aws-request-id"]
+            request_id: input_headers.get("lambda-runtime-aws-request-id")
+                .unwrap_or(&HeaderValue::from_str("").unwrap())
                 .to_str()
                 .expect("Missing Request ID")
                 .to_owned(),
-            deadline: input_headers["lambda-runtime-deadline-ms"]
+            deadline: input_headers.get("lambda-runtime-deadline-ms")
+                .unwrap_or(&HeaderValue::from_str("").unwrap())
                 .to_str()?
                 .parse()
                 .expect("Missing deadline"),
             invoked_function_arn: input_headers.get("lambda-runtime-invoked-function-arn")
-                .unwrap_or(&HeaderValue::from_str("arn:test:12345").unwrap())
+                .unwrap_or(&HeaderValue::from_str("").unwrap())
                 .to_str()
                 .expect("Missing arn; this is a bug")
                 .to_owned(),
             xray_trace_id: input_headers.get("lambda-runtime-trace-id")
-                .unwrap_or(&HeaderValue::from_str("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1").unwrap())
+                .unwrap_or(&HeaderValue::from_str("").unwrap())
                 .to_str()
                 .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
                 .to_owned(),

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -122,19 +122,19 @@ impl TryFrom<HeaderMap> for Context {
         let ctx = Context {
             request_id: headers["lambda-runtime-aws-request-id"]
                 .to_str()
-                .expect("Missing Request ID")
+                .unwrap_or("test-instance")
                 .to_owned(),
             deadline: headers["lambda-runtime-deadline-ms"]
                 .to_str()?
                 .parse()
-                .expect("Missing deadline"),
+                .unwrap_or(10),
             invoked_function_arn: headers["lambda-runtime-invoked-function-arn"]
                 .to_str()
-                .expect("Missing arn; this is a bug")
+                .unwrap_or("arn:test-instance")
                 .to_owned(),
             xray_trace_id: headers["lambda-runtime-trace-id"]
                 .to_str()
-                .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
+                .unwrap_or("Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1")
                 .to_owned(),
             ..Default::default()
         };

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -136,10 +136,7 @@ impl TryFrom<HeaderMap> for Context {
                 .expect("Missing arn; this is a bug")
                 .to_owned(),
             xray_trace_id: input_headers.get("lambda-runtime-trace-id")
-                .unwrap_or(&HeaderValue::from_str(
-                    "Root=1-5759e988-bd862e3fe1be46a994272793;
-                     Parent=53995c3f42cd8ad8;Sampled=1"
-                ).unwrap())
+                .unwrap_or(&HeaderValue::from_str("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1").unwrap())
                 .to_str()
                 .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
                 .to_owned(),

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -118,24 +118,24 @@ pub struct Context {
 
 impl TryFrom<HeaderMap> for Context {
     type Error = Error;
-    fn try_from(input_headers: HeaderMap) -> Result<Self, Self::Error> {
+    fn try_from(headers: HeaderMap) -> Result<Self, Self::Error> {
         let ctx = Context {
-            request_id: input_headers.get("lambda-runtime-aws-request-id")
+            request_id: headers.get("lambda-runtime-aws-request-id")
                 .unwrap_or(&HeaderValue::from_str("").unwrap())
                 .to_str()
                 .expect("Missing Request ID")
                 .to_owned(),
-            deadline: input_headers.get("lambda-runtime-deadline-ms")
+            deadline: headers.get("lambda-runtime-deadline-ms")
                 .unwrap_or(&HeaderValue::from_str("100").unwrap())
                 .to_str()?
                 .parse()
                 .expect("Missing deadline"),
-            invoked_function_arn: input_headers.get("lambda-runtime-invoked-function-arn")
+            invoked_function_arn: headers.get("lambda-runtime-invoked-function-arn")
                 .unwrap_or(&HeaderValue::from_str("").unwrap())
                 .to_str()
                 .expect("Missing arn; this is a bug")
                 .to_owned(),
-            xray_trace_id: input_headers.get("lambda-runtime-trace-id")
+            xray_trace_id: headers.get("lambda-runtime-trace-id")
                 .unwrap_or(&HeaderValue::from_str("").unwrap())
                 .to_str()
                 .expect("Invalid XRayTraceID sent by Lambda; this is a bug")

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -126,7 +126,7 @@ impl TryFrom<HeaderMap> for Context {
                 .expect("Missing Request ID")
                 .to_owned(),
             deadline: input_headers.get("lambda-runtime-deadline-ms")
-                .unwrap_or(&HeaderValue::from_str("").unwrap())
+                .unwrap_or(&HeaderValue::from_str("100").unwrap())
                 .to_str()?
                 .parse()
                 .expect("Missing deadline"),

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -123,19 +123,23 @@ impl TryFrom<HeaderMap> for Context {
         let ctx = Context {
             request_id: input_headers["lambda-runtime-aws-request-id"]
                 .to_str()
-                .expect("Missing Request ID")
+                .unwrap_or("12345")
                 .to_owned(),
             deadline: input_headers["lambda-runtime-deadline-ms"]
-                .to_str()?
+                .to_str()
+                .unwrap_or("10")
                 .parse()
                 .expect("Missing deadline"),
             invoked_function_arn: input_headers["lambda-runtime-invoked-function-arn"]
                 .to_str()
-                .expect("Missing arn; this is a bug")
+                .unwrap_or("arn:test:local:12345")
                 .to_owned(),
             xray_trace_id: input_headers["lambda-runtime-trace-id"]
                 .to_str()
-                .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
+                .unwrap_or(
+                    "Root=1-5759e988-bd862e3fe1be46a994272793;\
+                    Parent=53995c3f42cd8ad8;Sampled=1"
+                )
                 .to_owned(),
             ..Default::default()
         };

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -123,22 +123,23 @@ impl TryFrom<HeaderMap> for Context {
         let ctx = Context {
             request_id: headers["lambda-runtime-aws-request-id"]
                 .to_str()
-                .unwrap_or("test-instance")
+                .expect("Missing Request ID")
                 .to_owned(),
             deadline: headers["lambda-runtime-deadline-ms"]
                 .to_str()?
                 .parse()
-                .unwrap_or(10),
+                .expect("Missing Deadline")
             invoked_function_arn: headers["lambda-runtime-invoked-function-arn"]
                 .to_str()
                 .unwrap_or("arn:test-instance")
-                .to_owned(),
+                .expect("Missing arn; this is a bug")
             xray_trace_id: headers["lambda-runtime-trace-id"]
                 .to_str()
-                .unwrap_or("Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1")
+                .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
                 .to_owned(),
             ..Default::default()
         };
         Ok(ctx)
     }
 }
+

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -121,22 +121,22 @@ impl TryFrom<HeaderMap> for Context {
     fn try_from(headers: HeaderMap) -> Result<Self, Self::Error> {
         let ctx = Context {
             request_id: headers.get("lambda-runtime-aws-request-id")
-                .unwrap_or(&HeaderValue::from_str("").unwrap())
+                .unwrap_or(&HeaderValue::from_str("8476a536-e9f4-11e8-9739-2dfe598c3fcd").unwrap())
                 .to_str()
                 .expect("Missing Request ID")
                 .to_owned(),
             deadline: headers.get("lambda-runtime-deadline-ms")
-                .unwrap_or(&HeaderValue::from_str("100").unwrap())
+                .unwrap_or(&HeaderValue::from_str("1542409706888").unwrap())
                 .to_str()?
                 .parse()
                 .expect("Missing deadline"),
             invoked_function_arn: headers.get("lambda-runtime-invoked-function-arn")
-                .unwrap_or(&HeaderValue::from_str("").unwrap())
+                .unwrap_or(&HeaderValue::from_str("arn:aws:lambda:us-east-2:123456789012:function:custom-runtime").unwrap())
                 .to_str()
                 .expect("Missing arn; this is a bug")
                 .to_owned(),
             xray_trace_id: headers.get("lambda-runtime-trace-id")
-                .unwrap_or(&HeaderValue::from_str("").unwrap())
+                .unwrap_or(&HeaderValue::from_str("Root=1-5bef4de7-ad49b0e87f6ef6c87fc2e700;Parent=9a9197af755a6419;Sampled=1").unwrap())
                 .to_str()
                 .expect("Invalid XRayTraceID sent by Lambda; this is a bug")
                 .to_owned(),

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -119,6 +119,7 @@ pub struct Context {
 impl TryFrom<HeaderMap> for Context {
     type Error = Error;
     fn try_from(input_headers: HeaderMap) -> Result<Self, Self::Error> {
+        println!("Test with header generation:");
         println!("{:?}", input_headers);
         let ctx = Context {
             request_id: input_headers["lambda-runtime-aws-request-id"]


### PR DESCRIPTION
*Issue #, if available: *
#313

*Description of changes:*
In order to make the runtime easier to consume, we would like to introduce a reasonable set of default values for the AWS Context to be used in combination with the official AWS Lambda container image. The values we chose came directly from the [official AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html) for Lambda context.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
