### PR TITLE
lambda-extension: remove logging

### DIFF
--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -24,6 +24,4 @@ tokio-stream = "0.1.2"
 lambda_runtime_api_client = { version = "0.4", path = "../lambda-runtime-api-client" }
 
 [dev-dependencies]
-simple_logger = "1.6.0"
-log = "^0.4"
 simple-error = "0.2"

--- a/lambda-extension/README.md
+++ b/lambda-extension/README.md
@@ -10,17 +10,14 @@ The code below creates a simple extension that's registered to every `INVOKE` an
 
 ```rust,no_run
 use lambda_extension::{extension_fn, Error, NextEvent};
-use log::LevelFilter;
-use simple_logger::SimpleLogger;
-use tracing::info;
 
 async fn log_extension(event: NextEvent) -> Result<(), Error> {
     match event {
         NextEvent::Shutdown(event) => {
-            info!("{}", event);
+            println!("Shutdown {:?}", event);
         }
         NextEvent::Invoke(event) => {
-            info!("{}", event);
+            println!("Invoke {:?}", event);
         }
     }
     Ok(())
@@ -28,8 +25,6 @@ async fn log_extension(event: NextEvent) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
-
     let func = extension_fn(log_extension);
     lambda_extension::run(func).await
 }

--- a/lambda-extension/examples/basic.rs
+++ b/lambda-extension/examples/basic.rs
@@ -1,6 +1,4 @@
 use lambda_extension::{extension_fn, Error, NextEvent};
-use log::LevelFilter;
-use simple_logger::SimpleLogger;
 
 async fn my_extension(event: NextEvent) -> Result<(), Error> {
     match event {
@@ -16,10 +14,6 @@ async fn my_extension(event: NextEvent) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // required to enable CloudWatch error logging by the runtime
-    // can be replaced with any other method of initializing `log`
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
-
     let func = extension_fn(my_extension);
     lambda_extension::run(func).await
 }

--- a/lambda-extension/examples/custom_events.rs
+++ b/lambda-extension/examples/custom_events.rs
@@ -1,6 +1,4 @@
 use lambda_extension::{extension_fn, Error, NextEvent, Runtime};
-use log::LevelFilter;
-use simple_logger::SimpleLogger;
 
 async fn my_extension(event: NextEvent) -> Result<(), Error> {
     match event {
@@ -18,10 +16,6 @@ async fn my_extension(event: NextEvent) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // required to enable CloudWatch error logging by the runtime
-    // can be replaced with any other method of initializing `log`
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
-
     let func = extension_fn(my_extension);
 
     let runtime = Runtime::builder().with_events(&["SHUTDOWN"]).register().await?;

--- a/lambda-extension/examples/custom_trait_implementation.rs
+++ b/lambda-extension/examples/custom_trait_implementation.rs
@@ -1,6 +1,4 @@
 use lambda_extension::{run, Error, Extension, InvokeEvent, NextEvent};
-use log::LevelFilter;
-use simple_logger::SimpleLogger;
 use std::{
     future::{ready, Future},
     pin::Pin,
@@ -28,9 +26,5 @@ impl Extension for MyExtension {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // required to enable CloudWatch error logging by the runtime
-    // can be replaced with any other method of initializing `log`
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
-
     run(MyExtension::default()).await
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When running on AWS lambda I encountered the following error:


> thread 'main' panicked at 'Could not determine the UTC offset on this
> system. Possible causes are that the time crate does not implement
> "local_offset_at" on your system, or that you are running in a
> multi-threaded environment and the time crate is returning "None" from
> "local_offset_at" to avoid unsafe behaviour. See the time crate's
> documentation for more information.
> (https://time-rs.github.io/internal-api/time/index.html#feature-flags):
> IndeterminateOffset',
> /home/simon/.cargo/registry/src/github.com-1ecc6299db9ec823/simple_logger-1.16.0/src/lib.rs:409:85

This means that the simple logger setup could not find the current time.
Instead, we can print to stdout which is also collected by CloudWatch.
We can leave more sophisticated control of the output to the user.



By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
