### PR TITLE
Add `with_request_context` to `RequestExt`

### DIFF
--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -165,6 +165,11 @@ pub trait RequestExt {
     /// Return request context data assocaited with the ALB or API gateway request
     fn request_context(&self) -> RequestContext;
 
+    /// Configures instance with request context
+    ///
+    /// This is intended for use in mock testing contexts.
+    fn with_request_context(self, context: RequestContext) -> Self;
+
     /// Return the Result of a payload parsed into a serde Deserializeable
     /// type
     ///
@@ -253,6 +258,12 @@ impl RequestExt for http::Request<Body> {
             .get::<RequestContext>()
             .cloned()
             .expect("Request did not contain a request context")
+    }
+
+    fn with_request_context(self, context: RequestContext) -> Self {
+        let mut s = self;
+        s.extensions_mut().insert(context);
+        s
     }
 
     fn lambda_context(&self) -> Context {


### PR DESCRIPTION
The trait `RequestExt` already includes functions to add query string parameters, path parameters and stage variables to a request, but none to add a `RequestContext`.

*Issue #, if available:* #522

*Description of changes:*
This commit adds another function to allow adding a `RequestContext` to the request. This is useful in cases where a lambda function is called by the API Gateway with a custom authorizer that adds parameters to the `RequestContext`.


By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
