### PR TITLE
make tracing init consistent across examples

### DIFF
--- a/examples/advanced-sqs-partial-batch-failures/Cargo.toml
+++ b/examples/advanced-sqs-partial-batch-failures/Cargo.toml
@@ -13,4 +13,4 @@ lambda_runtime = "0.7"
 tokio = { version = "1", features = ["macros"] }
 futures = "0.3"
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }

--- a/examples/advanced-sqs-partial-batch-failures/src/main.rs
+++ b/examples/advanced-sqs-partial-batch-failures/src/main.rs
@@ -28,10 +28,14 @@ async fn data_handler(data: Data) -> Result<(), Error> {
 /// Main function for the lambda executable.
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-error-handling/Cargo.toml
+++ b/examples/basic-error-handling/Cargo.toml
@@ -17,6 +17,6 @@ serde_json = "1.0.81"
 simple-error = "0.2.3"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/basic-error-handling/src/main.rs
+++ b/examples/basic-error-handling/src/main.rs
@@ -49,10 +49,14 @@ impl std::fmt::Display for CustomError {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-lambda/Cargo.toml
+++ b/examples/basic-lambda/Cargo.toml
@@ -15,4 +15,4 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }

--- a/examples/basic-lambda/src/main.rs
+++ b/examples/basic-lambda/src/main.rs
@@ -24,8 +24,14 @@ struct Response {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-shared-resource/Cargo.toml
+++ b/examples/basic-shared-resource/Cargo.toml
@@ -15,6 +15,6 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/basic-shared-resource/src/main.rs
+++ b/examples/basic-shared-resource/src/main.rs
@@ -47,6 +47,11 @@ async fn main() -> Result<(), Error> {
     // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-sqs/Cargo.toml
+++ b/examples/basic-sqs/Cargo.toml
@@ -20,4 +20,4 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }

--- a/examples/basic-sqs/src/main.rs
+++ b/examples/basic-sqs/src/main.rs
@@ -20,10 +20,14 @@ async fn function_handler(event: LambdaEvent<SqsEventObj<Data>>) -> Result<(), E
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-basic/Cargo.toml
+++ b/examples/extension-basic/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/extension-basic/src/main.rs
+++ b/examples/extension-basic/src/main.rs
@@ -14,10 +14,14 @@ async fn my_extension(event: LambdaEvent) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-combined/Cargo.toml
+++ b/examples/extension-combined/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/extension-combined/src/main.rs
+++ b/examples/extension-combined/src/main.rs
@@ -29,10 +29,14 @@ async fn my_log_processor(logs: Vec<LambdaLog>) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-custom-events/Cargo.toml
+++ b/examples/extension-custom-events/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/extension-custom-events/src/main.rs
+++ b/examples/extension-custom-events/src/main.rs
@@ -16,10 +16,14 @@ async fn my_extension(event: LambdaEvent) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-custom-service/Cargo.toml
+++ b/examples/extension-custom-service/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/extension-custom-service/src/main.rs
+++ b/examples/extension-custom-service/src/main.rs
@@ -33,10 +33,14 @@ impl Service<LambdaEvent> for MyExtension {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-logs-basic/Cargo.toml
+++ b/examples/extension-logs-basic/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/extension-logs-basic/src/main.rs
+++ b/examples/extension-logs-basic/src/main.rs
@@ -15,10 +15,14 @@ async fn handler(logs: Vec<LambdaLog>) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-logs-custom-service/Cargo.toml
+++ b/examples/extension-logs-custom-service/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/extension-logs-custom-service/src/main.rs
+++ b/examples/extension-logs-custom-service/src/main.rs
@@ -56,10 +56,14 @@ impl Service<Vec<LambdaLog>> for MyLogsProcessor {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-logs-kinesis-firehose/Cargo.toml
+++ b/examples/extension-logs-kinesis-firehose/Cargo.toml
@@ -12,6 +12,8 @@ edition = "2021"
 [dependencies]
 lambda-extension = { path = "../../lambda-extension" }
 tokio = { version = "1.17.0", features = ["full"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 aws-config = "0.13.0"
 aws-sdk-firehose = "0.13.0"
 

--- a/examples/extension-logs-kinesis-firehose/src/main.rs
+++ b/examples/extension-logs-kinesis-firehose/src/main.rs
@@ -53,6 +53,18 @@ impl Service<Vec<LambdaLog>> for FirehoseLogsProcessor {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
+
     let config = aws_config::load_from_env().await;
     let logs_processor = SharedService::new(FirehoseLogsProcessor::new(Client::new(&config)));
 

--- a/examples/extension-telemetry-basic/Cargo.toml
+++ b/examples/extension-telemetry-basic/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/extension-telemetry-basic/src/main.rs
+++ b/examples/extension-telemetry-basic/src/main.rs
@@ -40,10 +40,14 @@ async fn handler(events: Vec<LambdaTelemetry>) -> Result<(), Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-axum/Cargo.toml
+++ b/examples/http-axum/Cargo.toml
@@ -15,7 +15,7 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 axum = "0.6.4"
 serde_json = "1.0"

--- a/examples/http-axum/src/main.rs
+++ b/examples/http-axum/src/main.rs
@@ -37,8 +37,14 @@ async fn post_foo_name(Path(name): Path<String>) -> Json<Value> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-basic-lambda/Cargo.toml
+++ b/examples/http-basic-lambda/Cargo.toml
@@ -15,6 +15,6 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/http-basic-lambda/src/main.rs
+++ b/examples/http-basic-lambda/src/main.rs
@@ -19,8 +19,14 @@ async fn function_handler(_event: Request) -> Result<Response<Body>, Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-cors/Cargo.toml
+++ b/examples/http-cors/Cargo.toml
@@ -16,6 +16,6 @@ lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tower-http = { version = "0.3.3", features = ["cors"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/http-cors/src/main.rs
+++ b/examples/http-cors/src/main.rs
@@ -5,10 +5,14 @@ use tower_http::cors::{Any, CorsLayer};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-dynamodb/Cargo.toml
+++ b/examples/http-dynamodb/Cargo.toml
@@ -19,7 +19,7 @@ lambda_runtime = { path = "../../lambda-runtime" }
 aws-sdk-dynamodb = "0.21.0"
 aws-config = "0.51.0"
 tokio = { version = "1", features = ["macros"] }
-tracing = { version = "0.1.37"}
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/http-dynamodb/src/main.rs
+++ b/examples/http-dynamodb/src/main.rs
@@ -54,8 +54,14 @@ async fn handle_request(db_client: &Client, event: Request) -> Result<Response<B
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-query-parameters/Cargo.toml
+++ b/examples/http-query-parameters/Cargo.toml
@@ -15,6 +15,6 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/http-query-parameters/src/main.rs
+++ b/examples/http-query-parameters/src/main.rs
@@ -17,8 +17,14 @@ async fn function_handler(event: Request) -> Result<impl IntoResponse, Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-raw-path/Cargo.toml
+++ b/examples/http-raw-path/Cargo.toml
@@ -15,6 +15,6 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/http-raw-path/src/main.rs
+++ b/examples/http-raw-path/src/main.rs
@@ -2,10 +2,14 @@ use lambda_http::{service_fn, Error, IntoResponse, Request, RequestExt};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-shared-resource/Cargo.toml
+++ b/examples/http-shared-resource/Cargo.toml
@@ -15,6 +15,6 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
 
 

--- a/examples/http-shared-resource/src/main.rs
+++ b/examples/http-shared-resource/src/main.rs
@@ -12,10 +12,14 @@ impl SharedClient {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // The runtime logging can be enabled here by initializing `tracing` with `tracing-subscriber`
-    // While `tracing` is used internally, `log` can be used as well if preferred.
+    // required to enable CloudWatch error logging by the runtime
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-tower-trace/Cargo.toml
+++ b/examples/http-tower-trace/Cargo.toml
@@ -16,4 +16,4 @@ lambda_runtime = "0.5.1"
 tokio = { version = "1", features = ["macros"] }
 tower-http = { version = "0.3.4", features = ["trace"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }

--- a/examples/http-tower-trace/src/main.rs
+++ b/examples/http-tower-trace/src/main.rs
@@ -9,7 +9,17 @@ async fn handler(_req: Request) -> Result<Response<String>, Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    tracing_subscriber::fmt().without_time().init();
+    // required to enable CloudWatch error logging by the runtime
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // this needs to be set to false, otherwise ANSI color codes will
+        // show up in a confusing manner in CloudWatch logs.
+        .with_ansi(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
 
     let layer = TraceLayer::new_for_http()
         .on_request(DefaultOnRequest::new().level(Level::INFO))


### PR DESCRIPTION
this just copies the code across examples so that we're initializing the tracing subscriber in a consistent way.  we want to set a max level, disable printing the name of the module every time, disable ANSI color codes (because CloudWatch prints them in a non-readable way), and disable logging the time at this layer because CloudWatch is going to add the ingestion time itself.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
