### PR TITLE
feat: inject user agent in Lambda runtime API calls

### DIFF
--- a/lambda-runtime/src/requests.rs
+++ b/lambda-runtime/src/requests.rs
@@ -20,7 +20,7 @@ impl IntoRequest for NextEventRequest {
     fn into_req(self) -> Result<Request<Body>, Error> {
         let req = Request::builder()
             .method(Method::GET)
-            .header("User-Agent", format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")))
+            .header("User-Agent", ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat())
             .uri(Uri::from_static("/2018-06-01/runtime/invocation/next"))
             .body(Body::empty())?;
         Ok(req)
@@ -59,7 +59,7 @@ fn test_next_event_request() {
     assert_eq!(req.method(), Method::GET);
     assert_eq!(req.uri(), &Uri::from_static("/2018-06-01/runtime/invocation/next"));
     assert!(match req.headers().get("User-Agent") {
-        Some(header) => header.to_str().unwrap() == format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")),
+        Some(header) => header.to_str().unwrap() == ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat(),
         None => false,
     });
 }
@@ -81,7 +81,7 @@ where
         let body = Body::from(body);
 
         let req = Request::builder()
-            .header("User-Agent", format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")))
+            .header("User-Agent", ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat())
             .method(Method::POST)
             .uri(uri)
             .body(body)?;
@@ -100,7 +100,7 @@ fn test_event_completion_request() {
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
     assert!(match req.headers().get("User-Agent") {
-        Some(header) => header.to_str().unwrap() == format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")),
+        Some(header) => header.to_str().unwrap() == ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat(),
         None => false,
     });
 }
@@ -121,7 +121,7 @@ impl<'a> IntoRequest for EventErrorRequest<'a> {
         let req = Request::builder()
             .method(Method::POST)
             .uri(uri)
-            .header("User-Agent", format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")))
+            .header("User-Agent", ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat())
             .header("lambda-runtime-function-error-type", "unhandled")
             .body(body)?;
         Ok(req)
@@ -142,7 +142,7 @@ fn test_event_error_request() {
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
     assert!(match req.headers().get("User-Agent") {
-        Some(header) => header.to_str().unwrap() == format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")),
+        Some(header) => header.to_str().unwrap() == ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat(),
         None => false,
     });
 }
@@ -158,7 +158,7 @@ impl IntoRequest for InitErrorRequest {
         let req = Request::builder()
             .method(Method::POST)
             .uri(uri)
-            .header("User-Agent", format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")))
+            .header("User-Agent", ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat())
             .header("lambda-runtime-function-error-type", "unhandled")
             .body(Body::empty())?;
         Ok(req)
@@ -173,7 +173,7 @@ fn test_init_error_request() {
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
     assert!(match req.headers().get("User-Agent") {
-        Some(header) => header.to_str().unwrap() == format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")),
+        Some(header) => header.to_str().unwrap() == ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat(),
         None => false,
     });
 }

--- a/lambda-runtime/src/requests.rs
+++ b/lambda-runtime/src/requests.rs
@@ -4,6 +4,8 @@ use hyper::Body;
 use serde::Serialize;
 use std::str::FromStr;
 
+const USER_AGENT: &str = concat!("aws-lambda-rust/", env!("CARGO_PKG_VERSION"));
+
 pub(crate) trait IntoRequest {
     fn into_req(self) -> Result<Request<Body>, Error>;
 }
@@ -20,7 +22,7 @@ impl IntoRequest for NextEventRequest {
     fn into_req(self) -> Result<Request<Body>, Error> {
         let req = Request::builder()
             .method(Method::GET)
-            .header("User-Agent", ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat())
+            .header("User-Agent", USER_AGENT)
             .uri(Uri::from_static("/2018-06-01/runtime/invocation/next"))
             .body(Body::empty())?;
         Ok(req)
@@ -59,7 +61,7 @@ fn test_next_event_request() {
     assert_eq!(req.method(), Method::GET);
     assert_eq!(req.uri(), &Uri::from_static("/2018-06-01/runtime/invocation/next"));
     assert!(match req.headers().get("User-Agent") {
-        Some(header) => header.to_str().unwrap() == ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat(),
+        Some(header) => header.to_str().unwrap().starts_with("aws-lambda-rust/"),
         None => false,
     });
 }
@@ -81,7 +83,7 @@ where
         let body = Body::from(body);
 
         let req = Request::builder()
-            .header("User-Agent", ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat())
+            .header("User-Agent", USER_AGENT)
             .method(Method::POST)
             .uri(uri)
             .body(body)?;
@@ -100,7 +102,7 @@ fn test_event_completion_request() {
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
     assert!(match req.headers().get("User-Agent") {
-        Some(header) => header.to_str().unwrap() == ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat(),
+        Some(header) => header.to_str().unwrap().starts_with("aws-lambda-rust/"),
         None => false,
     });
 }
@@ -121,7 +123,7 @@ impl<'a> IntoRequest for EventErrorRequest<'a> {
         let req = Request::builder()
             .method(Method::POST)
             .uri(uri)
-            .header("User-Agent", ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat())
+            .header("User-Agent", USER_AGENT)
             .header("lambda-runtime-function-error-type", "unhandled")
             .body(body)?;
         Ok(req)
@@ -142,7 +144,7 @@ fn test_event_error_request() {
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
     assert!(match req.headers().get("User-Agent") {
-        Some(header) => header.to_str().unwrap() == ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat(),
+        Some(header) => header.to_str().unwrap().starts_with("aws-lambda-rust/"),
         None => false,
     });
 }
@@ -158,7 +160,7 @@ impl IntoRequest for InitErrorRequest {
         let req = Request::builder()
             .method(Method::POST)
             .uri(uri)
-            .header("User-Agent", ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat())
+            .header("User-Agent", USER_AGENT)
             .header("lambda-runtime-function-error-type", "unhandled")
             .body(Body::empty())?;
         Ok(req)
@@ -173,7 +175,7 @@ fn test_init_error_request() {
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
     assert!(match req.headers().get("User-Agent") {
-        Some(header) => header.to_str().unwrap() == ["aws-lambda-rust/", env!("CARGO_PKG_VERSION")].concat(),
+        Some(header) => header.to_str().unwrap().starts_with("aws-lambda-rust/"),
         None => false,
     });
 }

--- a/lambda-runtime/src/requests.rs
+++ b/lambda-runtime/src/requests.rs
@@ -20,6 +20,7 @@ impl IntoRequest for NextEventRequest {
     fn into_req(self) -> Result<Request<Body>, Error> {
         let req = Request::builder()
             .method(Method::GET)
+            .header("User-Agent", format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")))
             .uri(Uri::from_static("/2018-06-01/runtime/invocation/next"))
             .body(Body::empty())?;
         Ok(req)
@@ -57,6 +58,10 @@ fn test_next_event_request() {
     let req = req.into_req().unwrap();
     assert_eq!(req.method(), Method::GET);
     assert_eq!(req.uri(), &Uri::from_static("/2018-06-01/runtime/invocation/next"));
+    assert!(match req.headers().get("User-Agent") {
+        Some(header) => header.to_str().unwrap() == format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")),
+        None => false,
+    });
 }
 
 // /runtime/invocation/{AwsRequestId}/response
@@ -75,7 +80,11 @@ where
         let body = serde_json::to_vec(&self.body)?;
         let body = Body::from(body);
 
-        let req = Request::builder().method(Method::POST).uri(uri).body(body)?;
+        let req = Request::builder()
+            .header("User-Agent", format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")))
+            .method(Method::POST)
+            .uri(uri)
+            .body(body)?;
         Ok(req)
     }
 }
@@ -90,6 +99,10 @@ fn test_event_completion_request() {
     let expected = Uri::from_static("/2018-06-01/runtime/invocation/id/response");
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
+    assert!(match req.headers().get("User-Agent") {
+        Some(header) => header.to_str().unwrap() == format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")),
+        None => false,
+    });
 }
 
 // /runtime/invocation/{AwsRequestId}/error
@@ -108,6 +121,7 @@ impl<'a> IntoRequest for EventErrorRequest<'a> {
         let req = Request::builder()
             .method(Method::POST)
             .uri(uri)
+            .header("User-Agent", format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")))
             .header("lambda-runtime-function-error-type", "unhandled")
             .body(body)?;
         Ok(req)
@@ -127,6 +141,10 @@ fn test_event_error_request() {
     let expected = Uri::from_static("/2018-06-01/runtime/invocation/id/error");
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
+    assert!(match req.headers().get("User-Agent") {
+        Some(header) => header.to_str().unwrap() == format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")),
+        None => false,
+    });
 }
 
 // /runtime/init/error
@@ -140,6 +158,7 @@ impl IntoRequest for InitErrorRequest {
         let req = Request::builder()
             .method(Method::POST)
             .uri(uri)
+            .header("User-Agent", format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")))
             .header("lambda-runtime-function-error-type", "unhandled")
             .body(Body::empty())?;
         Ok(req)
@@ -153,4 +172,8 @@ fn test_init_error_request() {
     let expected = Uri::from_static("/2018-06-01/runtime/init/error");
     assert_eq!(req.method(), Method::POST);
     assert_eq!(req.uri(), &expected);
+    assert!(match req.headers().get("User-Agent") {
+        Some(header) => header.to_str().unwrap() == format!("aws-lambda-rust/{}", env!("CARGO_PKG_VERSION")),
+        None => false,
+    });
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This injects a User-Agent header into the Lambda runtime API calls to track usage of Rust for provided/provided.al2 Lambda runtimes.

This uses `aws-lambda-rust/%s`, with __%s__ being the crate version, to mimick the behaviour of other runtimes. E.g. for [Go](https://github.com/aws/aws-lambda-go/blob/main/lambda/runtime_api_client.go#L40), [Java RIC](https://github.com/aws/aws-lambda-java-libs/pull/277). This is slightly different as we cannot get the rustc version directly from the environment variables set by Cargo.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
