### PR TITLE
Add message in closed issues

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,0 +1,17 @@
+name: Closed Issue Message
+on:
+    issues:
+       types: [closed]
+jobs:
+    auto_comment:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: aws-actions/closed-issue-message@v1
+          with:
+            # These inputs are both required
+            repo-token: "${{ secrets.GITHUB_TOKEN }}"
+            message: |
+                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
+                     Comments on closed issues are hard for the maintainers of this repository to see. 
+                     If you need more assistance, please open a new issue that references this one. 
+                     If you wish to keep having a conversation with other community members under this issue feel free to do so.


### PR DESCRIPTION
Add a new workflow that will post a message about visibility in closed issues.

I've seen this working pretty well in other open source repositories because users know how to act if they bump into a closed issue that they are interested in.


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
