### PR TITLE
Release lambda-runtime-api-client v0.8.0

### DIFF
--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime_api_client"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = [
     "David Calavera <dcalaver@amazon.com>",


### PR DESCRIPTION
Release lambda-runtime-api-client v0.8.0

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
