### PR TITLE
Ignore hosts from ALB health checks when they are not present

### DIFF
--- a/lambda-http/tests/data/alb_no_host.json
+++ b/lambda-http/tests/data/alb_no_host.json
@@ -1,0 +1,17 @@
+{
+  "body": "",
+  "headers": {
+    "user-agent": "ELB-HealthChecker/2.0"
+  },
+  "httpMethod": "GET",
+
+  "isBase64Encoded": false,
+
+  "path": "/v1/health/",
+  "queryStringParameters": {},
+  "requestContext": {
+    "elb": {
+      "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111:targetgroup/cdn-ingestor-tg-usea1-dev/3fe2aca58c0da101"
+    }
+  }
+}


### PR DESCRIPTION
ALB health checks don't include a host value.

Signed-off-by: David Calavera <david.calavera@gmail.com>

*Issue #, if available:*

Fixes #488 

*Description of changes:*


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
