### PR TITLE
Update MSRV to 1.62

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         rust:
-          - "1.58.0" # Current MSRV
+          - "1.62.0" # Current MSRV
           - stable
           - beta
           - nightly

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ This will make your function compile much faster.
 
 ## Supported Rust Versions (MSRV)
 
-The AWS Lambda Rust Runtime requires a minimum of Rust 1.58, and is not guaranteed to build on compiler versions earlier than that.
+The AWS Lambda Rust Runtime requires a minimum of Rust 1.62, and is not guaranteed to build on compiler versions earlier than that.
 
 ## Security
 


### PR DESCRIPTION
This keeps us compatible with the AWS SDK.
Adds support for `Default` in enums: 

https://github.com/rust-lang/rust/pull/94457
https://github.com/awslabs/aws-lambda-rust-runtime/actions/runs/3223215837/jobs/5274494524#step:4:301

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
