### PR TITLE
remove stage from generated http request url

### DIFF
--- a/lambda-runtime-api-client/README.md
+++ b/lambda-runtime-api-client/README.md
@@ -33,3 +33,8 @@ async fn main() -> Result<(), Error> {
     client.call(request).await
 }
 ```
+
+## Custom User Agent
+
+To customize User Agent header sent to Lambda Runtime API, you can configure an environment variable `LAMBDA_RUNTIME_USER_AGENT` at compiling time. 
+This will overide the default User Agent. 

--- a/lambda-runtime-api-client/src/lib.rs
+++ b/lambda-runtime-api-client/src/lib.rs
@@ -14,7 +14,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 
 const USER_AGENT_HEADER: &str = "User-Agent";
-const USER_AGENT: &str = concat!("aws-lambda-rust/", env!("CARGO_PKG_VERSION"));
+const DEFAULT_USER_AGENT: &str = concat!("aws-lambda-rust/", env!("CARGO_PKG_VERSION"));
+const CUSTOM_USER_AGENT: Option<&str> = option_env!("LAMBDA_RUNTIME_USER_AGENT");
 
 /// Error type that lambdas may result in
 pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -127,8 +128,13 @@ where
 
 /// Create a request builder.
 /// This builder uses `aws-lambda-rust/CRATE_VERSION` as
-/// the default User-Agent.
+/// the default User-Agent. Configure environment variable `LAMBDA_RUNTIME_USER_AGENT`
+/// at compile time to modify User-Agent value.
 pub fn build_request() -> http::request::Builder {
+    const USER_AGENT: &str = match CUSTOM_USER_AGENT {
+        Some(value) => value,
+        None => DEFAULT_USER_AGENT,
+    };
     http::Request::builder().header(USER_AGENT_HEADER, USER_AGENT)
 }
 


### PR DESCRIPTION
*Issue #, if available:*

Issue #450 

*Description of changes:*

This PR removes stage from generated http request url. This is the behavior in v0.4.1. 

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
