### PR TITLE
Fix issue parsing WebSocket requests.

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Doug Tangren"]
 edition = "2018"
 description = "Application Load Balancer and API Gateway event types for AWS Lambda"

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "awslabs/aws-lambda-rust-runtime" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-aws_lambda_events = { version = "0.6", default-features = false, features = ["alb", "apigw"]}
+aws_lambda_events = { version = "^0.6", default-features = false, features = ["alb", "apigw"]}
 base64 = "0.13.0"
 bytes = "1"
 http = "0.2"


### PR DESCRIPTION
Allow patch versions of aws_lambda_events.

@alistaim this version should fix the problem that you detected in https://github.com/LegNeato/aws-lambda-events/issues/71

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
