### PR TITLE
fix: move clippy::cargo lint to warn level

### DIFF
--- a/lambda-runtime-api-client/src/lib.rs
+++ b/lambda-runtime-api-client/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all, clippy::cargo)]
 #![warn(missing_docs, nonstandard_style, rust_2018_idioms)]
+#![warn(clippy::multiple_crate_versions)]
 
 //! This crate includes a base HTTP client to interact with
 //! the AWS Lambda Runtime API.


### PR DESCRIPTION
 fix: Allow multiple versions of crates

Downstream dependencies may have different versions of crates, and
this could change at any time. Disable this lint so that clippy
builds are not at the mercy of donwstream dependencies.


By submitting this pull request

- [x ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x ] I confirm that I've made a best effort attempt to update all relevant documentation.
