### PR TITLE
Expose the raw http path coming from the lambda event.

### DIFF
--- a/lambda-http/examples/hello-raw-http-path.rs
+++ b/lambda-http/examples/hello-raw-http-path.rs
@@ -1,0 +1,13 @@
+use lambda_http::{service_fn, Error, IntoResponse, Request, RequestExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    lambda_http::run(service_fn(func)).await?;
+    Ok(())
+}
+
+async fn func(event: Request) -> Result<impl IntoResponse, Error> {
+    let res = format!("The raw path for this request is: {}", event.raw_http_path()).into_response();
+
+    Ok(res)
+}


### PR DESCRIPTION
The API GW url includes th API GW stage information, so it's not easy to know what's the raw http path coming into the event.

With this change, we expose the raw http path in a general way, so people that need to know the exact raw path have a common interface, regardless of where the event comes from.

I believe this is a better solution to #450 than #451 because the AWS documentation explicitly says that the API GW URL includes the stage when requests come in, see https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html, so our behavior is going to be more expected by API GW users with our current implementation. However, I see the need to access the raw path when you write integrations with other services. With this change, people can access that raw path in a consistent manner regardless where the event comes from.

/cc @bnusunny

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
