### PR TITLE
Fixed invalid architectures reference in the SAM snippet (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       MemorySize: 128
-      Architectures: ["aarch64"]
+      Architectures: ["arm64"]
       Handler: bootstrap
       Runtime: provided.al2
       Timeout: 5


### PR DESCRIPTION
*Description of changes:*

Lambda functions don't list an `aarch64` architecture as a valid option for the `Architectures` list in the serverless function SAM resource definition. This should instead be `arm64`. Valid architectures can be found here: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-architectures

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
