### PR TITLE
Fix outdated docstring of some RequestExt functions

### DIFF
--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -125,7 +125,7 @@ pub trait RequestExt {
     /// will yield an empty `QueryMap`.
     fn query_string_parameters(&self) -> QueryMap;
 
-    /// Configures instance with query string parameters under #[cfg(test)] configurations
+    /// Configures instance with query string parameters
     ///
     /// This is intended for use in mock testing contexts.
     fn with_query_string_parameters<Q>(self, parameters: Q) -> Self
@@ -140,7 +140,7 @@ pub trait RequestExt {
     /// These will always be empty for ALB triggered requests
     fn path_parameters(&self) -> QueryMap;
 
-    /// Configures instance with path parameters under #[cfg(test)] configurations
+    /// Configures instance with path parameters
     ///
     /// This is intended for use in mock testing contexts.
     fn with_path_parameters<P>(self, parameters: P) -> Self


### PR DESCRIPTION


*Issue #, if available:*
None added, trivial change

*Description of changes:*
The PR #253 removed some of the `#[cfg(test)]` guards for a few
functions which are useful in testing outside of the library. However
the docstrings still stated that the test configuration was needed. This
commit fixes the docstrings.


By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
