### PR TITLE
fix lambda-extension README

### DIFF
--- a/lambda-extension/README.md
+++ b/lambda-extension/README.md
@@ -29,7 +29,9 @@ async fn my_extension(event: LambdaEvent) -> Result<(), Error> {
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
-        .with_ansi(false)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();
 


### PR DESCRIPTION
*Description of changes:*
the current example code doesn't work if you copy/paste it into a repo created with
`cargo lambda new`, even if you change the `Cargo.toml` to pull in the `lambda-extension`
crate.  The default template doesn't bring in `tracing` with the `ansi` feature.  This
updates the README to have code that's more in line with the default template.

By submitting this pull request

- [ x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ x] I confirm that I've made a best effort attempt to update all relevant documentation.
