### PR TITLE
Pin aws_lambda_events dependency to patch versions

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "awslabs/aws-lambda-rust-runtime" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-aws_lambda_events = { version = "^0.6", default-features = false, features = ["alb", "apigw"]}
+aws_lambda_events = { version = "^0.6.3", default-features = false, features = ["alb", "apigw"]}
 base64 = "0.13.0"
 bytes = "1"
 http = "0.2"


### PR DESCRIPTION
*Description of changes:*

If you already have a version of aws_lambda_events in your project, and you update lambda_http, the events package's version might not be updated. This can cause compilation issues like the ones we saw in #471. With this change, the events package will be update with new patch versions, which should prevent issues like that from happening.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
