### PR TITLE
Fix check examples workflow to only run once in pull requests

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -1,6 +1,9 @@
 name: Check examples
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   check:


### PR DESCRIPTION
Fixes Issue #670

Examples are now only checked a single time in pull requests

By submitting this pull request

- [x ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ x] I confirm that I've made a best effort attempt to update all relevant documentation.
