### PR TITLE
fix: create a valid URL for REST APIs and ALBs when the host header i…

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -440,9 +440,7 @@ impl<'a> From<LambdaRequest<'a>> for http::Request<Body> {
                 let builder = http::Request::builder()
                     .method(http_method)
                     .uri({
-                        let host = headers
-                            .get(http::header::HOST)
-                            .and_then(|val| val.to_str().ok());
+                        let host = headers.get(http::header::HOST).and_then(|val| val.to_str().ok());
                         match host {
                             Some(host) => {
                                 format!(
@@ -508,9 +506,7 @@ impl<'a> From<LambdaRequest<'a>> for http::Request<Body> {
                 let builder = http::Request::builder()
                     .method(http_method)
                     .uri({
-                        let host = headers
-                            .get(http::header::HOST)
-                            .and_then(|val| val.to_str().ok());
+                        let host = headers.get(http::header::HOST).and_then(|val| val.to_str().ok());
                         match host {
                             Some(host) => {
                                 format!(

--- a/lambda-http/tests/data/apigw_no_host.json
+++ b/lambda-http/tests/data/apigw_no_host.json
@@ -1,0 +1,54 @@
+{
+  "path": "/test/hello",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, lzma, sdch, br",
+    "Accept-Language": "en-US,en;q=0.8",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+    "Via": "1.1 fb7cca60f0ecd82ce07790c9c5eef16c.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "nBsWBOrSHMgnaROZJK1wGCZ9PcRcSpq_oSXZNQwQ10OTZL4cimZo3g==",
+    "X-Forwarded-For": "192.168.100.1, 192.168.1.1",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "pathParameters": {
+    "proxy": "hello"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "us4z18",
+    "stage": "test",
+    "requestId": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
+    "identity": {
+      "cognitoIdentityPoolId": "",
+      "accountId": "",
+      "cognitoIdentityId": "",
+      "caller": "",
+      "apiKey": "",
+      "sourceIp": "192.168.100.1",
+      "cognitoAuthenticationType": "",
+      "cognitoAuthenticationProvider": "",
+      "userArn": "",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+      "user": ""
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "wt6mne2s9k"
+  },
+  "resource": "/{proxy+}",
+  "httpMethod": "GET",
+  "queryStringParameters": {
+    "name": "me"
+  },
+  "stageVariables": {
+    "stageVarName": "stageVarValue"
+  }
+}


### PR DESCRIPTION
…s missing

*Issue #, if available:* https://github.com/awslabs/aws-lambda-rust-runtime/issues/368

*Description of changes:*

When the __Host__ header is missing from an API Gateway REST API or ALB request, the current implementations defaults to an empty value. This means that the `lambda_http` crate tries to transform a value of `https:///my/path` into an Uri, which results in an `http::Error(InvalidUri(InvalidFormat))` error.

This PR changes the behavior by checking first if there is a valid host header present. It then uses the `http(s)://my-host/my/path` pattern if it is present, or just `/my/path` otherwise.

No changes are needed for API Gateway v2 since it adds a `requestContext.domainName` value, which means we can always derive a valid domain name in that situation.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
