### PR TITLE
Fix support for APIGW console requests

### DIFF
--- a/lambda-events/src/event/apigw/mod.rs
+++ b/lambda-events/src/event/apigw/mod.rs
@@ -107,6 +107,7 @@ where
     pub http_method: Method,
     #[serde(default)]
     pub request_time: Option<String>,
+    #[serde(default)]
     pub request_time_epoch: i64,
     /// The API Gateway rest API Id
     #[serde(default)]
@@ -180,6 +181,7 @@ where
     pub domain_prefix: Option<String>,
     #[serde(default)]
     pub time: Option<String>,
+    #[serde(default)]
     pub time_epoch: i64,
     pub http: ApiGatewayV2httpRequestContextHttpDescription,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -918,6 +920,16 @@ mod test {
         let parsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "apigw")]
+    fn example_apigw_console_request() {
+        let data = include_bytes!("../../fixtures/example-apigw-console-request.json");
+        let parsed: ApiGatewayProxyRequest = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/fixtures/example-apigw-console-request.json
+++ b/lambda-events/src/fixtures/example-apigw-console-request.json
@@ -1,0 +1,57 @@
+{
+    "body": "{\"test\":\"body\"}",
+    "resource": "/{proxy+}",
+    "path": "/path/to/resource",
+    "httpMethod": "POST",
+    "queryStringParameters": {
+        "foo": "bar"
+    },
+    "pathParameters": {
+        "proxy": "path/to/resource"
+    },
+    "stageVariables": {
+        "baz": "qux"
+    },
+    "headers": {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Encoding": "gzip, deflate, sdch",
+        "Accept-Language": "en-US,en;q=0.8",
+        "Cache-Control": "max-age=0",
+        "CloudFront-Forwarded-Proto": "https",
+        "CloudFront-Is-Desktop-Viewer": "true",
+        "CloudFront-Is-Mobile-Viewer": "false",
+        "CloudFront-Is-SmartTV-Viewer": "false",
+        "CloudFront-Is-Tablet-Viewer": "false",
+        "CloudFront-Viewer-Country": "US",
+        "Host": "1234567890.execute-api.{dns_suffix}",
+        "Upgrade-Insecure-Requests": "1",
+        "User-Agent": "Custom User Agent String",
+        "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+        "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "requestContext": {
+        "accountId": "123456789012",
+        "resourceId": "123456",
+        "stage": "prod",
+        "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "apiKey": null,
+            "sourceIp": "127.0.0.1",
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "Custom User Agent String",
+            "user": null
+        },
+        "resourcePath": "/{proxy+}",
+        "httpMethod": "POST",
+        "apiId": "1234567890"
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

Fixes #655 

*Description of changes:*

Test requests from the APIGW console don't include time epoch. This change makes that field to be deserialized with a default value in those cases.

I'm trying to just make minimal changes to this, but we should think about better ways to surface deserialization problems in http requests, maybe even writing our own deserializer, out of the scope for this PR.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
