### PR TITLE
Fix double cookie header for Lambda Function URL requests

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -122,7 +122,7 @@ fn into_api_gateway_v2_request(ag: ApiGatewayV2httpRequest) -> http::Request<Bod
     update_xray_trace_id_header(&mut headers);
     if let Some(cookies) = ag.cookies {
         if let Ok(header_value) = HeaderValue::from_str(&cookies.join(";")) {
-            headers.append(http::header::COOKIE, header_value);
+            headers.insert(http::header::COOKIE, header_value);
         }
     }
 
@@ -541,6 +541,41 @@ mod tests {
         assert!(
             matches!(req_context, RequestContext::ApiGatewayV1(_)),
             "expected ApiGateway context, got {:?}",
+            req_context
+        );
+    }
+
+    #[test]
+    fn deserializes_lambda_function_url_request_events() {
+        // from the docs
+        // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-api-gateway-request
+        let input = include_str!("../tests/data/lambda_function_url_request.json");
+        let result = from_str(input);
+        assert!(
+            result.is_ok(),
+            "event was not parsed as expected {:?} given {}",
+            result,
+            input
+        );
+        let req = result.expect("failed to parse request");
+        let cookie_header = req
+            .headers()
+            .get_all(http::header::COOKIE)
+            .iter()
+            .map(|v| v.to_str().unwrap().to_string())
+            .reduce(|acc, nxt|
+                [acc, nxt].join(";")
+            );
+
+        assert_eq!(req.method(), "GET");
+        assert_eq!(req.uri(), "https://id.lambda-url.eu-west-2.on.aws/my/path?parameter1=value1&parameter1=value2&parameter2=value");
+        assert_eq!(cookie_header, Some("test=hi".to_string()));
+
+        // Ensure this is an APIGWv2 request (Lambda Function URL requests confirm to API GW v2 Request format)
+        let req_context = req.request_context();
+        assert!(
+            matches!(req_context, RequestContext::ApiGatewayV2(_)),
+            "expected ApiGatewayV2 context, got {:?}",
             req_context
         );
     }

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -563,12 +563,13 @@ mod tests {
             .get_all(http::header::COOKIE)
             .iter()
             .map(|v| v.to_str().unwrap().to_string())
-            .reduce(|acc, nxt|
-                [acc, nxt].join(";")
-            );
+            .reduce(|acc, nxt| [acc, nxt].join(";"));
 
         assert_eq!(req.method(), "GET");
-        assert_eq!(req.uri(), "https://id.lambda-url.eu-west-2.on.aws/my/path?parameter1=value1&parameter1=value2&parameter2=value");
+        assert_eq!(
+            req.uri(),
+            "https://id.lambda-url.eu-west-2.on.aws/my/path?parameter1=value1&parameter1=value2&parameter2=value"
+        );
         assert_eq!(cookie_header, Some("test=hi".to_string()));
 
         // Ensure this is an APIGWv2 request (Lambda Function URL requests confirm to API GW v2 Request format)

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -548,7 +548,7 @@ mod tests {
     #[test]
     fn deserializes_lambda_function_url_request_events() {
         // from the docs
-        // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-api-gateway-request
+        // https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads
         let input = include_str!("../tests/data/lambda_function_url_request.json");
         let result = from_str(input);
         assert!(

--- a/lambda-http/tests/data/lambda_function_url_request.json
+++ b/lambda-http/tests/data/lambda_function_url_request.json
@@ -1,0 +1,40 @@
+{
+  "version": "2.0",
+  "routeKey": "$default",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": [
+    "test=hi"
+  ],
+  "headers": {
+    "x-amzn-tls-cipher-suite": "ECDHE-RSA-AES128-GCM-SHA256",
+    "x-amzn-tls-version": "TLSv1.2",
+    "x-amzn-trace-id": "Root=1-5eb33c07-de25b420912dee103a5db434",
+    "cookie": "test=hi",
+    "x-forwarded-proto": "https",
+    "host": "id.lambda-url.eu-west-2.on.aws",
+    "x-forwarded-port": "443",
+    "x-forwarded-for": "65.78.31.245",
+    "accept": "*/*",
+    "user-agent": "curl/7.68.0"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "xxx",
+    "domainName": "id.lambda-url.eu-west-2.on.aws",
+    "domainPrefix": "id",
+    "http": {
+      "method": "GET",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "65.78.31.245",
+      "userAgent": "curl/7.68.0"
+    },
+    "requestId": "MIZRNhJtIAMEMDw=",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "11/Jan/2023:11:45:34 +0000",
+    "timeEpoch": 1673437534837
+  },
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
*Issue #, if available:*

awslabs/aws-lambda-web-adapter/issues/121 

Lambda Function URL requests include cookie in both `cookies` and `headers.cookie` objects. This causes lambda-http to duplicate cookie headers in the requests. 

*Description of changes:*

 Replace `headers.append()` with`headers.insert()`. This fixes the issue.


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
