### PR TITLE
Exclude the ansi feature of tracing-subscriber instead of building with .with_ansi(false)

### DIFF
--- a/examples/advanced-sqs-partial-batch-failures/Cargo.toml
+++ b/examples/advanced-sqs-partial-batch-failures/Cargo.toml
@@ -13,4 +13,4 @@ lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 futures = "0.3"
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/examples/advanced-sqs-partial-batch-failures/src/main.rs
+++ b/examples/advanced-sqs-partial-batch-failures/src/main.rs
@@ -33,9 +33,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();
@@ -78,9 +75,7 @@ where
     tracing::trace!("Handling batch size {}", event.payload.records.len());
     let create_task = |msg| {
         // We need to keep the message_id to report failures to SQS
-        let SqsMessageObj {
-            message_id, body, ..
-        } = msg;
+        let SqsMessageObj { message_id, body, .. } = msg;
         let span = tracing::span!(tracing::Level::INFO, "Handling SQS msg", message_id);
         let task = async {
             //TODO catch panics like the `run` function from lambda_runtime
@@ -104,9 +99,7 @@ where
                 }
             },
         )
-        .map(|id| BatchItemFailure {
-            item_identifier: id,
-        })
+        .map(|id| BatchItemFailure { item_identifier: id })
         .collect();
 
     Ok(SqsBatchResponse {

--- a/examples/basic-error-handling/Cargo.toml
+++ b/examples/basic-error-handling/Cargo.toml
@@ -17,6 +17,6 @@ serde_json = "1.0.81"
 simple-error = "0.2.3"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/basic-error-handling/src/main.rs
+++ b/examples/basic-error-handling/src/main.rs
@@ -54,9 +54,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-lambda-external-runtime/Cargo.toml
+++ b/examples/basic-lambda-external-runtime/Cargo.toml
@@ -12,4 +12,4 @@ serde = "1.0.163"
 tokio = "1.28.2"
 tokio-test = "0.4.2"
 tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/examples/basic-lambda-external-runtime/src/main.rs
+++ b/examples/basic-lambda-external-runtime/src/main.rs
@@ -29,9 +29,6 @@ fn main() -> Result<(), io::Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-lambda/Cargo.toml
+++ b/examples/basic-lambda/Cargo.toml
@@ -15,5 +15,5 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 tokio-test = "0.4.2"

--- a/examples/basic-lambda/src/main.rs
+++ b/examples/basic-lambda/src/main.rs
@@ -29,9 +29,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-s3-object-lambda-thumbnail/Cargo.toml
+++ b/examples/basic-s3-object-lambda-thumbnail/Cargo.toml
@@ -20,7 +20,7 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 aws-config = "0.55.3"
 aws-sdk-s3 = "0.28.0"
 thumbnailer = "0.4.0"

--- a/examples/basic-s3-object-lambda-thumbnail/src/main.rs
+++ b/examples/basic-s3-object-lambda-thumbnail/src/main.rs
@@ -69,9 +69,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::TRACE)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-s3-thumbnail/Cargo.toml
+++ b/examples/basic-s3-thumbnail/Cargo.toml
@@ -20,7 +20,7 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 aws-config = "0.54.1"
 aws-sdk-s3 = "0.24.0"
 thumbnailer = "0.4.0"

--- a/examples/basic-s3-thumbnail/src/main.rs
+++ b/examples/basic-s3-thumbnail/src/main.rs
@@ -111,9 +111,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-sdk/Cargo.toml
+++ b/examples/basic-sdk/Cargo.toml
@@ -13,7 +13,7 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 [dev-dependencies]
 mockall = "0.11.3"

--- a/examples/basic-sdk/src/main.rs
+++ b/examples/basic-sdk/src/main.rs
@@ -38,9 +38,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-shared-resource/Cargo.toml
+++ b/examples/basic-shared-resource/Cargo.toml
@@ -15,6 +15,5 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
-
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 

--- a/examples/basic-shared-resource/src/main.rs
+++ b/examples/basic-shared-resource/src/main.rs
@@ -49,9 +49,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-sqs/Cargo.toml
+++ b/examples/basic-sqs/Cargo.toml
@@ -20,4 +20,4 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/examples/basic-sqs/src/main.rs
+++ b/examples/basic-sqs/src/main.rs
@@ -25,9 +25,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/basic-streaming-response/Cargo.toml
+++ b/examples/basic-streaming-response/Cargo.toml
@@ -14,5 +14,5 @@ hyper = { version = "0.14", features = [
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 serde_json = "1.0"

--- a/examples/basic-streaming-response/src/main.rs
+++ b/examples/basic-streaming-response/src/main.rs
@@ -30,9 +30,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-basic/Cargo.toml
+++ b/examples/extension-basic/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/extension-basic/src/main.rs
+++ b/examples/extension-basic/src/main.rs
@@ -19,9 +19,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-combined/Cargo.toml
+++ b/examples/extension-combined/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/extension-combined/src/main.rs
+++ b/examples/extension-combined/src/main.rs
@@ -34,9 +34,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-custom-events/Cargo.toml
+++ b/examples/extension-custom-events/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/extension-custom-events/src/main.rs
+++ b/examples/extension-custom-events/src/main.rs
@@ -21,9 +21,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-custom-service/Cargo.toml
+++ b/examples/extension-custom-service/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/extension-custom-service/src/main.rs
+++ b/examples/extension-custom-service/src/main.rs
@@ -38,9 +38,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-logs-basic/Cargo.toml
+++ b/examples/extension-logs-basic/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/extension-logs-basic/src/main.rs
+++ b/examples/extension-logs-basic/src/main.rs
@@ -20,9 +20,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-logs-custom-service/Cargo.toml
+++ b/examples/extension-logs-custom-service/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/extension-logs-custom-service/src/main.rs
+++ b/examples/extension-logs-custom-service/src/main.rs
@@ -61,9 +61,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-logs-kinesis-firehose/Cargo.toml
+++ b/examples/extension-logs-kinesis-firehose/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 lambda-extension = { path = "../../lambda-extension" }
 tokio = { version = "1.17.0", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 aws-config = "0.13.0"
 aws-sdk-firehose = "0.13.0"
 

--- a/examples/extension-logs-kinesis-firehose/src/main.rs
+++ b/examples/extension-logs-kinesis-firehose/src/main.rs
@@ -58,9 +58,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/extension-telemetry-basic/Cargo.toml
+++ b/examples/extension-telemetry-basic/Cargo.toml
@@ -15,6 +15,6 @@ lambda-extension = { path = "../../lambda-extension" }
 serde = "1.0.136"
 tokio = { version = "1", features = ["macros", "rt"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/extension-telemetry-basic/src/main.rs
+++ b/examples/extension-telemetry-basic/src/main.rs
@@ -45,9 +45,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-axum-diesel/Cargo.toml
+++ b/examples/http-axum-diesel/Cargo.toml
@@ -20,4 +20,4 @@ lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.159"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/examples/http-axum-diesel/src/main.rs
+++ b/examples/http-axum-diesel/src/main.rs
@@ -97,9 +97,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-axum/Cargo.toml
+++ b/examples/http-axum/Cargo.toml
@@ -15,7 +15,7 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 axum = "0.6.4"
 serde_json = "1.0"

--- a/examples/http-axum/src/main.rs
+++ b/examples/http-axum/src/main.rs
@@ -42,9 +42,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-basic-lambda/Cargo.toml
+++ b/examples/http-basic-lambda/Cargo.toml
@@ -15,6 +15,6 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/http-basic-lambda/src/main.rs
+++ b/examples/http-basic-lambda/src/main.rs
@@ -24,9 +24,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-cors/Cargo.toml
+++ b/examples/http-cors/Cargo.toml
@@ -16,6 +16,6 @@ lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tower-http = { version = "0.3.3", features = ["cors"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/http-cors/src/main.rs
+++ b/examples/http-cors/src/main.rs
@@ -10,9 +10,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-dynamodb/Cargo.toml
+++ b/examples/http-dynamodb/Cargo.toml
@@ -20,6 +20,6 @@ aws-sdk-dynamodb = "0.21.0"
 aws-config = "0.51.0"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/http-dynamodb/src/main.rs
+++ b/examples/http-dynamodb/src/main.rs
@@ -59,9 +59,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-query-parameters/Cargo.toml
+++ b/examples/http-query-parameters/Cargo.toml
@@ -15,6 +15,6 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/http-query-parameters/src/main.rs
+++ b/examples/http-query-parameters/src/main.rs
@@ -27,9 +27,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-raw-path/Cargo.toml
+++ b/examples/http-raw-path/Cargo.toml
@@ -15,6 +15,6 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/http-raw-path/src/main.rs
+++ b/examples/http-raw-path/src/main.rs
@@ -7,9 +7,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-shared-resource/Cargo.toml
+++ b/examples/http-shared-resource/Cargo.toml
@@ -15,6 +15,6 @@ lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 

--- a/examples/http-shared-resource/src/main.rs
+++ b/examples/http-shared-resource/src/main.rs
@@ -17,9 +17,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/examples/http-tower-trace/Cargo.toml
+++ b/examples/http-tower-trace/Cargo.toml
@@ -16,4 +16,4 @@ lambda_runtime = "0.5.1"
 tokio = { version = "1", features = ["macros"] }
 tower-http = { version = "0.3.4", features = ["trace"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/examples/http-tower-trace/src/main.rs
+++ b/examples/http-tower-trace/src/main.rs
@@ -14,9 +14,6 @@ async fn main() -> Result<(), Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/lambda-http/README.md
+++ b/lambda-http/README.md
@@ -50,7 +50,6 @@ use serde_json::json;
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
-        .with_ansi(false)
         .without_time()
         .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
         .init();
@@ -89,7 +88,6 @@ use serde_json::json;
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
-        .with_ansi(false)
         .without_time()
         .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
         .init();
@@ -131,7 +129,6 @@ use serde_json::json;
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
-        .with_ansi(false)
         .without_time()
         .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
         .init();
@@ -191,7 +188,6 @@ use serde_json::json;
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
-        .with_ansi(false)
         .without_time()
         .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
         .init();

--- a/lambda-http/README.md
+++ b/lambda-http/README.md
@@ -51,7 +51,7 @@ use serde_json::json;
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .without_time()
-        .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
+        .with_max_level(tracing::Level::INFO)
         .init();
 
     run(service_fn(function_handler)).await
@@ -89,7 +89,7 @@ use serde_json::json;
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .without_time()
-        .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
+        .with_max_level(tracing::Level::INFO)
         .init();
 
     run(service_fn(function_handler)).await
@@ -130,7 +130,7 @@ use serde_json::json;
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .without_time()
-        .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
+        .with_max_level(tracing::Level::INFO)
         .init();
 
     run(service_fn(function_handler)).await
@@ -189,7 +189,7 @@ use serde_json::json;
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .without_time()
-        .with_max_level(tracing_subscriber::filter::LevelFilter::INFO)
+        .with_max_level(tracing::Level::INFO)
         .init();
 
     let config = aws_config::from_env()

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -19,4 +19,4 @@ lambda-extension = { path = "../lambda-extension" }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }

--- a/lambda-integration-tests/src/bin/extension-fn.rs
+++ b/lambda-integration-tests/src/bin/extension-fn.rs
@@ -20,9 +20,6 @@ async fn main() -> Result<(), Error> {
     // While `tracing` is used internally, `log` can be used as well if preferred.
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/lambda-integration-tests/src/bin/extension-trait.rs
+++ b/lambda-integration-tests/src/bin/extension-trait.rs
@@ -80,9 +80,6 @@ async fn main() -> Result<(), Error> {
     // While `tracing` is used internally, `log` can be used as well if preferred.
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/lambda-integration-tests/src/bin/http-fn.rs
+++ b/lambda-integration-tests/src/bin/http-fn.rs
@@ -17,9 +17,6 @@ async fn main() -> Result<(), Error> {
     // While `tracing` is used internally, `log` can be used as well if preferred.
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/lambda-integration-tests/src/bin/http-trait.rs
+++ b/lambda-integration-tests/src/bin/http-trait.rs
@@ -75,9 +75,6 @@ impl Service<Request> for MyHandler {
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/lambda-integration-tests/src/bin/logs-trait.rs
+++ b/lambda-integration-tests/src/bin/logs-trait.rs
@@ -64,9 +64,6 @@ impl Service<Vec<LambdaLog>> for MyLogsProcessor {
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/lambda-integration-tests/src/bin/runtime-fn.rs
+++ b/lambda-integration-tests/src/bin/runtime-fn.rs
@@ -28,9 +28,6 @@ async fn main() -> Result<(), Error> {
     // While `tracing` is used internally, `log` can be used as well if preferred.
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();

--- a/lambda-integration-tests/src/bin/runtime-trait.rs
+++ b/lambda-integration-tests/src/bin/runtime-trait.rs
@@ -84,9 +84,6 @@ impl Service<LambdaEvent<Request>> for MyHandler {
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::INFO)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
         // disabling time is handy because CloudWatch will add the ingestion time.
         .without_time()
         .init();


### PR DESCRIPTION
https://github.com/awslabs/aws-lambda-rust-runtime/discussions/672
as requested by [calavera](https://github.com/calavera)

Updated all code in repo to exclude the ansi feature of tracing-subscriber instead of building with .with_ansi(false)
Updated README.md to use tracing::Level::INFO instead of tracing_subscriber::filter::LevelFilter::INFO to match examples

By submitting this pull request

- [ x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ x] I confirm that I've made a best effort attempt to update all relevant documentation.