### PR TITLE
Make errors implement Debug+Display

### DIFF
--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -91,7 +91,7 @@ where
     where
         F: Service<LambdaEvent<A>>,
         F::Future: Future<Output = Result<B, F::Error>>,
-        F::Error: fmt::Display,
+        F::Error: fmt::Debug + fmt::Display,
         A: for<'de> Deserialize<'de>,
         B: Serialize,
     {
@@ -125,7 +125,7 @@ where
                         .into_req()
                     }
                     Err(err) => {
-                        error!("{}", err); // logs the error in CloudWatch
+                        error!("{:?}", err); // logs the error in CloudWatch
                         EventErrorRequest {
                             request_id,
                             diagnostic: Diagnostic {
@@ -137,7 +137,7 @@ where
                     }
                 },
                 Err(err) => {
-                    error!("{:?}", err); // inconsistent with other log record formats - to be reviewed
+                    error!("{:?}", err);
                     EventErrorRequest {
                         request_id,
                         diagnostic: Diagnostic {
@@ -199,7 +199,7 @@ pub async fn run<A, B, F>(handler: F) -> Result<(), Error>
 where
     F: Service<LambdaEvent<A>>,
     F::Future: Future<Output = Result<B, F::Error>>,
-    F::Error: fmt::Display,
+    F::Error: fmt::Debug + fmt::Display,
     A: for<'de> Deserialize<'de>,
     B: Serialize,
 {


### PR DESCRIPTION
std::error::Error has the minimal requirement of describing
errors with both of these traits, I think we should enforce it too.

This will allow us to send the full callstack to CloudWatch when
there is an error.

Fixes https://github.com/awslabs/aws-lambda-rust-runtime/issues/348

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
