### PR TITLE
feat: use rc to avoid allocating a new string for extension_id

### DIFF
--- a/lambda-extension/src/events.rs
+++ b/lambda-extension/src/events.rs
@@ -1,3 +1,5 @@
+use std::{rc::Rc};
+
 use serde::Deserialize;
 
 /// Request tracing information
@@ -56,16 +58,13 @@ impl NextEvent {
 /// event that the Lambda Runtime is going to process
 pub struct LambdaEvent {
     /// ID assigned to this extension by the Lambda Runtime
-    pub extension_id: String,
+    pub extension_id: Rc<String>,
     /// Next incoming event
     pub next: NextEvent,
 }
 
 impl LambdaEvent {
-    pub(crate) fn new(ex_id: &str, next: NextEvent) -> LambdaEvent {
-        LambdaEvent {
-            extension_id: ex_id.into(),
-            next,
-        }
+    pub(crate) fn new(extension_id: Rc<String>, next: NextEvent) -> Self {
+        LambdaEvent { extension_id, next }
     }
 }

--- a/lambda-extension/src/extension.rs
+++ b/lambda-extension/src/extension.rs
@@ -1,5 +1,6 @@
 use std::{
-    convert::Infallible, fmt, future::ready, future::Future, net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc,
+    convert::Infallible, fmt, future::ready, future::Future, net::SocketAddr, path::PathBuf, pin::Pin, rc::Rc,
+    sync::Arc,
 };
 
 use hyper::{server::conn::AddrStream, Server};
@@ -221,6 +222,7 @@ where
 
         let extension_id = register(client, self.extension_name, self.events).await?;
         let extension_id = extension_id.to_str()?;
+        let extension_id_rc = Rc::new(String::from(extension_id));
         let mut ep = self.events_processor;
 
         if let Some(mut log_processor) = self.logs_processor {
@@ -315,7 +317,7 @@ where
             let event: NextEvent = serde_json::from_slice(&body)?;
             let is_invoke = event.is_invoke();
 
-            let event = LambdaEvent::new(extension_id, event);
+            let event = LambdaEvent::new(extension_id_rc.clone(), event);
 
             let ep = match ep.ready().await {
                 Ok(ep) => ep,


### PR DESCRIPTION
*Issue #, if available:* potential fix for #614

*Description of changes:*
Using a RC around the extension id. 
Now it clones the RC for each event which is way lighter than cloning the full extension_id string

⚠️ this is a breaking change as LambdaEvent is public

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
