### PR TITLE
fix: null deserialization of stageVariables for sam local

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -33,9 +33,9 @@ pub enum LambdaRequest<'a> {
         cookies: Option<Vec<Cow<'a, str>>>,
         #[serde(deserialize_with = "deserialize_headers")]
         headers: http::HeaderMap,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "nullable_default")]
         query_string_parameters: StrMap,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "nullable_default")]
         path_parameters: StrMap,
         #[serde(default, deserialize_with = "nullable_default")]
         stage_variables: StrMap,
@@ -55,7 +55,7 @@ pub enum LambdaRequest<'a> {
         /// the `lambda.multi_value_headers.enabled` target group setting turned on
         #[serde(default, deserialize_with = "deserialize_multi_value_headers")]
         multi_value_headers: http::HeaderMap,
-        #[serde(deserialize_with = "nullable_default")]
+        #[serde(default, deserialize_with = "nullable_default")]
         query_string_parameters: StrMap,
         /// For alb events these are only present when
         /// the `lambda.multi_value_headers.enabled` target group setting turned on
@@ -75,7 +75,7 @@ pub enum LambdaRequest<'a> {
         headers: http::HeaderMap,
         #[serde(default, deserialize_with = "deserialize_multi_value_headers")]
         multi_value_headers: http::HeaderMap,
-        #[serde(deserialize_with = "nullable_default")]
+        #[serde(default, deserialize_with = "nullable_default")]
         query_string_parameters: StrMap,
         #[serde(default, deserialize_with = "nullable_default")]
         multi_value_query_string_parameters: StrMap,

--- a/lambda-http/tests/data/apigw_v2_sam_local.json
+++ b/lambda-http/tests/data/apigw_v2_sam_local.json
@@ -1,0 +1,46 @@
+{
+  "version": "2.0",
+  "routeKey": "GET /hello",
+  "rawPath": "/hello",
+  "rawQueryString": "",
+  "cookies": [],
+  "headers": {
+    "Host": "127.0.0.1:3000",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:94.0) Gecko/20100101 Firefox/94.0",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+    "Accept-Encoding": "gzip, deflate",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Cache-Control": "max-age=0",
+    "X-Forwarded-Proto": "http",
+    "X-Forwarded-Port": "3000"
+  },
+  "queryStringParameters": {},
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "1234567890",
+    "http": {
+      "method": "GET",
+      "path": "/hello",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "127.0.0.1",
+      "userAgent": "Custom User Agent String"
+    },
+    "requestId": "1ac06eee-f687-44ec-9036-dfd49d0be0a3",
+    "routeKey": "GET /hello",
+    "stage": "$default",
+    "time": "16/Nov/2021:11:54:33 +0000",
+    "timeEpoch": 1637063673,
+    "domainName": "localhost",
+    "domainPrefix": "localhost"
+  },
+  "body": "",
+  "pathParameters": {},
+  "stageVariables": null,
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-rust-runtime/issues/365

*Description of changes:*

Add support for deserializing API Gateway v2 payloads when `stageVariables` is set to null.

AWS SAM local sends a payload that contains a null value for `stageVariables`, which causes the deserialization into a `lambda_http::request::LambdaRequest` to fail. This makes this field deserializable using the `nullable_default` function to handle that edge case.

__Open question__: should we also make this change to all fields that deserializes into a `StrMap`?

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
