### PR TITLE
chore: stable fmt and clippy, set MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         rust:
+          - "1.54.0" # Current MSRV
           - stable
           - beta
           - nightly
@@ -21,24 +22,24 @@ jobs:
         include:
           - rust: nightly
             allow_failure: true
-        exclude:
-          - os: macOS-latest
-            target: x86_64-unknown-linux-musl
-          - os: ubuntu-latest
-            rust: 1.40.0
-            target: x86_64-unknown-linux-musl
-          - os: ubuntu-latest
-            rust: beta
-            target: x86_64-unknown-linux-musl
-          - os: ubuntu-latest
-            rust: nightly
-            target: x86_64-unknown-linux-musl
-          - os: macOS-latest
-            rust: 1.40.0
-          - os: macOS-latest
-            rust: beta
-          - os: macOS-latest
-            rust: nightly
+        # exclude:
+        #   - os: macOS-latest
+        #     target: x86_64-unknown-linux-musl
+        #   - os: ubuntu-latest
+        #     rust: 1.40.0
+        #     target: x86_64-unknown-linux-musl
+        #   - os: ubuntu-latest
+        #     rust: beta
+        #     target: x86_64-unknown-linux-musl
+        #   - os: ubuntu-latest
+        #     rust: nightly
+        #     target: x86_64-unknown-linux-musl
+        #   - os: macOS-latest
+        #     rust: 1.40.0
+        #   - os: macOS-latest
+        #     rust: beta
+        #   - os: macOS-latest
+        #     rust: nightly
     env:
       RUST_BACKTRACE: 1
     steps:
@@ -63,7 +64,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: rustfmt
           override: true
       - name: Run fmt check
@@ -74,7 +75,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           components: clippy
           override: true
       - name: Run clippy check

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,6 @@
 edition = "2018"
-# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports
-merge_imports = true
+# imports_granularity is unstable
+# # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports
+# imports_granularity = "Crate"
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#max_width
 max_width = 120

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ INTEG_EXTENSIONS := extension-fn extension-trait
 # Using musl to run extensions on both AL1 and AL2
 INTEG_ARCH := x86_64-unknown-linux-musl
 
+pr-check:
+	cargo +1.54.0 check --all
+	cargo +stable fmt --all -- --check
+	cargo +stable clippy
+
 integration-tests:
 # Build Integration functions
 	cross build --release --target $(INTEG_ARCH) -p lambda_integration_tests

--- a/README.md
+++ b/README.md
@@ -259,3 +259,15 @@ fn main() -> Result<(), Box<Error>> {
     Ok(())
 }
 ```
+
+## Supported Rust Versions (MSRV)
+
+The AWS Lambda Rust Runtime requires a minimum of Rust 1.54, and is not guaranteed to build on compiler versions earlier than that.
+
+## Security
+
+See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This project is licensed under the Apache-2.0 License.

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lambda_extension"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 authors = ["David Calavera <david.calavera@gmail.com>"]
 description = "AWS Lambda Extension API"
 license = "Apache-2.0"

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -103,7 +103,7 @@ pub trait Handler<'a>: Sized {
 pub fn handler<'a, H: Handler<'a>>(handler: H) -> Adapter<'a, H> {
     Adapter {
         handler,
-        _pd: PhantomData,
+        _phantom_data: PhantomData,
     }
 }
 
@@ -152,7 +152,7 @@ where
 /// for a larger explanation of why this is necessary
 pub struct Adapter<'a, H: Handler<'a>> {
     handler: H,
-    _pd: PhantomData<&'a H>,
+    _phantom_data: PhantomData<&'a H>,
 }
 
 impl<'a, H: Handler<'a>> Handler<'a> for Adapter<'a, H> {

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lambda_runtime_api_client"
 version = "0.4.1"
-edition = "2021"
+edition = "2018"
 authors = ["David Calavera <david.calavera@gmail.com>"]
 description = "AWS Lambda Runtime interaction API"
 license = "Apache-2.0"

--- a/lambda-runtime-api-client/src/lib.rs
+++ b/lambda-runtime-api-client/src/lib.rs
@@ -8,7 +8,7 @@ use hyper::{
     client::{connect::Connection, HttpConnector},
     Body,
 };
-use std::fmt::Debug;
+use std::{convert::TryInto, fmt::Debug};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-rust-runtime/issues/380

*Description of changes:*

* Set MSRV to 1.54.0
* GitHub actions: Use stable for fmt and clippy
* GitHub actions: add build for MSRV
* GitHub actions: remove exclusions (will re-add them if any fail)
* Change PhantomData abbreviation (that abbreviation has another meaning in French)
* Add MSRV, security disclosure, and license to README file.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
