### PR TITLE
feat: expose types useful for other runtimes

### DIFF
--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -68,7 +68,8 @@ use lambda_runtime::{Error, Handler as LambdaHandler};
 mod body;
 pub mod ext;
 pub mod request;
-mod response;
+#[doc(hidden)]
+pub mod response;
 mod strmap;
 pub use crate::{body::Body, ext::RequestExt, response::IntoResponse, strmap::StrMap};
 use crate::{

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -107,7 +107,7 @@ where
 
 /// tranformation from http type to internal type
 impl LambdaResponse {
-    pub(crate) fn from_response<T>(request_origin: &RequestOrigin, value: Response<T>) -> Self
+    pub fn from_response<T>(request_origin: &RequestOrigin, value: Response<T>) -> Self
     where
         T: Into<Body>,
     {

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -20,15 +20,17 @@ use tokio_stream::{Stream, StreamExt};
 use tower_service::Service;
 use tracing::{error, trace};
 
+#[doc(hidden)]
+pub mod requests;
+
 mod client;
-mod requests;
 #[cfg(test)]
 mod simulated;
 /// Types available to a Lambda function.
 mod types;
 
 use requests::{EventCompletionRequest, EventErrorRequest, IntoRequest, NextEventRequest};
-use types::Diagnostic;
+pub use types::Diagnostic;
 
 /// Error type that lambdas may result in
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;

--- a/lambda-runtime/src/requests.rs
+++ b/lambda-runtime/src/requests.rs
@@ -4,7 +4,8 @@ use hyper::Body;
 use serde::Serialize;
 use std::str::FromStr;
 
-pub(crate) trait IntoRequest {
+#[doc(hidden)]
+pub trait IntoRequest {
     fn into_req(self) -> Result<Request<Body>, Error>;
 }
 

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -3,11 +3,12 @@ use http::HeaderMap;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, convert::TryFrom};
 
+#[doc(hidden)]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct Diagnostic {
-    pub(crate) error_type: String,
-    pub(crate) error_message: String,
+pub struct Diagnostic {
+    pub error_type: String,
+    pub error_message: String,
 }
 
 #[test]


### PR DESCRIPTION
Hi Folks - we'd like to run Rust on AWS Lambda, however our Rust services stack is async-std based. (We very keenly picked [Tide](https://docs.rs/tide/0.16.0/tide/index.html) as our server framework of choice due to general approachability for new rust developers!)

Things do mostly work running this on-top of Tokio, but we'd like to have a full async-std version of the lambda http handler, ideally written as a Tide [Listener](https://docs.rs/tide/0.16.0/tide/listener/trait.Listener.html). Tide's http stack includes a feature to translate between hyperium's http requests and http-rs's http-types requests, using this in combination with exposing more input/output structures here, we can reduce a lot of code we'd otherwise have to replicate (particularly incoming request deserialization and http request restructuring code). It would be greatly appreciated if some form of this could make it's way into these crates.

*Description of changes:*

Other runtimes would benefit from the types for deserializing incoming lambda requests (and a few others), so, in an effort to not have people replicate everything, expose these extra parts but hide them from the docs, since this essentially unstable code spelunking at this point.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
