### PR TITLE
`README.md`: invoke lambda function with `raw-in-base64-out`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ $ aws lambda create-function --function-name rustTest \
 You can now test the function using the AWS CLI or the AWS Lambda console
 
 ```bash
-$ aws lambda invoke --function-name rustTest \
+$ aws lambda invoke
+  --cli-binary-format raw-in-base64-out \
+  --function-name rustTest \
   --payload '{"command": "Say Hi!"}' \
   output.json
 $ cat output.json  # Prints: {"msg": "Command Say Hi! executed."}


### PR DESCRIPTION
In AWS CLI v2, you need to set `cli-binary-format` to
`raw-in-base64-out` to send binary values as literals. You otherwise
need to pass base64-encoded data.

See https://docs.aws.amazon.com/sdkref/latest/guide/setting-global-cli_binary_format.html.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
