### PR TITLE
Make Kafka header values i8 instead of u8

### DIFF
--- a/lambda-events/src/event/kafka/mod.rs
+++ b/lambda-events/src/event/kafka/mod.rs
@@ -28,7 +28,7 @@ pub struct KafkaRecord {
     pub timestamp_type: Option<String>,
     pub key: Option<String>,
     pub value: Option<String>,
-    pub headers: Vec<HashMap<String, Vec<u8>>>,
+    pub headers: Vec<HashMap<String, Vec<i8>>>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
*Issue #, if available:*
#688 
*Description of changes:*
Change Kafka header value to i8 from u8.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
