### PR TITLE
Allow running handler with a callback

### DIFF
--- a/examples/basic-lambda-with-callback/Cargo.toml
+++ b/examples/basic-lambda-with-callback/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "basic-lambda-with-callback"
+version = "0.1.0"
+edition = "2021"
+
+
+# Use cargo-edit(https://github.com/killercup/cargo-edit#installation)
+# to manage dependencies.
+# Running `cargo add DEPENDENCY_NAME` will
+# add the latest version of a dependency to the list,
+# and it will keep the alphabetic ordering for you.
+
+[dependencies]
+lambda_runtime = { path = "../../lambda-runtime" }
+serde = "1.0.136"
+tokio = { version = "1", features = ["macros"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+tokio-test = "0.4.2"

--- a/examples/basic-lambda-with-callback/README.md
+++ b/examples/basic-lambda-with-callback/README.md
@@ -1,0 +1,11 @@
+# AWS Lambda Function example
+
+## Build & Deploy
+
+1. Install [cargo-lambda](https://github.com/cargo-lambda/cargo-lambda#installation)
+2. Build the function with `cargo lambda build --release`
+3. Deploy the function to AWS Lambda with `cargo lambda deploy --iam-role YOUR_ROLE`
+
+## Build for ARM 64
+
+Build the function with `cargo lambda build --release --arm64`

--- a/examples/basic-lambda-with-callback/src/main.rs
+++ b/examples/basic-lambda-with-callback/src/main.rs
@@ -1,0 +1,61 @@
+// This example requires the following input to succeed:
+// { "command": "do something" }
+use std::sync::Arc;
+
+use lambda_runtime::{service_fn, Error, LambdaEvent};
+use serde::{Deserialize, Serialize};
+
+/// This is also a made-up example. Requests come into the runtime as unicode
+/// strings in json format, which can map to any structure that implements `serde::Deserialize`
+/// The runtime pays no attention to the contents of the request payload.
+#[derive(Deserialize)]
+struct Request {
+    command: String,
+}
+
+/// This is a made-up example of what a response structure may look like.
+/// There is no restriction on what it can be. The runtime requires responses
+/// to be serialized into json. The runtime pays no attention
+/// to the contents of the response payload.
+#[derive(Serialize)]
+struct Response {
+    req_id: String,
+    msg: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // required to enable CloudWatch error logging by the runtime
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        // disabling time is handy because CloudWatch will add the ingestion time.
+        .without_time()
+        .init();
+
+    // Since the Lambda is fozen in between invocations you can use this callback
+    // to e.g. flush traces/logs/metrics
+    let cleanup = Arc::new(|| {
+        println!("Callback called!");
+    });
+
+
+    let func = service_fn(my_handler);
+    lambda_runtime::run_with_callback(func, cleanup).await?;
+    Ok(())
+}
+
+pub(crate) async fn my_handler(event: LambdaEvent<Request>) -> Result<Response, Error> {
+    // extract some useful info from the request
+    let command = event.payload.command;
+
+    // prepare the response
+    let resp = Response {
+        req_id: event.context.request_id,
+        msg: format!("Command {} executed.", command),
+    };
+
+    // return `Response` (it will be serialized to JSON automatically by the runtime)
+    Ok(resp)
+}


### PR DESCRIPTION
## What?
This is a pretty naive approach that allows the end user to supply a callback that will be invoked once a single event loop has been finished.

## Why?
Because currently there is no good way(that I know of) to flush logs/traces/metrics. By having a callback that is called after all event handling is finished allows the end user to do a cleanup at the end of each lambda invocation.

See #691 for further context