### PR TITLE
feat(lambda-extension): make errors implement Debug+Display

### DIFF
--- a/lambda-extension/src/lib.rs
+++ b/lambda-extension/src/lib.rs
@@ -26,7 +26,7 @@ pub async fn run<E>(events_processor: E) -> Result<(), Error>
 where
     E: Service<LambdaEvent>,
     E::Future: Future<Output = Result<(), E::Error>>,
-    E::Error: Into<Box<dyn std::error::Error + Send + Sync>> + fmt::Display,
+    E::Error: Into<Box<dyn std::error::Error + Send + Sync>> + fmt::Display + fmt::Debug,
 {
     let ext = Extension::new().with_events_processor(events_processor);
     ext.run().await


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Similar to https://github.com/awslabs/aws-lambda-rust-runtime/pull/418, but for `lambda-extension`.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
