### PR TITLE
feat(lambda-http): implement http_body::Body for lambda_http::body

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -18,7 +18,9 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 base64 = "0.13.0"
+bytes = "1"
 http = "0.2"
+http-body = "0.4"
 lambda_runtime = { path = "../lambda-runtime", version = "0.4.1" }
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-lambda-rust-runtime/issues/398

*Description of changes:*

Add an implementation of `http_body::Body` for `lambda_http::Body`.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.

Closes https://github.com/awslabs/aws-lambda-rust-runtime/issues/398