### PR TITLE
feat(lambda-http): create separate trait for lambda events body

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -29,6 +29,7 @@ serde_urlencoded = "0.7.0"
 query_map = { version = "0.4", features = ["url-query"] }
 
 [dev-dependencies]
+hyper = "0.14"
 log = "^0.4"
 maplit = "1.0"
 tokio = { version = "1.0", features = ["macros"] }

--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -67,7 +67,7 @@ impl Error for PayloadError {
 ///
 /// # Examples
 ///
-/// We can retrieve the stage variables and return it to the user.
+/// We can retrieve the stage variables from API Gateway and return it to the user.
 ///
 /// ```rust,no_run
 /// use lambda_http::{service_fn, Error, Context, Body, IntoResponse, Request, Response, RequestExt};

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -69,7 +69,7 @@ pub use lambda_runtime::{self, service_fn, tower, Context, Error, Service};
 pub mod ext;
 pub mod request;
 mod response;
-pub use crate::{ext::RequestExt, response::IntoResponse};
+pub use crate::{ext::{RequestExt, RequestExtBody}, response::IntoResponse};
 use crate::{
     request::{LambdaRequest, RequestOrigin},
     response::LambdaResponse,


### PR DESCRIPTION
*Issue #, if available:* #472

*Description of changes:*

This will allow the extensions to be used outside the context of a service that passes the Lambda events body. The base trait will accept a default body, and a separate trait will be created specifically for the Lambda events body.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
