### PR TITLE
Re-export external modules of publicly used types

### DIFF
--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -78,6 +78,12 @@ use crate::{
     request::{LambdaRequest, RequestOrigin},
     response::LambdaResponse,
 };
+
+#[cfg(feature = "alb")]
+pub use aws_lambda_events::alb;
+#[cfg(any(feature = "apigw_rest", feature = "apigw_http", feature = "apigw_websockets"))]
+pub use aws_lambda_events::apigw;
+
 pub use aws_lambda_events::encodings::Body;
 use std::{
     future::Future,

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -1,13 +1,13 @@
 //! Response types
 
 use crate::request::RequestOrigin;
-use aws_lambda_events::encodings::Body;
 #[cfg(feature = "alb")]
-use aws_lambda_events::event::alb::AlbTargetGroupResponse;
+use aws_lambda_events::alb::AlbTargetGroupResponse;
 #[cfg(any(feature = "apigw_rest", feature = "apigw_websockets"))]
-use aws_lambda_events::event::apigw::ApiGatewayProxyResponse;
+use aws_lambda_events::apigw::ApiGatewayProxyResponse;
 #[cfg(feature = "apigw_http")]
-use aws_lambda_events::event::apigw::ApiGatewayV2httpResponse;
+use aws_lambda_events::apigw::ApiGatewayV2httpResponse;
+use aws_lambda_events::encodings::Body;
 use encoding_rs::Encoding;
 use http::header::CONTENT_ENCODING;
 use http::HeaderMap;


### PR DESCRIPTION
Some types that were used publicly were not re-exported, in some cases, making things more difficult for consumers. This change re-exports modules that were missing from being re-exported (several crates/modules already were re-exported).

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
