### PR TITLE
Add custom response header to force text encoding

### DIFF
--- a/lambda-http/tests/data/svg_logo.svg
+++ b/lambda-http/tests/data/svg_logo.svg
@@ -1,0 +1,49 @@
+<!-- The Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) license. Attribution of the image should be "W3C SVG Logo". -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 195 82">
+  <title>SVG logo combined with the W3C logo, set horizontally</title>
+  <desc>The logo combines three entities displayed horizontally: the W3C logo with the text 'W3C'; the drawing of a flower or star shape with eight arms; and the text 'SVG'. These three entities are set horizontally.</desc>
+  
+  <metadata>
+    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:cc="http://creativecommons.org/ns#" xmlns:xhtml="http://www.w3.org/1999/xhtml/vocab#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+      <cc:Work rdf:about="">
+        <dc:title>SVG logo combined with the W3C logo</dc:title>
+        <dc:format>image/svg+xml</dc:format>
+        <rdfs:seeAlso rdf:resource="http://www.w3.org/2007/10/sw-logos.html"/>
+        <dc:date>2007-11-01</dc:date>
+        <xhtml:license rdf:resource="http://www.w3.org/Consortium/Legal/2002/copyright-documents-20021231"/>
+        <cc:morePermissions rdf:resource="http://www.w3.org/2007/10/sw-logos.html#LogoWithW3C"/>
+        <cc:attributionURL rdf:reource="http://www.w3.org/2001/sw/"/>
+        <dc:description>The logo combines three entities displayed horizontally: the W3C logo with the text 'W3C'; the drawing of a flower or star shape with eight arms; and the text 'SVG'. These three entities are set horizontally.
+			</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  
+  <text x="0" y="75" font-size="83" fill-opacity="0" font-family="Trebuchet" letter-spacing="-12">W3C</text>
+  <text x="180" y="75" font-size="83" fill-opacity="0" font-family="Trebuchet" font-weight="bold">SVG</text>
+  <defs>
+    <g id="SVG" fill="#005A9C">
+      <path id="S" d="M 5.482,31.319 C2.163,28.001 0.109,23.419 0.109,18.358 C0.109,8.232 8.322,0.024 18.443,0.024 C28.569,0.024 36.782,8.232 36.782,18.358 L26.042,18.358 C26.042,14.164 22.638,10.765 18.443,10.765 C14.249,10.765 10.850,14.164 10.850,18.358 C10.850,20.453 11.701,22.351 13.070,23.721 L13.075,23.721 C14.450,25.101 15.595,25.500 18.443,25.952 L18.443,25.952 C23.509,26.479 28.091,28.006 31.409,31.324 L31.409,31.324 C34.728,34.643 36.782,39.225 36.782,44.286 C36.782,54.412 28.569,62.625 18.443,62.625 C8.322,62.625 0.109,54.412 0.109,44.286 L10.850,44.286 C10.850,48.480 14.249,51.884 18.443,51.884 C22.638,51.884 26.042,48.480 26.042,44.286 C26.042,42.191 25.191,40.298 23.821,38.923 L23.816,38.923 C22.441,37.548 20.468,37.074 18.443,36.697 L18.443,36.692 C13.533,35.939 8.800,34.638 5.482,31.319 L5.482,31.319 L5.482,31.319 Z"/>
+      <path id="V" d="M 73.452,0.024 L60.482,62.625 L49.742,62.625 L36.782,0.024 L47.522,0.024 L55.122,36.687 L62.712,0.024 L73.452,0.024 Z"/>
+      <path id="G" d="M 91.792,25.952 L110.126,25.952 L110.126,44.286 L110.131,44.286 C110.131,54.413 101.918,62.626 91.792,62.626 C81.665,62.626 73.458,54.413 73.458,44.286 L73.458,44.286 L73.458,18.359 L73.453,18.359 C73.453,8.233 81.665,0.025 91.792,0.025 C101.913,0.025 110.126,8.233 110.126,18.359 L99.385,18.359 C99.385,14.169 95.981,10.765 91.792,10.765 C87.597,10.765 84.198,14.169 84.198,18.359 L84.198,44.286 L84.198,44.286 C84.198,48.481 87.597,51.880 91.792,51.880 C95.981,51.880 99.380,48.481 99.385,44.291 L99.385,44.286 L99.385,36.698 L91.792,36.698 L91.792,25.952 L91.792,25.952 Z"/>
+    </g>
+  </defs>
+  <g shape-rendering="geometricPrecision" text-rendering="geometricPrecision" image-rendering="optimizeQuality">
+    <g>
+      <g id="logo" transform="scale(0.24) translate(0, 35)">
+        <g stroke-width="38.0086" stroke="#000">
+          <g id="svgstar" transform="translate(150, 150)">
+            <path id="svgbar" fill="#EDA921" d="M-84.1487,-15.8513 a22.4171,22.4171 0 1 0 0,31.7026 h168.2974 a22.4171,22.4171 0 1 0 0,-31.7026 Z"/>
+            <use xlink:href="#svgbar" transform="rotate(45)"/>
+            <use xlink:href="#svgbar" transform="rotate(90)"/>
+            <use xlink:href="#svgbar" transform="rotate(135)"/>
+          </g>
+        </g>
+        <use xlink:href="#svgstar"/>
+      </g>
+      <g id="SVG-label">
+        <use xlink:href="#SVG" transform="scale(1.08) translate(65,10)"/>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This allows users to force text encoding on responses that the runtime doesn't consider text and would return binary data otherwise.

I thought about adding some kind of configuration, but I think this is more straightforward to help people in cases where we don't return text responses and they would expect text.

Signed-off-by: David Calavera <david.calavera@gmail.com>

*Issue #, if available:*

Follow up to #531 

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
