### PR TITLE
Bump patch version of lambda-http

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>"
@@ -38,7 +38,7 @@ url = "2.2.2"
 percent-encoding = "2.2.0"
 
 [dependencies.aws_lambda_events]
-version = "^0.7"
+version = "^0.7.2"
 default-features = false
 features = ["alb", "apigw"]
 


### PR DESCRIPTION
This PR updates the version of `lambda-http` to 0.7.1. The crate now depends on `aws-lambda-events` 0.7.2 or higher whereas it previously depended on that of ^0.7.

This crate currently does not compile against `aws-lambda-events` 0.7.0 or 0.7.1. In `aws-lambda-events` 0.7.0, the module `query_map` is private when it should be public for `lambda-http` to compile. Similarly, in `aws-lambda-events` 0.7.1, the trait bound `QueryMap: FromStr` is not satisfied so `lambda-http` does not compile either.

It has been discovered as part of [this test failure](https://github.com/awslabs/smithy-rs/actions/runs/3330967146/jobs/5510160282) in CI for https://github.com/awslabs/smithy-rs/pull/1907. The test was running `cargo minimal-versions check` within the top-level [rust-runtime](https://github.com/awslabs/smithy-rs/tree/main/rust-runtime) workspace.

By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
