### PR TITLE
Incrementing to 0.4.0

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 base64 = "0.13.0"
 http = "0.2"
-lambda_runtime = { path = "../lambda-runtime", version = "0.3" }
+lambda_runtime = { path = "../lambda-runtime", version = "0.4" }
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
 serde_urlencoded = "0.7.0"

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Doug Tangren"]
 edition = "2018"
 description = "Application Load Balancer and API Gateway event types for AWS Lambda"

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["David Barsky <dbarsky@amazon.com>"]
 description = "AWS Lambda Runtime"
 edition = "2018"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-rust-runtime/issues/338

*Description of changes:*
0.3.1 is not semantically versioned correctly as it added a lifetime to the Handler, which was not a backwards compatible change with users of 0.3.0 that implemented their own handlers. Republishing as 0.4.0 with this.


By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
