### PR TITLE
Update `lambda_http`'s dependency on `query_map` to 0.5

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -26,7 +26,7 @@ lambda_runtime = { path = "../lambda-runtime", version = "0.5" }
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
 serde_urlencoded = "0.7.0"
-query_map = { version = "0.4", features = ["url-query"] }
+query_map = { version = "0.5", features = ["url-query"] }
 
 [dev-dependencies]
 log = "^0.4"


### PR DESCRIPTION
`aws_lambda_events` is using `query_map` 0.5, but `lambda_http` is
currently using `query_map` 0.4.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
