### PR TITLE
Release v0.8.0

### DIFF
--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-extension"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
@@ -19,7 +19,7 @@ bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 hyper = { version = "0.14.20", features = ["http1", "client", "server", "stream", "runtime"] }
-lambda_runtime_api_client = { version = "0.7", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "0.8", path = "../lambda-runtime-api-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "^1"
 tracing = { version = "0.1", features = ["log"] }

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.7.3"
+version = "0.8.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -29,7 +29,7 @@ futures = "0.3"
 http = "0.2"
 http-body = "0.4"
 hyper = "0.14"
-lambda_runtime = { path = "../lambda-runtime", version = "0.7" }
+lambda_runtime = { path = "../lambda-runtime", version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime_api_client"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = [
     "David Calavera <dcalaver@amazon.com>",

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "0.7.3"
+version = "0.8.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -40,4 +40,4 @@ async-stream = "0.3"
 tracing = { version = "0.1.37", features = ["log"] }
 tower = { version = "0.4", features = ["util"] }
 tokio-stream = "0.1.2"
-lambda_runtime_api_client = { version = "0.7", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "0.8", path = "../lambda-runtime-api-client" }


### PR DESCRIPTION
Release a new version for the following crates: 

lambda-runtime-client-api v0.8.0
lambda-runtime v0.8.0
lambda-http v0.8.0
lambda-extension v0.8.1

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
