### PR TITLE
Change examples to use tracing-subscriber for logging

### DIFF
--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -24,6 +24,5 @@ tokio-stream = "0.1.2"
 lambda_runtime_api_client = { version = "0.4", path = "../lambda-runtime-api-client" }
 
 [dev-dependencies]
-simple_logger = "1.6.0"
-log = "^0.4"
 simple-error = "0.2"
+tracing-subscriber = "0.3"

--- a/lambda-extension/examples/basic.rs
+++ b/lambda-extension/examples/basic.rs
@@ -1,6 +1,4 @@
 use lambda_extension::{extension_fn, Error, NextEvent};
-use log::LevelFilter;
-use simple_logger::SimpleLogger;
 
 async fn my_extension(event: NextEvent) -> Result<(), Error> {
     match event {
@@ -16,9 +14,16 @@ async fn my_extension(event: NextEvent) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // required to enable CloudWatch error logging by the runtime
-    // can be replaced with any other method of initializing `log`
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
+    // While `tracing` is used internally, `log` can be used as well if preferred.
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     let func = extension_fn(my_extension);
     lambda_extension::run(func).await

--- a/lambda-extension/examples/custom_events.rs
+++ b/lambda-extension/examples/custom_events.rs
@@ -1,6 +1,4 @@
 use lambda_extension::{extension_fn, Error, NextEvent, Runtime};
-use log::LevelFilter;
-use simple_logger::SimpleLogger;
 
 async fn my_extension(event: NextEvent) -> Result<(), Error> {
     match event {
@@ -18,9 +16,16 @@ async fn my_extension(event: NextEvent) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // required to enable CloudWatch error logging by the runtime
-    // can be replaced with any other method of initializing `log`
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
+    // While `tracing` is used internally, `log` can be used as well if preferred.
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     let func = extension_fn(my_extension);
 

--- a/lambda-extension/examples/custom_trait_implementation.rs
+++ b/lambda-extension/examples/custom_trait_implementation.rs
@@ -1,6 +1,4 @@
 use lambda_extension::{run, Error, Extension, InvokeEvent, NextEvent};
-use log::LevelFilter;
-use simple_logger::SimpleLogger;
 use std::{
     future::{ready, Future},
     pin::Pin,
@@ -28,9 +26,16 @@ impl Extension for MyExtension {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // required to enable CloudWatch error logging by the runtime
-    // can be replaced with any other method of initializing `log`
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
+    // While `tracing` is used internally, `log` can be used as well if preferred.
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     run(MyExtension::default()).await
 }

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 lambda_http = { path = "../lambda-http", version = "0.4.1" }
 lambda_runtime = { path = "../lambda-runtime", version = "0.4.1" }
 lambda_extension = { path = "../lambda-extension", version = "0.1.0" }
-log = "0.4"
 serde = { version = "1", features = ["derive"] }
-simple_logger = { version = "1.15", default-features = false }
 tokio = { version = "1", features = ["full"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = "0.3"

--- a/lambda-integration-tests/src/bin/extension-fn.rs
+++ b/lambda-integration-tests/src/bin/extension-fn.rs
@@ -1,6 +1,5 @@
 use lambda_extension::{extension_fn, Error, NextEvent};
-use log::{info, LevelFilter};
-use simple_logger::SimpleLogger;
+use tracing::info;
 
 async fn my_extension(event: NextEvent) -> Result<(), Error> {
     match event {
@@ -17,7 +16,16 @@ async fn my_extension(event: NextEvent) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
+    // While `tracing` is used internally, `log` can be used as well if preferred.
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     lambda_extension::run(extension_fn(my_extension)).await
 }

--- a/lambda-integration-tests/src/bin/extension-trait.rs
+++ b/lambda-integration-tests/src/bin/extension-trait.rs
@@ -1,10 +1,9 @@
 use lambda_extension::{Error, Extension, NextEvent};
-use log::{info, LevelFilter};
-use simple_logger::SimpleLogger;
 use std::{
     future::{ready, Future},
     pin::Pin,
 };
+use tracing::info;
 
 #[derive(Default)]
 struct MyExtension {
@@ -31,7 +30,16 @@ impl Extension for MyExtension {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
+    // While `tracing` is used internally, `log` can be used as well if preferred.
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     lambda_extension::run(MyExtension::default()).await
 }

--- a/lambda-integration-tests/src/bin/http-fn.rs
+++ b/lambda-integration-tests/src/bin/http-fn.rs
@@ -2,8 +2,7 @@ use lambda_http::{
     lambda_runtime::{self, Context, Error},
     IntoResponse, Request, Response,
 };
-use log::{info, LevelFilter};
-use simple_logger::SimpleLogger;
+use tracing::info;
 
 async fn handler(event: Request, _context: Context) -> Result<impl IntoResponse, Error> {
     info!("[http-fn] Received event {} {}", event.method(), event.uri().path());
@@ -13,7 +12,16 @@ async fn handler(event: Request, _context: Context) -> Result<impl IntoResponse,
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
+    // While `tracing` is used internally, `log` can be used as well if preferred.
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     lambda_runtime::run(lambda_http::handler(handler)).await
 }

--- a/lambda-integration-tests/src/bin/runtime-fn.rs
+++ b/lambda-integration-tests/src/bin/runtime-fn.rs
@@ -1,7 +1,6 @@
 use lambda_runtime::{handler_fn, Context, Error};
-use log::{info, LevelFilter};
 use serde::{Deserialize, Serialize};
-use simple_logger::SimpleLogger;
+use tracing::info;
 
 #[derive(Deserialize, Debug)]
 struct Request {
@@ -23,7 +22,16 @@ async fn handler(event: Request, _context: Context) -> Result<Response, Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
+    // While `tracing` is used internally, `log` can be used as well if preferred.
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     lambda_runtime::run(handler_fn(handler)).await
 }

--- a/lambda-integration-tests/src/bin/runtime-trait.rs
+++ b/lambda-integration-tests/src/bin/runtime-trait.rs
@@ -1,11 +1,10 @@
 use lambda_runtime::{Context, Error, Handler};
-use log::{info, LevelFilter};
 use serde::{Deserialize, Serialize};
-use simple_logger::SimpleLogger;
 use std::{
     future::{ready, Future},
     pin::Pin,
 };
+use tracing::info;
 
 #[derive(Deserialize, Debug)]
 struct Request {
@@ -37,7 +36,14 @@ impl Handler<Request, Response> for MyHandler {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     lambda_runtime::run(MyHandler::default()).await
 }

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -28,6 +28,5 @@ tokio-stream = "0.1.2"
 lambda_runtime_api_client = { version = "0.4", path = "../lambda-runtime-api-client" }
 
 [dev-dependencies]
-simple_logger = "1.6.0"
-log = "^0.4"
+tracing-subscriber = "0.3"
 simple-error = "0.2"

--- a/lambda-runtime/examples/basic.rs
+++ b/lambda-runtime/examples/basic.rs
@@ -2,9 +2,7 @@
 // { "command": "do something" }
 
 use lambda_runtime::{handler_fn, Context, Error};
-use log::LevelFilter;
 use serde::{Deserialize, Serialize};
-use simple_logger::SimpleLogger;
 
 /// This is also a made-up example. Requests come into the runtime as unicode
 /// strings in json format, which can map to any structure that implements `serde::Deserialize`
@@ -26,9 +24,14 @@ struct Response {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // required to enable CloudWatch error logging by the runtime
-    // can be replaced with any other method of initializing `log`
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     let func = handler_fn(my_handler);
     lambda_runtime::run(func).await?;

--- a/lambda-runtime/examples/error-handling.rs
+++ b/lambda-runtime/examples/error-handling.rs
@@ -1,9 +1,7 @@
 /// See https://github.com/awslabs/aws-lambda-rust-runtime for more info on Rust runtime for AWS Lambda
 use lambda_runtime::{handler_fn, Error};
-use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use simple_logger::SimpleLogger;
 use std::fs::File;
 
 /// A simple Lambda request structure with just one field
@@ -51,13 +49,8 @@ impl std::fmt::Display for CustomError {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `log` with `simple_logger`
-    // or another compatible crate. The runtime is using `tracing` internally.
-    // You can comment out the `simple_logger` init line and uncomment the following block to
-    // use `tracing` in the handler function.
-    //
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
-    /*
+    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
+    // While `tracing` is used internally, `log` can be used as well if preferred.
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         // this needs to be set to false, otherwise ANSI color codes will
@@ -66,7 +59,6 @@ async fn main() -> Result<(), Error> {
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();
-    */
 
     // call the actual handler of the request
     let func = handler_fn(func);

--- a/lambda-runtime/examples/shared_resource.rs
+++ b/lambda-runtime/examples/shared_resource.rs
@@ -5,9 +5,7 @@
 // { "command": "do something" }
 
 use lambda_runtime::{handler_fn, Context, Error};
-use log::LevelFilter;
 use serde::{Deserialize, Serialize};
-use simple_logger::SimpleLogger;
 
 /// This is also a made-up example. Requests come into the runtime as unicode
 /// strings in json format, which can map to any structure that implements `serde::Deserialize`
@@ -47,8 +45,14 @@ impl SharedClient {
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // required to enable CloudWatch error logging by the runtime
-    // can be replaced with any other method of initializing `log`
-    SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     let client = SharedClient::new("Shared Client 1 (perhaps a database)");
     let client_ref = &client;


### PR DESCRIPTION


*Description of changes:*
Update examples to use `tracing-subscriber` to be more in line with with usage inside library.

By submitting this pull request

- [x ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ x] I confirm that I've made a best effort attempt to update all relevant documentation.
