### PR TITLE
LambdaRequest lifetime fix

### DIFF
--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate abstracts over all of these trigger events using standard [`http`](https://github.com/hyperium/http) types minimizing the mental overhead
 //! of understanding the nuances and variation between trigger details allowing you to focus more on your application while also giving you to the maximum flexibility to
-//! transparently use whichever lambda trigger suits your application and cost optimiztions best.
+//! transparently use whichever lambda trigger suits your application and cost optimizations best.
 //!
 //! # Examples
 //!
@@ -149,7 +149,7 @@ where
 /// It serves as a opaque trait covering type.
 ///
 /// See [this article](http://smallcultfollowing.com/babysteps/blog/2015/01/14/little-orphan-impls/)
-/// for a larger explaination of why this is nessessary
+/// for a larger explanation of why this is necessary
 pub struct Adapter<'a, H: Handler<'a>> {
     handler: H,
     _pd: PhantomData<&'a H>,
@@ -164,7 +164,7 @@ impl<'a, H: Handler<'a>> Handler<'a> for Adapter<'a, H> {
     }
 }
 
-impl<'a, H: Handler<'a>> LambdaHandler<LambdaRequest<'a>, LambdaResponse> for Adapter<'a, H> {
+impl<'a, 'b, H: Handler<'a>> LambdaHandler<LambdaRequest<'b>, LambdaResponse> for Adapter<'a, H> {
     type Error = H::Error;
     type Fut = TransformResponse<'a, H::Response, Self::Error>;
 


### PR DESCRIPTION
*Description of changes:*

Making the LambdaHandler implementation for the adapter more generic over the lifetime of the LambdaRequest, issue encountered in valid code yielding such errors:

```
= note: `lambda_runtime::Handler<lambda_http::request::LambdaRequest<'1>, lambda_http::response::LambdaResponse>` would have to be implemented for the type `lambda_http::Adapter<'0, grpc::aws_lambda_handler::AwsLambdaHandler<tonic_web::service::GrpcWeb<MultiplexerService>>>`, for any two lifetimes `'0` and 
`'1`...
= note: ...but `lambda_runtime::Handler<lambda_http::request::LambdaRequest<'2>, lambda_http::response::LambdaResponse>` is actually implemented for the type `lambda_http::Adapter<'2, grpc::aws_lambda_handler::AwsLambdaHandler<tonic_web::service::GrpcWeb<MultiplexerService>>>`, for some specific lifetime `'2`
```

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
