### PR TITLE
feat(lambda-http): accept http_body::Body in responses

### DIFF
--- a/examples/http-basic-lambda/src/main.rs
+++ b/examples/http-basic-lambda/src/main.rs
@@ -1,10 +1,10 @@
-use lambda_http::{run, service_fn, Error, IntoResponse, Request, Response};
+use lambda_http::{run, service_fn, Body, Error, Request, Response};
 
 /// This is the main body for the function.
 /// Write your code inside it.
 /// There are some code examples in the Runtime repository:
 /// - https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/examples
-async fn function_handler(_event: Request) -> Result<impl IntoResponse, Error> {
+async fn function_handler(_event: Request) -> Result<Response<Body>, Error> {
     // Extract some useful information from the request
 
     // Return something that implements IntoResponse.
@@ -12,7 +12,7 @@ async fn function_handler(_event: Request) -> Result<impl IntoResponse, Error> {
     let resp = Response::builder()
         .status(200)
         .header("content-type", "text/html")
-        .body("Hello AWS Lambda HTTP request")
+        .body("Hello AWS Lambda HTTP request".into())
         .map_err(Box::new)?;
     Ok(resp)
 }

--- a/examples/http-cors/src/main.rs
+++ b/examples/http-cors/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Error> {
 
 async fn func(event: Request) -> Result<Response<Body>, Error> {
     Ok(match event.query_string_parameters().first("first_name") {
-        Some(first_name) => format!("Hello, {}!", first_name).into_response(),
+        Some(first_name) => format!("Hello, {}!", first_name).into_response().await,
         _ => Response::builder()
             .status(400)
             .body("Empty first name".into())

--- a/examples/http-query-parameters/src/main.rs
+++ b/examples/http-query-parameters/src/main.rs
@@ -7,7 +7,7 @@ use lambda_http::{run, service_fn, Error, IntoResponse, Request, RequestExt, Res
 async fn function_handler(event: Request) -> Result<impl IntoResponse, Error> {
     // Extract some useful information from the request
     Ok(match event.query_string_parameters().first("first_name") {
-        Some(first_name) => format!("Hello, {}!", first_name).into_response(),
+        Some(first_name) => format!("Hello, {}!", first_name).into_response().await,
         _ => Response::builder()
             .status(400)
             .body("Empty first name".into())

--- a/examples/http-raw-path/src/main.rs
+++ b/examples/http-raw-path/src/main.rs
@@ -15,7 +15,9 @@ async fn main() -> Result<(), Error> {
 }
 
 async fn func(event: Request) -> Result<impl IntoResponse, Error> {
-    let res = format!("The raw path for this request is: {}", event.raw_http_path()).into_response();
+    let res = format!("The raw path for this request is: {}", event.raw_http_path())
+        .into_response()
+        .await;
 
     Ok(res)
 }

--- a/examples/http-shared-resource/src/main.rs
+++ b/examples/http-shared-resource/src/main.rs
@@ -29,9 +29,12 @@ async fn main() -> Result<(), Error> {
     // Define a closure here that makes use of the shared client.
     let handler_func_closure = move |event: Request| async move {
         Result::<Response<Body>, Error>::Ok(match event.query_string_parameters().first("first_name") {
-            Some(first_name) => shared_client_ref
-                .response(event.lambda_context().request_id, first_name)
-                .into_response(),
+            Some(first_name) => {
+                shared_client_ref
+                    .response(event.lambda_context().request_id, first_name)
+                    .into_response()
+                    .await
+            }
             _ => Response::builder()
                 .status(400)
                 .body("Empty first name".into())

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -30,6 +30,8 @@ serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"
 serde_urlencoded = "0.7.0"
 query_map = { version = "0.5", features = ["url-query"] }
+mime = "0.3.16"
+encoding_rs = "0.8.31"
 
 [dependencies.aws_lambda_events]
 version = "^0.6.3"

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -22,6 +22,7 @@ base64 = "0.13.0"
 bytes = "1"
 http = "0.2"
 http-body = "0.4"
+hyper = "0.14"
 lambda_runtime = { path = "../lambda-runtime", version = "0.5" }
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -107,9 +107,7 @@ where
     fn poll(mut self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
         if let Some(fut_res) = self.fut_res.as_mut() {
             match fut_res.as_mut().poll(cx) {
-                Poll::Ready(resp) => Poll::Ready(
-                    Ok(LambdaResponse::from_response(&self.request_origin, resp))
-                ),
+                Poll::Ready(resp) => Poll::Ready(Ok(LambdaResponse::from_response(&self.request_origin, resp))),
                 Poll::Pending => Poll::Pending,
             }
         } else {
@@ -117,7 +115,7 @@ where
                 Poll::Ready(Ok(resp)) => {
                     self.fut_res = Some(resp.into_response());
                     Poll::Pending
-                },
+                }
                 Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
                 Poll::Pending => Poll::Pending,
             }
@@ -166,7 +164,11 @@ where
         let request_origin = req.payload.request_origin();
         let event: Request = req.payload.into();
         let fut = Box::pin(self.service.call(event.with_lambda_context(req.context)));
-        TransformResponse { request_origin, fut_req: fut, fut_res: None, }
+        TransformResponse {
+            request_origin,
+            fut_req: fut,
+            fut_res: None,
+        }
     }
 }
 

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -67,6 +67,7 @@ extern crate maplit;
 pub use http::{self, Response};
 use lambda_runtime::LambdaEvent;
 pub use lambda_runtime::{self, service_fn, tower, Context, Error, Service};
+use request::RequestFuture;
 use response::ResponseFuture;
 
 pub mod ext;
@@ -92,10 +93,9 @@ pub type Request = http::Request<Body>;
 ///
 /// This is used by the `Adapter` wrapper and is completely internal to the `lambda_http::run` function.
 #[doc(hidden)]
-pub struct TransformResponse<'a, R, E> {
-    request_origin: RequestOrigin,
-    fut_req: Pin<Box<dyn Future<Output = Result<R, E>> + 'a>>,
-    fut_res: Option<ResponseFuture>,
+pub enum TransformResponse<'a, R, E> {
+    Request(RequestOrigin, RequestFuture<'a, R, E>),
+    Response(RequestOrigin, ResponseFuture),
 }
 
 impl<'a, R, E> Future for TransformResponse<'a, R, E>
@@ -105,21 +105,19 @@ where
     type Output = Result<LambdaResponse, E>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut TaskContext) -> Poll<Self::Output> {
-        if let Some(fut_res) = self.fut_res.as_mut() {
-            match fut_res.as_mut().poll(cx) {
-                Poll::Ready(resp) => Poll::Ready(Ok(LambdaResponse::from_response(&self.request_origin, resp))),
-                Poll::Pending => Poll::Pending,
-            }
-        } else {
-            match self.fut_req.as_mut().poll(cx) {
+        match *self {
+            TransformResponse::Request(ref mut origin, ref mut request) => match request.as_mut().poll(cx) {
                 Poll::Ready(Ok(resp)) => {
-                    self.fut_res = Some(resp.into_response());
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
+                    *self = TransformResponse::Response(origin.clone(), resp.into_response());
+                    self.poll(cx)
                 }
                 Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
                 Poll::Pending => Poll::Pending,
-            }
+            },
+            TransformResponse::Response(ref mut origin, ref mut response) => match response.as_mut().poll(cx) {
+                Poll::Ready(resp) => Poll::Ready(Ok(LambdaResponse::from_response(origin, resp))),
+                Poll::Pending => Poll::Pending,
+            },
         }
     }
 }
@@ -165,11 +163,8 @@ where
         let request_origin = req.payload.request_origin();
         let event: Request = req.payload.into();
         let fut = Box::pin(self.service.call(event.with_lambda_context(req.context)));
-        TransformResponse {
-            request_origin,
-            fut_req: fut,
-            fut_res: None,
-        }
+
+        TransformResponse::Request(request_origin, fut)
     }
 }
 

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -114,6 +114,7 @@ where
             match self.fut_req.as_mut().poll(cx) {
                 Poll::Ready(Ok(resp)) => {
                     self.fut_res = Some(resp.into_response());
+                    cx.waker().wake_by_ref();
                     Poll::Pending
                 }
                 Poll::Ready(Err(err)) => Poll::Ready(Err(err)),

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -63,7 +63,7 @@ pub type RequestFuture<'a, R, E> = Pin<Box<dyn Future<Output = Result<R, E>> + '
 
 /// Represents the origin from which the lambda was requested from.
 #[doc(hidden)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RequestOrigin {
     /// API Gateway request origin
     #[cfg(feature = "apigw_rest")]
@@ -77,17 +77,6 @@ pub enum RequestOrigin {
     /// API Gateway WebSocket
     #[cfg(feature = "apigw_websockets")]
     WebSocket,
-}
-
-impl RequestOrigin {
-    pub(crate) fn clone(&self) -> RequestOrigin {
-        match self {
-            RequestOrigin::ApiGatewayV1 => RequestOrigin::ApiGatewayV1,
-            RequestOrigin::ApiGatewayV2 => RequestOrigin::ApiGatewayV2,
-            RequestOrigin::Alb => RequestOrigin::Alb,
-            RequestOrigin::WebSocket => RequestOrigin::WebSocket,
-        }
-    }
 }
 
 #[cfg(feature = "apigw_http")]

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -185,7 +185,7 @@ where
             value.to_str().unwrap_or_default()
         } else {
             // Content-Type and Content-Encoding not set, passthrough as utf8 text
-            return convert_to_text(self, "utf-8".to_string());
+            return convert_to_text(self, "utf-8");
         };
 
         if content_type.starts_with("text")
@@ -193,7 +193,7 @@ where
             || content_type.starts_with("application/javascript")
             || content_type.starts_with("application/xml")
         {
-            return convert_to_text(self, content_type.to_string());
+            return convert_to_text(self, content_type);
         }
 
         convert_to_binary(self)
@@ -208,7 +208,7 @@ where
     Box::pin(async move { Body::from(to_bytes(body).await.expect("unable to read bytes from body").to_vec()) })
 }
 
-fn convert_to_text<B>(body: B, content_type: String) -> BodyFuture
+fn convert_to_text<B>(body: B, content_type: &str) -> BodyFuture
 where
     B: HttpBody + Unpin + 'static,
     B::Error: fmt::Debug,

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -126,6 +126,18 @@ impl IntoResponse for &str {
     }
 }
 
+impl IntoResponse for &[u8] {
+    fn into_response(self) -> ResponseFuture {
+        Box::pin(ready(Response::new(Body::from(self))))
+    }
+}
+
+impl IntoResponse for Vec<u8> {
+    fn into_response(self) -> ResponseFuture {
+        Box::pin(ready(Response::new(Body::from(self))))
+    }
+}
+
 impl IntoResponse for serde_json::Value {
     fn into_response(self) -> ResponseFuture {
         Box::pin(async move {
@@ -192,6 +204,15 @@ mod tests {
         let response = "text".into_response().await;
         match response.body() {
             Body::Text(text) => assert_eq!(text, "text"),
+            _ => panic!("invalid body"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bytes_into_response() {
+        let response = "text".as_bytes().into_response().await;
+        match response.body() {
+            Body::Binary(data) => assert_eq!(data, "text".as_bytes()),
             _ => panic!("invalid body"),
         }
     }

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -29,7 +29,7 @@ pub enum LambdaResponse {
     Alb(AlbTargetGroupResponse),
 }
 
-/// Tranformation from http type to internal type
+/// Transformation from http type to internal type
 impl LambdaResponse {
     pub(crate) fn from_response(request_origin: &RequestOrigin, value: Response<Body>) -> Self {
         let (parts, bod) = value.into_parts();

--- a/lambda-integration-tests/src/bin/http-fn.rs
+++ b/lambda-integration-tests/src/bin/http-fn.rs
@@ -1,11 +1,14 @@
-use lambda_http::{service_fn, Error, IntoResponse, Request, RequestExt, Response};
+use lambda_http::{service_fn, Body, Error, IntoResponse, Request, RequestExt, Response};
 use tracing::info;
 
 async fn handler(event: Request) -> Result<impl IntoResponse, Error> {
     let _context = event.lambda_context();
     info!("[http-fn] Received event {} {}", event.method(), event.uri().path());
 
-    Ok(Response::builder().status(200).body("Hello, world!").unwrap())
+    Ok(Response::builder()
+        .status(200)
+        .body(Body::from("Hello, world!"))
+        .unwrap())
 }
 
 #[tokio::main]

--- a/lambda-integration-tests/src/bin/http-trait.rs
+++ b/lambda-integration-tests/src/bin/http-trait.rs
@@ -1,4 +1,4 @@
-use lambda_http::{Error, Request, RequestExt, Response, Service};
+use lambda_http::{Body, Error, Request, RequestExt, Response, Service};
 use std::{
     future::{ready, Future},
     pin::Pin,
@@ -13,7 +13,7 @@ struct MyHandler {
 impl Service<Request> for MyHandler {
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Error>> + Send>>;
-    type Response = Response<&'static str>;
+    type Response = Response<Body>;
 
     fn poll_ready(&mut self, _cx: &mut core::task::Context<'_>) -> core::task::Poll<Result<(), Self::Error>> {
         core::task::Poll::Ready(Ok(()))
@@ -25,7 +25,7 @@ impl Service<Request> for MyHandler {
         info!("[http-trait] Lambda context: {:?}", request.lambda_context());
         Box::pin(ready(Ok(Response::builder()
             .status(200)
-            .body("Hello, World!")
+            .body(Body::from("Hello, World!"))
             .unwrap())))
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
This PR is meant to continue the work started here: https://github.com/awslabs/aws-lambda-rust-runtime/pull/466

*Description of changes:*

**Original description**:
 _Allows using any http_body::Body implementation in the response for lambda_http._

---

For context, the outstanding issue on the original PR stems from this comment: https://github.com/awslabs/aws-lambda-rust-runtime/pull/466#issuecomment-1121351819

I picked up this PR and worked on it to the point where I believe that I had a viable testing approach. Ultimately I am blocked from performing the testing that has been requested in the original PR.

Here's why

In order to configure `contentHandling` we have to put the integration in the `aws`  (ie. not `aws-proxy`) configuration.

The request is treated as a `LambdaRequest::WebSocket` by the lambda_http crate, why this is and why the rust code panics when operated in this way, I don't know.

On an `aws-proxy` configuration, binary formats are dealt with by encoding the body of the response as base64 and setting `isBase64Encoded: true` (documentation: [Working with binary media types for REST APIs - Amazon API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-payload-encodings.html))

I managed to configure an API Gateway + Lambdas to be tested with CONVERT_TO_BINARY and CONVERT_TO_TEXT and it doesn't appear to work. What does work is setting the integration as `aws-proxy` but then it operates completely differently.

If we test through API gateway we only have two type requests, one where the function returns a `Body::Binary` and one where it returns a `Body::Text` (maybe a 3rd one for `Body::Empty`).

I'm proposing a simpler verification where we rely on the current unit tests (I'm adding impl IntoResponse for binaries + tests) and pasting the Lambda console results (below) that I got while debugging.

Happy to dig in further if I'm wrong and misunderstanding something.

---

Here's the console output for both a lambda that returns text and one that returns bytes

#### Bytes

```
{
  "statusCode": 200,
  "headers": {},
  "multiValueHeaders": {},
  "body": "YmluYXJ5IGRhdGE=",
  "isBase64Encoded": true
}
```

#### Text

```
{
  "statusCode": 200,
  "headers": {},
  "multiValueHeaders": {},
  "body": "text data",
  "isBase64Encoded": false
}
```

---

Finally, because I was most of the way there I want to share the commit I removed from this PR where I setup an API gateway (non-proxy) and the makefile changes where I would have added the verifications. https://github.com/hugobast/aws-lambda-rust-runtime/commit/83fa77dc0f4be23dbba9c2e6654fb00ec18d4e54

By submitting this pull request

---

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
