### PR TITLE
Report error when we cannot deserialize the payload.

### DIFF
--- a/lambda-runtime/src/requests.rs
+++ b/lambda-runtime/src/requests.rs
@@ -104,7 +104,19 @@ fn test_event_completion_request() {
 // /runtime/invocation/{AwsRequestId}/error
 pub(crate) struct EventErrorRequest<'a> {
     pub(crate) request_id: &'a str,
-    pub(crate) diagnostic: Diagnostic,
+    pub(crate) diagnostic: Diagnostic<'a>,
+}
+
+impl<'a> EventErrorRequest<'a> {
+    pub(crate) fn new(request_id: &'a str, error_type: &'a str, error_message: &'a str) -> EventErrorRequest<'a> {
+        EventErrorRequest {
+            request_id,
+            diagnostic: Diagnostic {
+                error_type,
+                error_message,
+            },
+        }
+    }
 }
 
 impl<'a> IntoRequest for EventErrorRequest<'a> {
@@ -128,8 +140,8 @@ fn test_event_error_request() {
     let req = EventErrorRequest {
         request_id: "id",
         diagnostic: Diagnostic {
-            error_type: "InvalidEventDataError".to_string(),
-            error_message: "Error parsing event data".to_string(),
+            error_type: "InvalidEventDataError",
+            error_message: "Error parsing event data",
         },
     };
     let req = req.into_req().unwrap();

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -5,24 +5,9 @@ use std::{collections::HashMap, convert::TryFrom};
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct Diagnostic {
-    pub(crate) error_type: String,
-    pub(crate) error_message: String,
-}
-
-#[test]
-fn round_trip_lambda_error() -> Result<(), Error> {
-    use serde_json::{json, Value};
-    let expected = json!({
-        "errorType": "InvalidEventDataError",
-        "errorMessage": "Error parsing event data.",
-    });
-
-    let actual: Diagnostic = serde_json::from_value(expected.clone())?;
-    let actual: Value = serde_json::to_value(actual)?;
-    assert_eq!(expected, actual);
-
-    Ok(())
+pub(crate) struct Diagnostic<'a> {
+    pub(crate) error_type: &'a str,
+    pub(crate) error_message: &'a str,
 }
 
 /// The request ID, which identifies the request that triggered the function invocation. This header
@@ -190,6 +175,22 @@ impl<T> LambdaEvent<T> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn round_trip_lambda_error() {
+        use serde_json::{json, Value};
+        let expected = json!({
+            "errorType": "InvalidEventDataError",
+            "errorMessage": "Error parsing event data.",
+        });
+
+        let actual = Diagnostic {
+            error_type: "InvalidEventDataError",
+            error_message: "Error parsing event data.",
+        };
+        let actual: Value = serde_json::to_value(actual).expect("failed to serialize diagnostic");
+        assert_eq!(expected, actual);
+    }
 
     #[test]
     fn context_with_expected_values_and_types_resolves() {


### PR DESCRIPTION
*Issue #, if available:*

Fixes #517 

*Description of changes:*

Instead of panic, capture the error, and report it to the Lambda api. This is more friendly to operate.

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
