### PR TITLE
Fix invoke span by specifying a minimum version of tracing

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2018"
+edition = "2021"
 # imports_granularity is unstable
 # # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports
 # imports_granularity = "Crate"

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -18,16 +18,26 @@ default = ["simulated"]
 simulated = []
 
 [dependencies]
-tokio = { version = "1.0", features = ["macros", "io-util", "sync", "rt-multi-thread"] }
+tokio = { version = "1.0", features = [
+    "macros",
+    "io-util",
+    "sync",
+    "rt-multi-thread",
+] }
 # Hyper requires the `server` feature to work on nightly
-hyper = { version = "0.14.20", features = ["http1", "client", "stream", "server"] }
+hyper = { version = "0.14.20", features = [
+    "http1",
+    "client",
+    "stream",
+    "server",
+] }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "^1"
 bytes = "1.0"
 http = "0.2"
 async-stream = "0.3"
-tracing = { version = "0.1", features = ["log"] }
+tracing = { version = "0.1.37", features = ["log"] }
 tower = { version = "0.4", features = ["util"] }
 tokio-stream = "0.1.2"
 lambda_runtime_api_client = { version = "0.7", path = "../lambda-runtime-api-client" }


### PR DESCRIPTION
Some versions of tracing don't implement the tracing::Value trait for &std::string::String, and the runtime doesn't compile with them. By setting a minimum required version, we guarantee that the runtime compiles.

Signed-off-by: David Calavera <david.calavera@gmail.com>

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
