### PR TITLE
fix: add support for null/invalid type for multi-value-headers

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -317,7 +317,7 @@ where
         }
     }
 
-    deserializer.deserialize_map(HeaderVisitor)
+    Ok(deserializer.deserialize_map(HeaderVisitor).unwrap_or_default())
 }
 
 /// Deserialize a map of Cow<'_, str> => Cow<'_, str> into an http::HeaderMap
@@ -865,6 +865,22 @@ mod tests {
             serde_json::from_str::<Test>(r#"{"headers":null}"#).expect("failed to deserialize"),
             Test {
                 headers: http::HeaderMap::new()
+            }
+        )
+    }
+
+    #[test]
+    fn deserialize_null_multi_value_headers() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Test {
+            #[serde(deserialize_with = "deserialize_multi_value_headers")]
+            multi_value_headers: http::HeaderMap,
+        }
+
+        assert_eq!(
+            serde_json::from_str::<Test>(r#"{"multi_value_headers":null}"#).expect("failed to deserialize"),
+            Test {
+                multi_value_headers: http::HeaderMap::new()
             }
         )
     }


### PR DESCRIPTION
*Issue #, if available: 367*

*Description of changes:*

This adds support for invalid/null value for multi-value headers, defaulting to an empty `HeaderMap` if need be, increasing resilience if the Lambda function would get an invalid value for multi-value headers.

This is a continuation of the work done by @nmoutschen in #371.

I have also successfully run the test in https://github.com/awslabs/aws-lambda-rust-runtime/issues/367#issuecomment-998753570 locally.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
