### PR TITLE
Allow `Adapter` to be `.boxed()`

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -61,7 +61,7 @@ impl LambdaRequest {
 }
 
 /// RequestFuture type
-pub type RequestFuture<'a, R, E> = Pin<Box<dyn Future<Output = Result<R, E>> + 'a>>;
+pub type RequestFuture<'a, R, E> = Pin<Box<dyn Future<Output = Result<R, E>> + Send + 'a>>;
 
 /// Represents the origin from which the lambda was requested from.
 #[doc(hidden)]


### PR DESCRIPTION
Allowing `Adapter` to be [`.boxed()`](https://docs.rs/tower/0.4.13/tower/trait.ServiceExt.html#method.boxed) enables easier composition of `tower::Service`s that may include additional middleware prior to `Adapter` converting the `LambdaEvent` to a `Request`.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
