### PR TITLE
build: BREAKING CHANGE: upgrade tracing-[error|subscriber]

### DIFF
--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -23,13 +23,13 @@ bytes = "1.0"
 http = "0.2"
 async-stream = "0.3"
 futures = "0.3"
-tracing-error = "0.1.2"
+tracing-error = "0.2"
 tracing = { version = "0.1", features = ["log"] }
 tower-service = "0.3"
 tokio-stream = "0.1.2"
 
 [dev-dependencies]
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3"
 once_cell = "1.4.0"
 simple_logger = "1.6.0"
 log = "^0.4"


### PR DESCRIPTION
*Issue #, if available:* #357

*Description of changes:* Upgrade tracing-error to 0.2, tracing-subscriber to 0.3. Fixes RUSTSEC advisory involving usage of chrono.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
