### PR TITLE
run lambda_runtime inside Lambda Extensions

### DIFF
--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -61,8 +61,8 @@ impl Config {
                 .parse::<i32>()
                 .expect("AWS_LAMBDA_FUNCTION_MEMORY_SIZE env var is not <i32>"),
             version: env::var("AWS_LAMBDA_FUNCTION_VERSION").expect("Missing AWS_LAMBDA_FUNCTION_VERSION env var"),
-            log_stream: env::var("AWS_LAMBDA_LOG_STREAM_NAME").expect("Missing AWS_LAMBDA_LOG_STREAM_NAME env var"),
-            log_group: env::var("AWS_LAMBDA_LOG_GROUP_NAME").expect("Missing AWS_LAMBDA_LOG_GROUP_NAME env var"),
+            log_stream: env::var("AWS_LAMBDA_LOG_STREAM_NAME").unwrap_or_default(),
+            log_group: env::var("AWS_LAMBDA_LOG_GROUP_NAME").unwrap_or_default(),
         };
         Ok(conf)
     }


### PR DESCRIPTION
*Issue #, if available:*
#410 

*Description of changes:*
do not panic when "AWS_LAMBDA_LOG_STREAM_NAME" and "AWS_LAMBDA_LOG_GROUP_NAME" are missing. This allows lambda_runtime running inside extensions.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
