### PR TITLE
Add test to check if params are missing

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -777,7 +777,8 @@ mod tests {
         assert_eq!(req.uri(), "https://id.execute-api.us-east-1.amazonaws.com/my/path-with%20space?parameter1=value1&parameter1=value2&parameter2=value");
     }
 
-    fn params_missing_handler(event: crate::Request) -> http::Response<Body> {
+    // This is async as this function would typically use futures, but this trival test case does not.
+    async fn params_missing_handler(event: crate::Request) -> crate::Response<Body> {
         let uri = event.uri();
 
         http::Response::builder()
@@ -787,13 +788,13 @@ mod tests {
             .unwrap()
     }
 
-    #[test]
-    fn params_missing() {
+    #[tokio::test]
+    async fn params_missing() {
         let input = include_str!("../tests/data/apigw_v2_proxy_request_minimal.json");
 
         let request = from_str(input).expect("created request");
 
-        let response = params_missing_handler(request);
+        let response = params_missing_handler(request).await;
         match response.body() {
             Body::Text(text) => {
                 assert_eq!(

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -473,7 +473,10 @@ mod tests {
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.method(), "GET");
-        assert_eq!(req.uri(), "https://xxx.execute-api.us-east-1.amazonaws.com/");
+        assert_eq!(
+            req.uri(),
+            "https://xxx.execute-api.us-east-1.amazonaws.com/test/test/hello?name=me/"
+        );
 
         // Ensure this is an APIGWv2 request
         let req_context = req.request_context();
@@ -772,6 +775,34 @@ mod tests {
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.uri(), "https://id.execute-api.us-east-1.amazonaws.com/my/path-with%20space?parameter1=value1&parameter1=value2&parameter2=value");
+    }
+
+    fn params_missing_handler(event: crate::Request) -> http::Response<Body> {
+        let uri = event.uri();
+
+        http::Response::builder()
+            .status(200)
+            .body(format!("URI: {}", uri).into())
+            .map_err(Box::new)
+            .unwrap()
+    }
+
+    #[test]
+    fn params_missing() {
+        let input = include_str!("../tests/data/apigw_v2_proxy_request_minimal.json");
+
+        let request = from_str(input).expect("created request");
+
+        let response = params_missing_handler(request);
+        match response.body() {
+            Body::Text(text) => {
+                assert_eq!(
+                    text,
+                    &r#"URI: https://xxx.execute-api.us-east-1.amazonaws.com/test/test/hello?name=me/"#.to_string()
+                )
+            }
+            _ => (),
+        };
     }
 
     #[test]

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -780,6 +780,7 @@ mod tests {
     // This is async as this function would typically use futures, but this trival test case does not.
     async fn params_missing_handler(event: crate::Request) -> crate::Response<Body> {
         let uri = event.uri();
+        assert_eq!(uri.query().unwrap(), "name=me/");
 
         http::Response::builder()
             .status(200)

--- a/lambda-http/tests/data/apigw_v2_proxy_request_minimal.json
+++ b/lambda-http/tests/data/apigw_v2_proxy_request_minimal.json
@@ -2,7 +2,7 @@
     "headers": {
       "accept": "*/*",
       "content-length": "0",
-      "host": "xxx.execute-api.us-east-1.amazonaws.com",
+      "host": "xxx.execute-api.us-east-1.amazonaws.com/test/test/hello?name=me",
       "user-agent": "curl/7.64.1",
       "x-amzn-trace-id": "Root=1-5eb33c07-de25b420912dee103a5db434",
       "x-forwarded-for": "65.78.31.245",


### PR DESCRIPTION
https://github.com/awslabs/aws-lambda-rust-runtime/issues/594

Added a test to check if it fails within the test suite, however, it passes.  In https://github.com/awslabs/aws-lambda-rust-runtime/issues/594 we see it fails.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
