### PR TITLE
fixes following v0.5.0 releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package makes it easy to run AWS Lambda Functions written in Rust. This wor
 
 - [![Docs](https://docs.rs/lambda_runtime/badge.svg)](https://docs.rs/lambda_runtime) **`lambda-runtime`** is a library that provides a Lambda runtime for applications written in Rust.
 - [![Docs](https://docs.rs/lambda_http/badge.svg)](https://docs.rs/lambda_http) **`lambda-http`** is a library that makes it easy to write API Gateway proxy event focused Lambda functions in Rust.
-- [![Docs](https://docs.rs/lambda_extension/badge.svg)](https://docs.rs/lambda_extension) **`lambda-extension`** is a library that makes it easy to write Lambda Runtime Extensions in Rust.
+- [![Docs](https://docs.rs/lambda-extension/badge.svg)](https://docs.rs/lambda-extension) **`lambda-extension`** is a library that makes it easy to write Lambda Runtime Extensions in Rust.
 - [![Docs](https://docs.rs/lambda_runtime_api_client/badge.svg)](https://docs.rs/lambda_runtime_api_client) **`lambda-runtime-api-client`** is a shared library between the lambda runtime and lambda extension libraries that includes a common API client to talk with the AWS Lambda Runtime API.
 
 

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lambda_extension"
+name = "lambda-extension"
 version = "0.5.0"
 edition = "2018"
 authors = ["David Calavera <david.calavera@gmail.com>"]

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 [dependencies]
 lambda_http = { path = "../lambda-http", version = "0.5" }
 lambda_runtime = { path = "../lambda-runtime", version = "0.5" }
-lambda_extension = { path = "../lambda-extension", version = "0.5" }
+lambda-extension = { path = "../lambda-extension", version = "0.5" }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This fixes the `lambda-extension` crate name. I originally reserved the name with a hyphen instead of an underscore, and cannot rename or delete the crate. See https://github.com/rust-lang/crates.io/issues/728 for more information.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
