### PR TITLE
Add history section to the readme.

### DIFF
--- a/lambda-events/README.md
+++ b/lambda-events/README.md
@@ -27,6 +27,12 @@ This crate divides all Lambda Events into features named after the service that 
 cargo add aws_lambda_events --no-default-features --features apigw,alb
 ```
 
+## History
+
+The AWS Lambda Events crate was created by [Christian Legnitto](https://github.com/LegNeato). Without all his work and dedication, this project could have not been possible.
+
+In 2023, the AWS Lambda Event crate was moved into this repository to continue its support for all AWS customers that use Rust on AWS Lambda.
+
 [//]: # 'badges'
 [crate-image]: https://img.shields.io/crates/v/aws_lambda_events.svg
 [crate-link]: https://crates.io/crates/aws_lambda_events


### PR DESCRIPTION
*Description of changes:*

Add a section to the readme about the history of the AWS Lambda Events crate.

/cc @LegNeato 

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
