### PR TITLE
add example for Lambda + HTTP + Axum

### DIFF
--- a/examples/http-axum/Cargo.toml
+++ b/examples/http-axum/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "http-basic-lambda"
+version = "0.1.0"
+edition = "2021"
+
+
+# Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
+# to manage dependencies.
+# Running `cargo add DEPENDENCY_NAME` will
+# add the latest version of a dependency to the list,
+# and it will keep the alphabetic ordering for you.
+
+[dependencies]
+lambda_http = { path = "../../lambda-http" }
+lambda_runtime = { path = "../../lambda-runtime" }
+tokio = { version = "1", features = ["macros"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+
+axum = "0.6.4"
+serde_json = "1.0"

--- a/examples/http-axum/README.md
+++ b/examples/http-axum/README.md
@@ -1,0 +1,11 @@
+# AWS Lambda Function example
+
+## Build & Deploy
+
+1. Install [cargo-lambda](https://github.com/cargo-lambda/cargo-lambda#installation)
+2. Build the function with `cargo lambda build --release` 
+3. Deploy the function to AWS Lambda with `cargo lambda deploy --iam-role YOUR_ROLE`
+
+## Build for ARM 64
+
+Build the function with `cargo lambda build --release --arm64` 

--- a/examples/http-axum/src/main.rs
+++ b/examples/http-axum/src/main.rs
@@ -1,0 +1,52 @@
+//! This is an example function that leverages the Lambda Rust runtime's HTTP support
+//! and the [axum](https://docs.rs/axum/latest/axum/index.html) web framework.  The
+//! runtime HTTP support is backed by the [tower::Service](https://docs.rs/tower-service/0.3.2/tower_service/trait.Service.html)
+//! trait.  Axum applications are also backed by the `tower::Service` trait.  That means
+//! that it is fairly easy to build an Axum application and pass the resulting `Service`
+//! implementation to the Lambda runtime to run as a Lambda function.  By using Axum instead
+//! of a basic `tower::Service` you get web framework niceties like routing, request component
+//! extraction, validation, etc.
+
+use lambda_http::{
+    run,
+    Error,
+};
+use axum::{
+    extract::Path,
+    response::Json,
+    Router,
+    routing::{get, post},
+};
+use serde_json::{Value, json};
+
+async fn root() -> Json<Value> {
+    Json(json!({ "msg": "I am GET /" }))
+}
+
+async fn get_foo() -> Json<Value> {
+    Json(json!({ "msg": "I am GET /foo" }))
+}
+
+async fn post_foo() -> Json<Value> {
+    Json(json!({ "msg": "I am POST /foo" }))
+}
+
+async fn post_foo_name(Path(name): Path<String>) -> Json<Value> {
+    Json(json!({ "msg": format!("I am POST /foo/:name, name={name}") }))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
+
+    let app = Router::new()
+        .route("/", get(root))
+        .route("/foo", get(get_foo).post(post_foo))
+        .route("/foo/:name", post(post_foo_name));
+
+    run(app).await
+}


### PR DESCRIPTION
this example bridges Lambda's HTTP support, which is based on the `tower::Service` trait, and the axum web framework, which builds applications that are also based on the `tower::Service` trait.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
