### PR TITLE
[WIP] feat!: Replace Handler with tower::Service

### DIFF
--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -63,7 +63,7 @@ extern crate maplit;
 
 pub use http::{self, Response};
 pub use lambda_runtime::{self, Context};
-use lambda_runtime::{Error, LambdaRequest as RuntimeRequest, Service};
+use lambda_runtime::{tower::Service, Error, LambdaRequest as RuntimeRequest};
 
 mod body;
 pub mod ext;

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -63,7 +63,7 @@ extern crate maplit;
 
 pub use http::{self, Response};
 pub use lambda_runtime::{self, Context};
-use lambda_runtime::{Error, Handler as LambdaHandler};
+use lambda_runtime::{Error, LambdaRequest as RuntimeRequest, Service};
 
 mod body;
 pub mod ext;
@@ -164,13 +164,18 @@ impl<'a, H: Handler<'a>> Handler<'a> for Adapter<'a, H> {
     }
 }
 
-impl<'a, 'b, H: Handler<'a>> LambdaHandler<LambdaRequest<'b>, LambdaResponse> for Adapter<'a, H> {
+impl<'a, 'b, H: Handler<'a>> Service<RuntimeRequest<LambdaRequest<'b>>> for Adapter<'a, H> {
     type Error = H::Error;
-    type Fut = TransformResponse<'a, H::Response, Self::Error>;
+    type Response = LambdaResponse;
+    type Future = TransformResponse<'a, H::Response, Self::Error>;
 
-    fn call(&mut self, event: LambdaRequest<'_>, context: Context) -> Self::Fut {
-        let request_origin = event.request_origin();
-        let fut = Box::pin(self.handler.call(event.into(), context));
+    fn poll_ready(&mut self, _cx: &mut core::task::Context<'_>) -> core::task::Poll<Result<(), Self::Error>> {
+        core::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RuntimeRequest<LambdaRequest<'_>>) -> Self::Future {
+        let request_origin = req.event.request_origin();
+        let fut = Box::pin(self.handler.call(req.event.into(), req.context));
         TransformResponse { request_origin, fut }
     }
 }

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -25,7 +25,7 @@ async-stream = "0.3"
 futures = "0.3"
 tracing-error = "0.2"
 tracing = { version = "0.1", features = ["log"] }
-tower-service = "0.3"
+tower = { version = "0.4", features = ["util"] }
 tokio-stream = "0.1.2"
 
 [dev-dependencies]

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -107,9 +107,9 @@ impl Runtime {
 impl<C> Runtime<C>
 where
     C: Service<http::Uri> + Clone + Send + Sync + Unpin + 'static,
-    <C as Service<http::Uri>>::Future: Unpin + Send,
-    <C as Service<http::Uri>>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-    <C as Service<http::Uri>>::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+    C::Future: Unpin + Send,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    C::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
 {
     pub async fn run<F, A, B>(
         &self,
@@ -119,8 +119,8 @@ where
     ) -> Result<(), Error>
     where
         F: Service<LambdaRequest<A>>,
-        <F as Service<LambdaRequest<A>>>::Future: Future<Output = Result<B, <F as Service<LambdaRequest<A>>>::Error>>,
-        <F as Service<LambdaRequest<A>>>::Error: fmt::Display,
+        F::Future: Future<Output = Result<B, F::Error>>,
+        F::Error: fmt::Display,
         A: for<'de> Deserialize<'de>,
         B: Serialize,
     {
@@ -201,16 +201,16 @@ struct RuntimeBuilder<C: Service<http::Uri> = hyper::client::HttpConnector> {
 impl<C> RuntimeBuilder<C>
 where
     C: Service<http::Uri> + Clone + Send + Sync + Unpin + 'static,
-    <C as Service<http::Uri>>::Future: Unpin + Send,
-    <C as Service<http::Uri>>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-    <C as Service<http::Uri>>::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+    C::Future: Unpin + Send,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    C::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
 {
     pub fn with_connector<C2>(self, connector: C2) -> RuntimeBuilder<C2>
     where
         C2: Service<http::Uri> + Clone + Send + Sync + Unpin + 'static,
-        <C2 as Service<http::Uri>>::Future: Unpin + Send,
-        <C2 as Service<http::Uri>>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-        <C2 as Service<http::Uri>>::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+        C2::Future: Unpin + Send,
+        C2::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        C2::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
     {
         RuntimeBuilder {
             connector,
@@ -246,9 +246,9 @@ fn test_builder() {
 fn incoming<C>(client: &Client<C>) -> impl Stream<Item = Result<http::Response<hyper::Body>, Error>> + Send + '_
 where
     C: Service<http::Uri> + Clone + Send + Sync + Unpin + 'static,
-    <C as Service<http::Uri>>::Future: Unpin + Send,
-    <C as Service<http::Uri>>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-    <C as Service<http::Uri>>::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
+    C::Future: Unpin + Send,
+    C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    C::Response: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static,
 {
     async_stream::stream! {
         loop {
@@ -282,8 +282,8 @@ where
 pub async fn run<A, B, F>(handler: F) -> Result<(), Error>
 where
     F: Service<LambdaRequest<A>>,
-    <F as Service<LambdaRequest<A>>>::Future: Future<Output = Result<B, <F as Service<LambdaRequest<A>>>::Error>>,
-    <F as Service<LambdaRequest<A>>>::Error: fmt::Display,
+    F::Future: Future<Output = Result<B, F::Error>>,
+    F::Error: fmt::Display,
     A: for<'de> Deserialize<'de>,
     B: Serialize,
 {

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -148,6 +148,15 @@ impl TryFrom<HeaderMap> for Context {
     }
 }
 
+/// Incoming Lambda request containing the event payload and context.
+#[derive(Clone, Debug)]
+pub struct LambdaRequest<T> {
+    /// Event payload.
+    pub event: T,
+    /// Invocation context.
+    pub context: Context,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-rust-runtime/issues/374

*Description of changes:*

__This PR is meant to compare the current implementation with `Handler` with using `tower::Service` and should not be merged as-is. See the discussion in https://github.com/awslabs/aws-lambda-rust-runtime/issues/374 for more information.__

List of changes:

* Removes `Handler` and `HandlerFn`.
* Makes `handler_fn`  return a `ServiceFn` instead.
* Adds a new `LambdaRequest` type to wrap request and context in a single struct.
* Changes `run` signature to take a `Service<LambdaRequest<A>>` instead.

__BREAKING CHANGE__: this removes the `Handler` trait, which could be used by existing libraries. However, developers that are using `lambda_runtime::run` and `lambda_runtime::handler_fn` should not be impacted. The closure taken by `HandlerFn` remains the same, so developers can keep using function with separate event and context parameters.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
