### PR TITLE
Log error chain to CloudWatch Logs

### DIFF
--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -125,7 +125,7 @@ where
                         .into_req()
                     }
                     Err(err) => {
-                        error!("{}", err); // logs the error in CloudWatch
+                        error!("{:?}", err); // logs the error (chain) to CloudWatch Logs
                         EventErrorRequest {
                             request_id,
                             diagnostic: Diagnostic {


### PR DESCRIPTION
The anyhow crate will only include the error chain with `{:?}` or `{:#}`.

Without this change, only the last error will be logged to CloudWatch and all underlying causes are lost when using `with_context` to augment errors.

Fixes #348

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
