### PR TITLE
feat: add integration tests stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 /.cargo
 lambda-runtime/libtest.rmeta
+lambda-integration-tests/target
 Cargo.lock
 
 # Built AWS Lambda zipfile
@@ -8,3 +9,6 @@ lambda.zip
 
 # output.json from example docs
 output.json
+
+.aws-sam
+build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "lambda-http",
+    "lambda-integration-tests",
     "lambda-runtime-api-client",
     "lambda-runtime",
     "lambda-extension"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+INTEG_STACK_NAME ?= rust-lambda-integration-tests
+INTEG_FUNCTIONS_BUILD := runtime-fn runtime-trait
+INTEG_FUNCTIONS_INVOKE := RuntimeFn RuntimeFnAl2 RuntimeTrait RuntimeTraitAl2 Python PythonAl2
+INTEG_EXTENSIONS := extension-fn extension-trait
+# Using musl to run extensions on both AL1 and AL2
+INTEG_ARCH := x86_64-unknown-linux-musl
+
+integration-tests:
+# Build Integration functions
+	cross build --release --target $(INTEG_ARCH) -p lambda_integration_tests
+	rm -rf ./build
+	mkdir -p ./build
+	${MAKE} ${MAKEOPTS} $(foreach function,${INTEG_FUNCTIONS_BUILD}, build-integration-function-${function})
+	${MAKE} ${MAKEOPTS} $(foreach extension,${INTEG_EXTENSIONS}, build-integration-extension-${extension})
+# Deploy to AWS
+	sam deploy \
+		--template lambda-integration-tests/template.yaml \
+		--stack-name ${INTEG_STACK_NAME} \
+		--capabilities CAPABILITY_IAM \
+		--resolve-s3 \
+		--no-fail-on-empty-changeset
+# Invoke functions
+	${MAKE} ${MAKEOPTS} $(foreach function,${INTEG_FUNCTIONS_INVOKE}, invoke-integration-function-${function})
+
+build-integration-function-%:
+	mkdir -p ./build/$*
+	cp -v ./target/$(INTEG_ARCH)/release/$* ./build/$*/bootstrap
+
+build-integration-extension-%:
+	mkdir -p ./build/$*/extensions
+	cp -v ./target/$(INTEG_ARCH)/release/$* ./build/$*/extensions/$*
+
+invoke-integration-function-%:
+	aws lambda invoke --function-name $$(aws cloudformation describe-stacks --stack-name $(INTEG_STACK_NAME) \
+		--query 'Stacks[0].Outputs[?OutputKey==`$*`].OutputValue' \
+		--output text) --payload '{"command": "hello"}' --cli-binary-format raw-in-base64-out /dev/stdout

--- a/lambda-extension/src/lib.rs
+++ b/lambda-extension/src/lib.rs
@@ -8,8 +8,7 @@
 use hyper::client::{connect::Connection, HttpConnector};
 use lambda_runtime_api_client::Client;
 use serde::Deserialize;
-use std::future::Future;
-use std::path::PathBuf;
+use std::{future::Future, path::PathBuf};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_stream::StreamExt;
 use tower_service::Service;

--- a/lambda-extension/src/lib.rs
+++ b/lambda-extension/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all, clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
 #![warn(missing_docs, nonstandard_style, rust_2018_idioms)]
 
 //! This module includes utilities to create Lambda Runtime Extensions.

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lambda_integration_tests"
+version = "0.4.1"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+lambda_http = { path = "../lambda-http", version = "0.4.1" }
+lambda_runtime = { path = "../lambda-runtime", version = "0.4.1" }
+lambda_extension = { path = "../lambda-extension", version = "0.1.0" }
+log = "0.4"
+serde = { version = "1", features = ["derive"] }
+simple_logger = { version = "1.15", default-features = false }
+tokio = { version = "1", features = ["full"] }

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "lambda_integration_tests"
 version = "0.4.1"
-edition = "2021"
+edition = "2018"
+description = "AWS Lambda Runtime integration tests"
+license = "Apache-2.0"
+repository = "https://github.com/awslabs/aws-lambda-rust-runtime"
+categories = ["web-programming::http-server"]
+keywords = ["AWS", "Lambda", "API"]
+readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lambda-integration-tests/python/main.py
+++ b/lambda-integration-tests/python/main.py
@@ -1,0 +1,4 @@
+def handler(event, context):
+    return {
+        "message": event["command"].upper()
+    }

--- a/lambda-integration-tests/src/bin/extension-fn.rs
+++ b/lambda-integration-tests/src/bin/extension-fn.rs
@@ -1,0 +1,23 @@
+use lambda_extension::{extension_fn, Error, NextEvent};
+use log::{info, LevelFilter};
+use simple_logger::SimpleLogger;
+
+async fn my_extension(event: NextEvent) -> Result<(), Error> {
+    match event {
+        NextEvent::Shutdown(e) => {
+            info!("[extension-fn] Shutdown event received: {:?}", e);
+        },
+        NextEvent::Invoke(e) => {
+            info!("[extension-fn] Request event received: {:?}", e);
+        },
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+
+    lambda_extension::run(extension_fn(my_extension)).await
+}

--- a/lambda-integration-tests/src/bin/extension-fn.rs
+++ b/lambda-integration-tests/src/bin/extension-fn.rs
@@ -6,10 +6,10 @@ async fn my_extension(event: NextEvent) -> Result<(), Error> {
     match event {
         NextEvent::Shutdown(e) => {
             info!("[extension-fn] Shutdown event received: {:?}", e);
-        },
+        }
         NextEvent::Invoke(e) => {
             info!("[extension-fn] Request event received: {:?}", e);
-        },
+        }
     }
 
     Ok(())

--- a/lambda-integration-tests/src/bin/extension-trait.rs
+++ b/lambda-integration-tests/src/bin/extension-trait.rs
@@ -6,14 +6,9 @@ use std::{
     pin::Pin,
 };
 
+#[derive(Default)]
 struct MyExtension {
     invoke_count: usize,
-}
-
-impl Default for MyExtension {
-    fn default() -> Self {
-        Self { invoke_count: 0 }
-    }
 }
 
 impl Extension for MyExtension {

--- a/lambda-integration-tests/src/bin/extension-trait.rs
+++ b/lambda-integration-tests/src/bin/extension-trait.rs
@@ -1,0 +1,42 @@
+use lambda_extension::{Extension, Error, NextEvent};
+use log::{info, LevelFilter};
+use simple_logger::SimpleLogger;
+use std::{
+    future::{ready, Future},
+    pin::Pin,
+};
+
+struct MyExtension {
+    invoke_count: usize,
+}
+
+impl Default for MyExtension {
+    fn default() -> Self {
+        Self { invoke_count: 0 }
+    }
+}
+
+impl Extension for MyExtension {
+    type Fut = Pin<Box<dyn Future<Output = Result<(), Error>>>>;
+
+    fn call(&mut self, event: NextEvent) -> Self::Fut {
+        match event {
+            NextEvent::Shutdown(e) => {
+                info!("[extension] Shutdown event received: {:?}", e);
+            },
+            NextEvent::Invoke(e) => {
+                self.invoke_count += 1;
+                info!("[extension] Request event {} received: {:?}", self.invoke_count, e);
+            },
+        }
+
+        Box::pin(ready(Ok(())))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+
+    lambda_extension::run(MyExtension::default()).await
+}

--- a/lambda-integration-tests/src/bin/extension-trait.rs
+++ b/lambda-integration-tests/src/bin/extension-trait.rs
@@ -1,4 +1,4 @@
-use lambda_extension::{Extension, Error, NextEvent};
+use lambda_extension::{Error, Extension, NextEvent};
 use log::{info, LevelFilter};
 use simple_logger::SimpleLogger;
 use std::{
@@ -23,11 +23,11 @@ impl Extension for MyExtension {
         match event {
             NextEvent::Shutdown(e) => {
                 info!("[extension] Shutdown event received: {:?}", e);
-            },
+            }
             NextEvent::Invoke(e) => {
                 self.invoke_count += 1;
                 info!("[extension] Request event {} received: {:?}", self.invoke_count, e);
-            },
+            }
         }
 
         Box::pin(ready(Ok(())))

--- a/lambda-integration-tests/src/bin/http-fn.rs
+++ b/lambda-integration-tests/src/bin/http-fn.rs
@@ -1,0 +1,19 @@
+use lambda_http::{
+    lambda_runtime::{self, Context, Error},
+    IntoResponse, Request, Response,
+};
+use log::{info, LevelFilter};
+use simple_logger::SimpleLogger;
+
+async fn handler(event: Request, _context: Context) -> Result<impl IntoResponse, Error> {
+    info!("[http-fn] Received event {} {}", event.method(), event.uri().path());
+
+    Ok(Response::builder().status(200).body("Hello, world!").unwrap())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+
+    lambda_runtime::run(lambda_http::handler(handler)).await
+}

--- a/lambda-integration-tests/src/bin/runtime-fn.rs
+++ b/lambda-integration-tests/src/bin/runtime-fn.rs
@@ -1,0 +1,29 @@
+use lambda_runtime::{handler_fn, Context, Error};
+use log::{info, LevelFilter};
+use serde::{Serialize, Deserialize};
+use simple_logger::SimpleLogger;
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    command: String,
+}
+
+#[derive(Serialize, Debug)]
+struct Response {
+    message: String,
+}
+
+async fn handler(event: Request, _context: Context) -> Result<Response, Error> {
+    info!("[handler-fn] Received event: {:?}", event);
+
+    Ok(Response {
+        message: event.command.to_uppercase(),
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+
+    lambda_runtime::run(handler_fn(handler)).await
+}

--- a/lambda-integration-tests/src/bin/runtime-fn.rs
+++ b/lambda-integration-tests/src/bin/runtime-fn.rs
@@ -1,6 +1,6 @@
 use lambda_runtime::{handler_fn, Context, Error};
 use log::{info, LevelFilter};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use simple_logger::SimpleLogger;
 
 #[derive(Deserialize, Debug)]

--- a/lambda-integration-tests/src/bin/runtime-trait.rs
+++ b/lambda-integration-tests/src/bin/runtime-trait.rs
@@ -17,14 +17,9 @@ struct Response {
     message: String,
 }
 
+#[derive(Default)]
 struct MyHandler {
     invoke_count: usize,
-}
-
-impl Default for MyHandler {
-    fn default() -> Self {
-        Self { invoke_count: 0 }
-    }
 }
 
 impl Handler<Request, Response> for MyHandler {

--- a/lambda-integration-tests/src/bin/runtime-trait.rs
+++ b/lambda-integration-tests/src/bin/runtime-trait.rs
@@ -1,6 +1,6 @@
-use lambda_runtime::{Context, Handler, Error};
+use lambda_runtime::{Context, Error, Handler};
 use log::{info, LevelFilter};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use simple_logger::SimpleLogger;
 use std::{
     future::{ready, Future},
@@ -34,11 +34,9 @@ impl Handler<Request, Response> for MyHandler {
     fn call(&mut self, event: Request, _context: Context) -> Self::Fut {
         self.invoke_count += 1;
         info!("[handler] Received event {}: {:?}", self.invoke_count, event);
-        Box::pin(ready(
-            Ok(Response {
-                message: event.command.to_uppercase(),
-            }))
-        )
+        Box::pin(ready(Ok(Response {
+            message: event.command.to_uppercase(),
+        })))
     }
 }
 

--- a/lambda-integration-tests/src/bin/runtime-trait.rs
+++ b/lambda-integration-tests/src/bin/runtime-trait.rs
@@ -1,0 +1,50 @@
+use lambda_runtime::{Context, Handler, Error};
+use log::{info, LevelFilter};
+use serde::{Serialize, Deserialize};
+use simple_logger::SimpleLogger;
+use std::{
+    future::{ready, Future},
+    pin::Pin,
+};
+
+#[derive(Deserialize, Debug)]
+struct Request {
+    command: String,
+}
+
+#[derive(Serialize, Debug)]
+struct Response {
+    message: String,
+}
+
+struct MyHandler {
+    invoke_count: usize,
+}
+
+impl Default for MyHandler {
+    fn default() -> Self {
+        Self { invoke_count: 0 }
+    }
+}
+
+impl Handler<Request, Response> for MyHandler {
+    type Error = Error;
+    type Fut = Pin<Box<dyn Future<Output = Result<Response, Error>>>>;
+
+    fn call(&mut self, event: Request, _context: Context) -> Self::Fut {
+        self.invoke_count += 1;
+        info!("[handler] Received event {}: {:?}", self.invoke_count, event);
+        Box::pin(ready(
+            Ok(Response {
+                message: event.command.to_uppercase(),
+            }))
+        )
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+
+    lambda_runtime::run(MyHandler::default()).await
+}

--- a/lambda-integration-tests/template.yaml
+++ b/lambda-integration-tests/template.yaml
@@ -48,6 +48,68 @@ Resources:
         - !Ref ExtensionFn
         - !Ref ExtensionTrait
   
+  # Rust function using lambda_http::runtime running on AL2
+  HttpFnAl2:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/http-fn/
+      Runtime: provided.al2
+      Events:
+        ApiGet:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /al2/get
+        ApiPost:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /al2/post
+        ApiV2Get:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /al2/get
+        ApiV2Post:
+          Type: HttpApi
+          Properties:
+            Method: POST
+            Path: /al2/post
+      Layers:
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
+  # Rust function using lambda_http::runtime running on AL1
+  HttpFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/http-fn/
+      Runtime: provided
+      Events:
+        ApiGet:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /get
+        ApiPost:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /post
+        ApiV2Get:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /get
+        ApiV2Post:
+          Type: HttpApi
+          Properties:
+            Method: POST
+            Path: /post
+      Layers:
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
   # Python function running on AL2
   PythonAl2:
     Type: AWS::Serverless::Function
@@ -93,3 +155,8 @@ Outputs:
     Value: !GetAtt PythonAl2.Arn
   Python:
     Value: !GetAtt Python.Arn
+
+  RestApiUrl:
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"
+  HttpApiUrl:
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com"

--- a/lambda-integration-tests/template.yaml
+++ b/lambda-integration-tests/template.yaml
@@ -1,0 +1,95 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    MemorySize: 128
+    Handler: bootstrap
+    Timeout: 5
+
+Resources:
+  # Rust function using runtime_fn running on AL2
+  RuntimeFnAl2:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/runtime-fn/
+      Runtime: provided.al2
+      Layers:
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+  
+  # Rust function using runtime_fn running on AL1
+  RuntimeFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/runtime-fn/
+      Runtime: provided
+      Layers:
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
+  # Rust function using a Handler implementation running on AL2
+  RuntimeTraitAl2:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/runtime-trait/
+      Runtime: provided.al2
+      Layers:
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+  
+  # Rust function using a Handler implementation running on AL1
+  RuntimeTrait:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/runtime-trait/
+      Runtime: provided
+      Layers:
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+  
+  # Python function running on AL2
+  PythonAl2:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./python/
+      Handler: main.handler
+      Runtime: python3.9
+      Layers:
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
+  # Python function running on AL1
+  Python:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./python/
+      Handler: main.handler
+      Runtime: python3.7
+      Layers:
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
+  ExtensionFn:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      ContentUri: ../build/extension-fn/
+  
+  ExtensionTrait:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      ContentUri: ../build/extension-trait/
+
+Outputs:
+  RuntimeFnAl2:
+    Value: !GetAtt RuntimeFnAl2.Arn
+  RuntimeFn:
+    Value: !GetAtt RuntimeFn.Arn
+  RuntimeTraitAl2:
+    Value: !GetAtt RuntimeTraitAl2.Arn
+  RuntimeTrait:
+    Value: !GetAtt RuntimeTrait.Arn
+  PythonAl2:
+    Value: !GetAtt PythonAl2.Arn
+  Python:
+    Value: !GetAtt Python.Arn

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all, clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
 #![warn(missing_docs, nonstandard_style, rust_2018_idioms)]
 
 //! The mechanism available for defining a Lambda function is as follows:


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-rust-runtime/issues/377

*Description of changes:*

Adds a SAM template and AWS Lambda functions to test the crates in this repository on AWS. This allows us to test Rust functions and extensions on both AL1 and AL2. Furthermore, I've included a sample Lambda function in Python so we can test extensions on non-provided runtimes as well.

I'm not a big fan of defining a new crate for those tests, but I don't see a better way to do it at the moment.

* [x] lambda_runtime with handler_fn
* [x] lambda_runtime with Handler trait
* [x] lambda_http with handler
* [x] lambda_extension with extension_fn
* [x] lambda_extension with Extension trait

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
