### PR TITLE
Remove extension_id from LambdaEvent

### DIFF
--- a/lambda-extension/src/events.rs
+++ b/lambda-extension/src/events.rs
@@ -55,17 +55,12 @@ impl NextEvent {
 /// Wrapper with information about the next
 /// event that the Lambda Runtime is going to process
 pub struct LambdaEvent {
-    /// ID assigned to this extension by the Lambda Runtime
-    pub extension_id: String,
     /// Next incoming event
     pub next: NextEvent,
 }
 
 impl LambdaEvent {
-    pub(crate) fn new(ex_id: &str, next: NextEvent) -> LambdaEvent {
-        LambdaEvent {
-            extension_id: ex_id.into(),
-            next,
-        }
+    pub(crate) fn new(next: NextEvent) -> LambdaEvent {
+        LambdaEvent { next }
     }
 }

--- a/lambda-extension/src/extension.rs
+++ b/lambda-extension/src/extension.rs
@@ -315,7 +315,7 @@ where
             let event: NextEvent = serde_json::from_slice(&body)?;
             let is_invoke = event.is_invoke();
 
-            let event = LambdaEvent::new(extension_id, event);
+            let event = LambdaEvent::new(event);
 
             let ep = match ep.ready().await {
                 Ok(ep) => ep,


### PR DESCRIPTION
This id is auto-generated when an extension is registered. The runtime uses it to interact with the extension via HTTP, but it doesn't have any meaning outside of that because it's always aleatory.

*Issue #, if available:*

Closes #614 
Closes #615 

*Description of changes:*

As explained in https://github.com/awslabs/aws-lambda-rust-runtime/pull/615#pullrequestreview-1376926445, this is internal data that's not useful to customers.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
