### PR TITLE
Treat XML MIME type responses as text

### DIFF
--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -188,10 +188,13 @@ where
             return convert_to_text(self, "utf-8");
         };
 
+        // See list of common MIME types:
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
         if content_type.starts_with("text")
             || content_type.starts_with("application/json")
             || content_type.starts_with("application/javascript")
             || content_type.starts_with("application/xml")
+            || content_type.ends_with("+xml")
         {
             return convert_to_text(self, content_type);
         }


### PR DESCRIPTION
Files with the following MIME types are xml files:

application/vnd.apple.installer+xml
image/svg+xml
application/xhtml+xml
application/vnd.mozilla.xul+xml
application/atom+xml

Signed-off-by: David Calavera <david.calavera@gmail.com>

*Issue #, if available:*

Fixes #531 


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
