### PR TITLE
Removed references to type Error aliases in docs

### DIFF
--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -66,10 +66,8 @@ impl Error for PayloadError {
 /// as well as `{"x":1, "y":2}` respectively.
 ///
 /// ```rust,no_run
-/// use lambda_http::{handler, lambda_runtime::{self, Context}, Body, IntoResponse, Request, Response, RequestExt};
+/// use lambda_http::{handler, lambda_runtime::{self, Error, Context}, Body, IntoResponse, Request, Response, RequestExt};
 /// use serde::Deserialize;
-///
-/// type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 ///
 /// #[derive(Debug,Deserialize,Default)]
 /// struct Args {

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -281,10 +281,8 @@ where
 ///
 /// # Example
 /// ```no_run
-/// use lambda_runtime::{handler_fn, Context};
+/// use lambda_runtime::{Error, handler_fn, Context};
 /// use serde_json::Value;
-///
-/// type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Error> {


### PR DESCRIPTION
We removed the need to define an alias for our internal Error type in this commit https://github.com/awslabs/aws-lambda-rust-runtime/commit/96fc5bce8543b42339c22f5c3ed9f83bfabd3991 a while back. I've just noticed that some internal docs didn't get updated.

### Description of changes

* removed alias definition
* added Error to `use`

I didn't run the examples, but this is a 1:1 copy from my working code.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
