### PR TITLE
Added `Context::deadline(&self) -> SystemTime`

### DIFF
--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -1,7 +1,11 @@
 use crate::{Config, Error};
 use http::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom};
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    time::{Duration, SystemTime},
+};
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -374,5 +378,10 @@ impl Context {
             env_config: config.clone(),
             ..self
         }
+    }
+
+    /// The execution deadline for the current invocation.
+    pub fn deadline(&self) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_millis(self.deadline)
     }
 }


### PR DESCRIPTION
*Description of changes:*

Added a function to get the `SystemTime` value for the deadline of the context.

There have been multiple times that I've needed a `SystemTime` (or similar) value, rather than simply the epoch ms `u64` that `Context` currently exposes. And I've watched other devs trip over that existing `u64` value. This should make it easier to use the deadline.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
