### PR TITLE
make RequestContext serializable

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -17,7 +17,7 @@ use aws_lambda_events::apigw::{ApiGatewayWebsocketProxyRequest, ApiGatewayWebsoc
 use aws_lambda_events::{encodings::Body, query_map::QueryMap};
 use http::header::HeaderName;
 use http::{HeaderMap, HeaderValue};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::error::Error as JsonError;
 use std::future::Future;
 use std::pin::Pin;
@@ -330,7 +330,7 @@ fn apigw_path_with_stage(stage: &Option<String>, path: &str) -> String {
 
 /// Event request context as an enumeration of request contexts
 /// for both ALB and API Gateway and HTTP API events
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Serialize)]
 #[serde(untagged)]
 pub enum RequestContext {
     /// API Gateway proxy request context


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Make RequestContext serializable, so that Lambda Web Adapter could forward its value to web apps in a http header. 

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
