### PR TITLE
Wrap incoming extension events in a struct

### DIFF
--- a/lambda-extension/examples/basic.rs
+++ b/lambda-extension/examples/basic.rs
@@ -1,7 +1,7 @@
-use lambda_extension::{extension_fn, Error, NextEvent};
+use lambda_extension::{extension_fn, Error, LambdaEvent, NextEvent};
 
-async fn my_extension(event: NextEvent) -> Result<(), Error> {
-    match event {
+async fn my_extension(event: LambdaEvent) -> Result<(), Error> {
+    match event.next {
         NextEvent::Shutdown(_e) => {
             // do something with the shutdown event
         }

--- a/lambda-extension/examples/custom_events.rs
+++ b/lambda-extension/examples/custom_events.rs
@@ -1,7 +1,7 @@
-use lambda_extension::{extension_fn, Error, NextEvent, Runtime};
+use lambda_extension::{extension_fn, Error, LambdaEvent, NextEvent, Runtime};
 
-async fn my_extension(event: NextEvent) -> Result<(), Error> {
-    match event {
+async fn my_extension(event: LambdaEvent) -> Result<(), Error> {
+    match event.next {
         NextEvent::Shutdown(_e) => {
             // do something with the shutdown event
         }

--- a/lambda-extension/examples/custom_trait_implementation.rs
+++ b/lambda-extension/examples/custom_trait_implementation.rs
@@ -1,4 +1,4 @@
-use lambda_extension::{run, Error, Extension, InvokeEvent, NextEvent};
+use lambda_extension::{run, Error, Extension, InvokeEvent, LambdaEvent, NextEvent};
 use std::{
     future::{ready, Future},
     pin::Pin,
@@ -11,8 +11,8 @@ struct MyExtension {
 
 impl Extension for MyExtension {
     type Fut = Pin<Box<dyn Future<Output = Result<(), Error>>>>;
-    fn call(&mut self, event: NextEvent) -> Self::Fut {
-        match event {
+    fn call(&mut self, event: LambdaEvent) -> Self::Fut {
+        match event.next {
             NextEvent::Shutdown(_e) => {
                 self.data.clear();
             }

--- a/lambda-integration-tests/src/bin/extension-fn.rs
+++ b/lambda-integration-tests/src/bin/extension-fn.rs
@@ -1,8 +1,8 @@
-use lambda_extension::{extension_fn, Error, NextEvent};
+use lambda_extension::{extension_fn, Error, LambdaEvent, NextEvent};
 use tracing::info;
 
-async fn my_extension(event: NextEvent) -> Result<(), Error> {
-    match event {
+async fn my_extension(event: LambdaEvent) -> Result<(), Error> {
+    match event.next {
         NextEvent::Shutdown(e) => {
             info!("[extension-fn] Shutdown event received: {:?}", e);
         }

--- a/lambda-integration-tests/src/bin/extension-trait.rs
+++ b/lambda-integration-tests/src/bin/extension-trait.rs
@@ -1,4 +1,4 @@
-use lambda_extension::{Error, Extension, NextEvent};
+use lambda_extension::{Error, Extension, LambdaEvent, NextEvent};
 use std::{
     future::{ready, Future},
     pin::Pin,
@@ -13,8 +13,8 @@ struct MyExtension {
 impl Extension for MyExtension {
     type Fut = Pin<Box<dyn Future<Output = Result<(), Error>>>>;
 
-    fn call(&mut self, event: NextEvent) -> Self::Fut {
-        match event {
+    fn call(&mut self, event: LambdaEvent) -> Self::Fut {
+        match event.next {
             NextEvent::Shutdown(e) => {
                 info!("[extension] Shutdown event received: {:?}", e);
             }


### PR DESCRIPTION
Signed-off-by: David Calavera <david.calavera@gmail.com>

*Issue #, if available:*

Fixes #392 

*Description of changes:*

This new structure can be used to pass additional information to the extension in each invocation, like the extension id that the Runtime assigns to the extension when it's initialized.

I'm not super keen in cloning the id in every event, but if I start messing with lifetimes, the extension trait becomes much more complicated to implement. I think this is good enough to fix the current issue, and we can iterate on it if it really becomes a problem before making the crate more stable.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
