### PR TITLE
Don't require Lambda `Service` to use `lambda_http::Error`

### DIFF
--- a/lambda-http/examples/shared-resources-example.rs
+++ b/lambda-http/examples/shared-resources-example.rs
@@ -1,4 +1,4 @@
-use lambda_http::{service_fn, Error, IntoResponse, Request, RequestExt, Response};
+use lambda_http::{service_fn, Body, Error, IntoResponse, Request, RequestExt, Response};
 
 struct SharedClient {
     name: &'static str,
@@ -20,15 +20,17 @@ async fn main() -> Result<(), Error> {
 
     // Define a closure here that makes use of the shared client.
     let handler_func_closure = move |event: Request| async move {
-        Ok(match event.query_string_parameters().first("first_name") {
-            Some(first_name) => shared_client_ref
-                .response(event.lambda_context().request_id, first_name)
-                .into_response(),
-            _ => Response::builder()
-                .status(400)
-                .body("Empty first name".into())
-                .expect("failed to render response"),
-        })
+        Result::<Response<Body>, std::convert::Infallible>::Ok(
+            match event.query_string_parameters().first("first_name") {
+                Some(first_name) => shared_client_ref
+                    .response(event.lambda_context().request_id, first_name)
+                    .into_response(),
+                _ => Response::builder()
+                    .status(400)
+                    .body("Empty first name".into())
+                    .expect("failed to render response"),
+            },
+        )
     };
 
     // Pass the closure to the runtime here.


### PR DESCRIPTION
Currently, the `Service` that you pass to `lambda_http::run` is required
to use `lambda_http::Error` as its associated error type, a type-erased
boxed error type. However, all the runtime needs is for the error type
to implement `Debug` and `Display`. This commit relaxes this constraint,
allowing users to run a broader class of `Service`s.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
