### PR TITLE
Removed 'static bound requirements for the lambda_http crate and create a shared resources example for the crate

### DIFF
--- a/lambda-http/examples/hello-http.rs
+++ b/lambda-http/examples/hello-http.rs
@@ -1,10 +1,8 @@
 use lambda_http::{
     handler,
-    lambda_runtime::{self, Context},
+    lambda_runtime::{self, Context, Error},
     IntoResponse, Request, RequestExt, Response,
 };
-
-type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/lambda-http/examples/shared-resources-example.rs
+++ b/lambda-http/examples/shared-resources-example.rs
@@ -1,0 +1,38 @@
+use lambda_http::{
+    handler,
+    lambda_runtime::{self, Context, Error},
+    IntoResponse, Request, RequestExt, Response,
+};
+
+struct SharedClient {
+    name: &'static str,
+}
+
+impl SharedClient {
+    fn response(&self, req_id: String, first_name: &str) -> String {
+        format!("{}: Client ({}) invoked by {}.", req_id, self.name, first_name)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+
+    // Create the "client" and a reference to it, so that we can pass this into the handler closure below.
+    let shared_client = SharedClient { name: "random_client_name_1" };
+    let shared_client_ref = &shared_client;
+
+    // Define a closure here that makes use of the shared client.
+    let handler_func_closure = move |event: Request, ctx: Context| async move {
+        Ok(match event.query_string_parameters().get("first_name") {
+            Some(first_name) => shared_client_ref.response(ctx.request_id, first_name).into_response(),
+            _ => Response::builder()
+                .status(400)
+                .body("Empty first name".into())
+                .expect("failed to render response"),
+        })
+    };
+
+    // Pass the closure to the runtime here.
+    lambda_runtime::run(handler(handler_func_closure)).await?;
+    Ok(())
+}

--- a/lambda-http/examples/shared-resources-example.rs
+++ b/lambda-http/examples/shared-resources-example.rs
@@ -16,9 +16,10 @@ impl SharedClient {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-
     // Create the "client" and a reference to it, so that we can pass this into the handler closure below.
-    let shared_client = SharedClient { name: "random_client_name_1" };
+    let shared_client = SharedClient {
+        name: "random_client_name_1",
+    };
     let shared_client_ref = &shared_client;
 
     // Define a closure here that makes use of the shared client.

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -75,11 +75,7 @@ use crate::{
     request::{LambdaRequest, RequestOrigin},
     response::LambdaResponse,
 };
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context as TaskContext, Poll},
-};
+use std::{future::Future, marker::PhantomData, pin::Pin, task::{Context as TaskContext, Poll}};
 
 /// Type alias for `http::Request`s with a fixed [`Body`](enum.Body.html) type
 pub type Request = http::Request<Body>;
@@ -87,28 +83,28 @@ pub type Request = http::Request<Body>;
 /// Functions serving as ALB and API Gateway REST and HTTP API handlers must conform to this type.
 ///
 /// This can be viewed as a `lambda_runtime::Handler` constrained to `http` crate `Request` and `Response` types
-pub trait Handler: Sized {
+pub trait Handler<'a>: Sized {
     /// The type of Error that this Handler will return
     type Error;
     /// The type of Response this Handler will return
     type Response: IntoResponse;
     /// The type of Future this Handler will return
-    type Fut: Future<Output = Result<Self::Response, Self::Error>> + Send + 'static;
+    type Fut: Future<Output = Result<Self::Response, Self::Error>> + Send + 'a;
     /// Function used to execute handler behavior
     fn call(&self, event: Request, context: Context) -> Self::Fut;
 }
 
 /// Adapts a [`Handler`](trait.Handler.html) to the `lambda_runtime::run` interface
-pub fn handler<H: Handler>(handler: H) -> Adapter<H> {
-    Adapter { handler }
+pub fn handler<'a, H: Handler<'a>>(handler: H) -> Adapter<'a, H> {
+    Adapter { handler, _pd: PhantomData }
 }
 
 /// An implementation of `Handler` for a given closure return a `Future` representing the computed response
-impl<F, R, Fut> Handler for F
+impl<'a, F, R, Fut> Handler<'a> for F
 where
     F: Fn(Request, Context) -> Fut,
     R: IntoResponse,
-    Fut: Future<Output = Result<R, Error>> + Send + 'static,
+    Fut: Future<Output = Result<R, Error>> + Send + 'a,
 {
     type Response = R;
     type Error = Error;
@@ -119,12 +115,12 @@ where
 }
 
 #[doc(hidden)]
-pub struct TransformResponse<R, E> {
+pub struct TransformResponse<'a, R, E> {
     request_origin: RequestOrigin,
-    fut: Pin<Box<dyn Future<Output = Result<R, E>> + Send>>,
+    fut: Pin<Box<dyn Future<Output = Result<R, E>> + Send + 'a>>,
 }
 
-impl<R, E> Future for TransformResponse<R, E>
+impl<'a, R, E> Future for TransformResponse<'a, R, E>
 where
     R: IntoResponse,
 {
@@ -146,11 +142,12 @@ where
 ///
 /// See [this article](http://smallcultfollowing.com/babysteps/blog/2015/01/14/little-orphan-impls/)
 /// for a larger explaination of why this is nessessary
-pub struct Adapter<H: Handler> {
+pub struct Adapter<'a, H: Handler<'a>> {
     handler: H,
+    _pd: PhantomData<&'a H>
 }
 
-impl<H: Handler> Handler for Adapter<H> {
+impl<'a, H: Handler<'a>> Handler<'a> for Adapter<'a, H> {
     type Response = H::Response;
     type Error = H::Error;
     type Fut = H::Fut;
@@ -159,9 +156,9 @@ impl<H: Handler> Handler for Adapter<H> {
     }
 }
 
-impl<H: Handler> LambdaHandler<LambdaRequest<'_>, LambdaResponse> for Adapter<H> {
+impl<'a, H: Handler<'a>> LambdaHandler<LambdaRequest<'a>, LambdaResponse> for Adapter<'a, H> {
     type Error = H::Error;
-    type Fut = TransformResponse<H::Response, Self::Error>;
+    type Fut = TransformResponse<'a, H::Response, Self::Error>;
 
     fn call(&self, event: LambdaRequest<'_>, context: Context) -> Self::Fut {
         let request_origin = event.request_origin();

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -75,7 +75,12 @@ use crate::{
     request::{LambdaRequest, RequestOrigin},
     response::LambdaResponse,
 };
-use std::{future::Future, marker::PhantomData, pin::Pin, task::{Context as TaskContext, Poll}};
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context as TaskContext, Poll},
+};
 
 /// Type alias for `http::Request`s with a fixed [`Body`](enum.Body.html) type
 pub type Request = http::Request<Body>;
@@ -96,7 +101,10 @@ pub trait Handler<'a>: Sized {
 
 /// Adapts a [`Handler`](trait.Handler.html) to the `lambda_runtime::run` interface
 pub fn handler<'a, H: Handler<'a>>(handler: H) -> Adapter<'a, H> {
-    Adapter { handler, _pd: PhantomData }
+    Adapter {
+        handler,
+        _pd: PhantomData,
+    }
 }
 
 /// An implementation of `Handler` for a given closure return a `Future` representing the computed response
@@ -144,7 +152,7 @@ where
 /// for a larger explaination of why this is nessessary
 pub struct Adapter<'a, H: Handler<'a>> {
     handler: H,
-    _pd: PhantomData<&'a H>
+    _pd: PhantomData<&'a H>,
 }
 
 impl<'a, H: Handler<'a>> Handler<'a> for Adapter<'a, H> {


### PR DESCRIPTION
Following discussion in https://github.com/awslabs/aws-lambda-rust-runtime/issues/310, it makes sense to include these changes in the lambda_http crate as well. I've given this work a pass, and am looking for feedback now.

*Issue #, if available:* #310

*Description of changes:*

* Added explicit lifetime bounds on each of the handler and adaptor types in the lambda_http crate, so we don't have to rely on the futures for these being 'static any longer.
* Added an example of how one might use this to the examples folder. Have tested that these changes work in the Lambda console with an APIGW event:

```
Response
{
  "statusCode": 200,
  "headers": {},
  "multiValueHeaders": {},
  "body": "f9b73b61-82cf-4da5-b084-19f01ee76346: Client (random_client_name_1) invoked by Colton.",
  "isBase64Encoded": false
}
```

The request was a regular APIGW proxy event with the query string value "first_name" set to my name.


By submitting this pull request

- [ X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ X] I confirm that I've made a best effort attempt to update all relevant documentation.
