### PR TITLE
Fix clippy warnings

### DIFF
--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -221,7 +221,7 @@ mod test_adapter {
 
         fn call(&mut self, event: LambdaEvent<LambdaRequest>) -> Self::Future {
             // Log the request
-            println!("Lambda event: {:#?}", event);
+            println!("Lambda event: {event:#?}");
 
             self.inner.call(event)
         }

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -456,7 +456,7 @@ mod tests {
         // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-api-gateway-request
         // note: file paths are relative to the directory of the crate at runtime
         let result = from_reader(File::open("tests/data/apigw_proxy_request.json").expect("expected file"));
-        assert!(result.is_ok(), "event was not parsed as expected {:?}", result);
+        assert!(result.is_ok(), "event was not parsed as expected {result:?}");
     }
 
     #[test]
@@ -467,9 +467,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.method(), "GET");
@@ -479,8 +477,7 @@ mod tests {
         let req_context = req.request_context();
         assert!(
             matches!(req_context, RequestContext::ApiGatewayV2(_)),
-            "expected ApiGatewayV2 context, got {:?}",
-            req_context
+            "expected ApiGatewayV2 context, got {req_context:?}"
         );
     }
 
@@ -492,9 +489,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         let cookie_header = req
@@ -511,8 +506,7 @@ mod tests {
         let req_context = req.request_context();
         assert!(
             matches!(req_context, RequestContext::ApiGatewayV2(_)),
-            "expected ApiGatewayV2 context, got {:?}",
-            req_context
+            "expected ApiGatewayV2 context, got {req_context:?}"
         );
     }
 
@@ -525,9 +519,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.method(), "GET");
@@ -540,8 +532,7 @@ mod tests {
         let req_context = req.request_context();
         assert!(
             matches!(req_context, RequestContext::ApiGatewayV1(_)),
-            "expected ApiGateway context, got {:?}",
-            req_context
+            "expected ApiGateway context, got {req_context:?}"
         );
     }
 
@@ -553,9 +544,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         let cookie_header = req
@@ -576,8 +565,7 @@ mod tests {
         let req_context = req.request_context();
         assert!(
             matches!(req_context, RequestContext::ApiGatewayV2(_)),
-            "expected ApiGatewayV2 context, got {:?}",
-            req_context
+            "expected ApiGatewayV2 context, got {req_context:?}"
         );
     }
 
@@ -589,9 +577,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.method(), "GET");
@@ -604,8 +590,7 @@ mod tests {
         let req_context = req.request_context();
         assert!(
             matches!(req_context, RequestContext::Alb(_)),
-            "expected Alb context, got {:?}",
-            req_context
+            "expected Alb context, got {req_context:?}"
         );
     }
 
@@ -617,9 +602,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.method(), "GET");
@@ -632,8 +615,7 @@ mod tests {
         let req_context = req.request_context();
         assert!(
             matches!(req_context, RequestContext::Alb(_)),
-            "expected Alb context, got {:?}",
-            req_context
+            "expected Alb context, got {req_context:?}"
         );
     }
 
@@ -645,9 +627,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event is was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event is was not parsed as expected {result:?} given {input}"
         );
         let request = result.expect("failed to parse request");
 
@@ -668,9 +648,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event is was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event is was not parsed as expected {result:?} given {input}"
         );
         let request = result.expect("failed to parse request");
         assert!(!request.query_string_parameters().is_empty());
@@ -690,9 +668,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event is was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event is was not parsed as expected {result:?} given {input}"
         );
         let request = result.expect("failed to parse request");
         assert!(!request.query_string_parameters().is_empty());
@@ -718,9 +694,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.method(), "GET");
@@ -734,9 +708,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.method(), "GET");
@@ -750,9 +722,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.method(), "GET");
@@ -766,9 +736,7 @@ mod tests {
         let result = from_str(input);
         assert!(
             result.is_ok(),
-            "event was not parsed as expected {:?} given {}",
-            result,
-            input
+            "event was not parsed as expected {result:?} given {input}"
         );
         let req = result.expect("failed to parse request");
         assert_eq!(req.uri(), "https://id.execute-api.us-east-1.amazonaws.com/my/path-with%20space?parameter1=value1&parameter1=value2&parameter2=value");

--- a/lambda-runtime-api-client/src/lib.rs
+++ b/lambda-runtime-api-client/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all, clippy::cargo)]
 #![warn(missing_docs, nonstandard_style, rust_2018_idioms)]
-#![warn(clippy::multiple_crate_versions)]
+#![allow(clippy::multiple_crate_versions)]
 
 //! This crate includes a base HTTP client to interact with
 //! the AWS Lambda Runtime API.

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -323,7 +323,7 @@ mod endpoint_tests {
             .body(Body::empty())
             .expect("Unable to construct response");
 
-        let expected = format!("/2018-06-01/runtime/invocation/{}/response", id);
+        let expected = format!("/2018-06-01/runtime/invocation/{id}/response");
         assert_eq!(expected, req.uri().path());
 
         Ok(rsp)
@@ -331,7 +331,7 @@ mod endpoint_tests {
 
     #[cfg(test)]
     async fn event_err(req: &Request<Body>, id: &str) -> Result<Response<Body>, Error> {
-        let expected = format!("/2018-06-01/runtime/invocation/{}/error", id);
+        let expected = format!("/2018-06-01/runtime/invocation/{id}/error");
         assert_eq!(expected, req.uri().path());
 
         assert_eq!(req.method(), Method::POST);

--- a/lambda-runtime/src/simulated.rs
+++ b/lambda-runtime/src/simulated.rs
@@ -66,7 +66,7 @@ impl hyper::service::Service<Uri> for Connector {
     fn call(&mut self, uri: Uri) -> Self::Future {
         let res = match self.inner.lock() {
             Ok(mut map) if map.contains_key(&uri) => Ok(map.remove(&uri).unwrap()),
-            Ok(_) => Err(format!("Uri {} is not in map", uri).into()),
+            Ok(_) => Err(format!("Uri {uri} is not in map").into()),
             Err(_) => Err("mutex was poisoned".into()),
         };
         Box::pin(async move { res })


### PR DESCRIPTION
fix clippy warnings that breaks the pipeline builds

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
