### PR TITLE
feat!(lambda-http): accept http_body::Body in responses

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -22,6 +22,7 @@ base64 = "0.13.0"
 bytes = "1"
 http = "0.2"
 http-body = "0.4"
+hyper = "0.14"
 lambda_runtime = { path = "../lambda-runtime", version = "0.5" }
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -65,6 +65,7 @@ extern crate maplit;
 pub use http::{self, Response};
 use lambda_runtime::LambdaEvent;
 pub use lambda_runtime::{self, service_fn, tower, Context, Error, Service};
+use response::ResponseFuture;
 
 pub mod ext;
 pub mod request;
@@ -91,7 +92,8 @@ pub type Request = http::Request<Body>;
 #[doc(hidden)]
 pub struct TransformResponse<'a, R, E> {
     request_origin: RequestOrigin,
-    fut: Pin<Box<dyn Future<Output = Result<R, E>> + 'a>>,
+    fut_req: Pin<Box<dyn Future<Output = Result<R, E>> + 'a>>,
+    fut_res: Option<ResponseFuture>,
 }
 
 impl<'a, R, E> Future for TransformResponse<'a, R, E>
@@ -101,11 +103,22 @@ where
     type Output = Result<LambdaResponse, E>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
-        match self.fut.as_mut().poll(cx) {
-            Poll::Ready(result) => Poll::Ready(
-                result.map(|resp| LambdaResponse::from_response(&self.request_origin, resp.into_response())),
-            ),
-            Poll::Pending => Poll::Pending,
+        if let Some(fut_res) = self.fut_res.as_mut() {
+            match fut_res.as_mut().poll(cx) {
+                Poll::Ready(resp) => Poll::Ready(
+                    Ok(LambdaResponse::from_response(&self.request_origin, resp))
+                ),
+                Poll::Pending => Poll::Pending,
+            }
+        } else {
+            match self.fut_req.as_mut().poll(cx) {
+                Poll::Ready(Ok(resp)) => {
+                    self.fut_res = Some(resp.into_response());
+                    Poll::Pending
+                },
+                Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                Poll::Pending => Poll::Pending,
+            }
         }
     }
 }
@@ -151,7 +164,7 @@ where
         let request_origin = req.payload.request_origin();
         let event: Request = req.payload.into();
         let fut = Box::pin(self.service.call(event.with_lambda_context(req.context)));
-        TransformResponse { request_origin, fut }
+        TransformResponse { request_origin, fut_req: fut, fut_res: None, }
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allows using any `http_body::Body` implementation in the response for `lambda_http`.

⚠️ At the moment, this PR removes the ability to return a `Response<String>` or any into value that implements [`Into<aws_lambda_events::encodings::Body>`](https://docs.rs/aws_lambda_events/latest/aws_lambda_events/encodings/enum.Body.html).


By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
