### PR TITLE
Be nice to more standard http servers.

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -72,7 +72,7 @@ fn into_api_gateway_v2_request(ag: ApiGatewayV2httpRequest) -> http::Request<Bod
                 .headers
                 .get(http::header::HOST)
                 .and_then(|s| s.to_str().ok())
-                .or_else(|| ag.request_context.domain_name.as_deref())
+                .or(ag.request_context.domain_name.as_deref())
                 .unwrap_or_default();
 
             let path = apigw_path_with_stage(&ag.request_context.stage, ag.raw_path.as_deref().unwrap_or_default());

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -97,15 +97,28 @@ where
     {
         let client = &self.client;
         tokio::pin!(incoming);
-        while let Some(event) = incoming.next().await {
+        while let Some(next_event_response) = incoming.next().await {
             trace!("New event arrived (run loop)");
-            let event = event?;
+            let event = next_event_response?;
             let (parts, body) = event.into_parts();
+
+            if parts.status == http::StatusCode::NO_CONTENT {
+                // Ignore the event if the status code is 204.
+                // This is a way to keep the runtime alive when
+                // there are no events pending to be processed.
+                continue;
+            }
+
+            let body = hyper::body::to_bytes(body).await?;
+            trace!("response body - {}", std::str::from_utf8(&body)?);
+
+            if parts.status.is_server_error() {
+                error!("Lambda Runtime server returned an unexpected error");
+                return Err(parts.status.to_string().into());
+            }
 
             let ctx: Context = Context::try_from(parts.headers)?;
             let ctx: Context = ctx.with_config(config);
-            let body = hyper::body::to_bytes(body).await?;
-            trace!("{}", std::str::from_utf8(&body)?); // this may be very verbose
             let body = serde_json::from_slice(&body)?;
 
             let xray_trace_id = &ctx.xray_trace_id.clone();

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -102,6 +102,7 @@ where
             let event = next_event_response?;
             let (parts, body) = event.into_parts();
 
+            #[cfg(debug_assertions)]
             if parts.status == http::StatusCode::NO_CONTENT {
                 // Ignore the event if the status code is 204.
                 // This is a way to keep the runtime alive when
@@ -112,6 +113,7 @@ where
             let body = hyper::body::to_bytes(body).await?;
             trace!("response body - {}", std::str::from_utf8(&body)?);
 
+            #[cfg(debug_assertions)]
             if parts.status.is_server_error() {
                 error!("Lambda Runtime server returned an unexpected error");
                 return Err(parts.status.to_string().into());


### PR DESCRIPTION
Handle HTTP status codes coming from the runtime server
in a way that plays nice with local development tools
like the runtime interface emulator.

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
