### PR TITLE
lambda_http: Add convenience methods to get references to data in the request

### DIFF
--- a/lambda-http/src/ext.rs
+++ b/lambda-http/src/ext.rs
@@ -55,7 +55,7 @@ impl Error for PayloadError {
     }
 }
 
-/// Extentions for `lambda_http::Request` structs that
+/// Extensions for `lambda_http::Request` structs that
 /// provide access to [API gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format)
 /// and [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html)
 /// features.
@@ -358,7 +358,7 @@ mod tests {
     }
 
     #[test]
-    fn requests_have_json_parseable_payloads() {
+    fn requests_have_json_parsable_payloads() {
         #[derive(Deserialize, Eq, PartialEq, Debug)]
         struct Payload {
             foo: String,
@@ -421,7 +421,7 @@ mod tests {
     }
 
     #[test]
-    fn requests_omiting_content_types_do_not_support_parseable_payloads() {
+    fn requests_omitting_content_types_do_not_support_parsable_payloads() {
         #[derive(Deserialize, Eq, PartialEq, Debug)]
         struct Payload {
             foo: String,
@@ -429,7 +429,7 @@ mod tests {
         }
         let request = http::Request::builder()
             .body(Body::from(r#"{"foo":"bar", "baz": 2}"#))
-            .expect("failed to bulid request");
+            .expect("failed to build request");
         let payload: Option<Payload> = request.payload().unwrap_or_default();
         assert_eq!(payload, None);
     }

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -298,7 +298,7 @@ fn into_websocket_request(ag: ApiGatewayWebsocketProxyRequest) -> http::Request<
         .extension(RequestContext::WebSocket(ag.request_context));
 
     // merge headers into multi_value_headers and make
-    // multi-value_headers our cannoncial source of request headers
+    // multi-value_headers our canonical source of request headers
     let mut headers = ag.multi_value_headers;
     headers.extend(ag.headers);
     update_xray_trace_id_header(&mut headers);


### PR DESCRIPTION
*Description of changes:*

There are existing methods to get owned clones of various pieces of data in the `Request`. This adds methods to get references where owned data is not needed.

Also fixed a typo in docs, and some typos in tests.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
