### PR TITLE
Fix docker mirror repository URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ $ npx serverless invoke -f hello -d '{"foo":"bar"}'
 
 ### Docker
 
-Alternatively, you can build a Rust-based Lambda function in a [docker mirror of the AWS Lambda provided runtime with the Rust toolchain preinstalled](https://github.com/rustserverless/lambda-rust).
+Alternatively, you can build a Rust-based Lambda function in a [docker mirror of the AWS Lambda provided runtime with the Rust toolchain preinstalled](https://github.com/rust-serverless/lambda-rust).
 
 Running the following command will start a ephemeral docker container which will build your Rust application and produce a zip file containing its binary auto-renamed to `bootstrap` to meet the AWS Lambda's expectations for binaries under `target/lambda_runtime/release/{your-binary-name}.zip`, typically this is just the name of your crate if you are using the cargo default binary (i.e. `main.rs`)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Docker mirror repository link was 404. So fixed to the correct URL.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
