### PR TITLE
Reduce dependency features

### DIFF
--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -12,6 +12,6 @@ readme = "README.md"
 
 [dependencies]
 http = "0.2"
-hyper = { version = "0.14", features = ["http1", "client", "server", "stream", "runtime"] }
+hyper = { version = "0.14", features = ["http1", "client", "stream", "tcp"] }
 tower-service = "0.3"
 tokio = { version = "1.0", features = ["io-util"] }

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -16,14 +16,14 @@ simulated = []
 
 [dependencies]
 tokio = { version = "1.0", features = ["macros", "io-util", "sync", "rt-multi-thread"] }
-hyper = { version = "0.14", features = ["http1", "client", "server", "stream", "runtime"] }
+hyper = { version = "0.14", features = ["http1", "client", "stream", "tcp"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "^1"
 bytes = "1.0"
 http = "0.2"
 async-stream = "0.3"
 tracing = { version = "0.1", features = ["log"] }
-tower = { version = "0.4", features = ["full"] }
+tower = { version = "0.4", features = ["util"] }
 tokio-stream = "0.1.2"
 lambda_runtime_api_client = { version = "0.5", path = "../lambda-runtime-api-client" }
 


### PR DESCRIPTION
This saves about 12 seconds of build times in the first build of simple functions.

- Stop compiling Tower full
- Remove server and runtime features from hyper

Signed-off-by: David Calavera <david.calavera@gmail.com>

*Issue #, if available:*

Part of investigating #481 

*Description of changes:*


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
