### PR TITLE
Add event definitions for CloudFormation custom resources

### DIFF
--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -42,6 +42,7 @@ default = [
   "autoscaling",
   "chime_bot",
   "clientvpn",
+  "cloudformation",
   "cloudwatch_events",
   "cloudwatch_logs",
   "code_commit",
@@ -81,6 +82,7 @@ appsync = []
 autoscaling = ["chrono"]
 chime_bot = ["chrono"]
 clientvpn = []
+cloudformation = []
 cloudwatch_events = ["chrono"]
 cloudwatch_logs = ["flate2"]
 code_commit = ["chrono"]

--- a/lambda-events/src/event/cloudformation/mod.rs
+++ b/lambda-events/src/event/cloudformation/mod.rs
@@ -1,0 +1,134 @@
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "RequestType")]
+pub enum CloudFormationCustomResourceRequest<P1 = Value, P2 = Value>
+where
+    P1: DeserializeOwned + Serialize,
+    P2: DeserializeOwned + Serialize,
+{
+    #[serde(bound = "")]
+    Create(CreateRequest<P2>),
+    #[serde(bound = "")]
+    Update(UpdateRequest<P1, P2>),
+    #[serde(bound = "")]
+    Delete(DeleteRequest<P2>),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[serde(deny_unknown_fields)]
+pub struct CreateRequest<P2 = Value>
+where
+    P2: DeserializeOwned + Serialize,
+{
+    #[serde(default)]
+    pub service_token: Option<String>,
+    pub request_id: String,
+    #[serde(rename = "ResponseURL")]
+    pub response_url: String,
+    pub stack_id: String,
+    pub resource_type: String,
+    pub logical_resource_id: String,
+    #[serde(bound = "")]
+    pub resource_properties: P2,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[serde(deny_unknown_fields)]
+pub struct UpdateRequest<P1 = Value, P2 = Value>
+where
+    P1: DeserializeOwned + Serialize,
+    P2: DeserializeOwned + Serialize,
+{
+    #[serde(default)]
+    pub service_token: Option<String>,
+    pub request_id: String,
+    #[serde(rename = "ResponseURL")]
+    pub response_url: String,
+    pub stack_id: String,
+    pub resource_type: String,
+    pub logical_resource_id: String,
+    pub physical_resource_id: String,
+    #[serde(bound = "")]
+    pub resource_properties: P2,
+    #[serde(bound = "")]
+    pub old_resource_properties: P1,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+#[serde(deny_unknown_fields)]
+pub struct DeleteRequest<P2 = Value>
+where
+    P2: DeserializeOwned + Serialize,
+{
+    #[serde(default)]
+    pub service_token: Option<String>,
+    pub request_id: String,
+    #[serde(rename = "ResponseURL")]
+    pub response_url: String,
+    pub stack_id: String,
+    pub resource_type: String,
+    pub logical_resource_id: String,
+    pub physical_resource_id: String,
+    #[serde(bound = "")]
+    pub resource_properties: P2,
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use super::CloudFormationCustomResourceRequest::*;
+    use super::*;
+
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+    #[serde(rename_all = "PascalCase")]
+    #[serde(deny_unknown_fields)]
+    struct TestProperties {
+        key_1: String,
+        key_2: Vec<String>,
+        key_3: HashMap<String, String>,
+    }
+
+    type TestRequest = CloudFormationCustomResourceRequest<TestProperties, TestProperties>;
+
+    #[test]
+    fn example_cloudformation_custom_resource_create_request() {
+        let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-create-request.json");
+        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+
+        let Create(_) = parsed else { panic!("expected Create request") };
+
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn example_cloudformation_custom_resource_update_request() {
+        let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-update-request.json");
+        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+
+        let Update(_) = parsed else { panic!("expected Update request") };
+
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn example_cloudformation_custom_resource_delete_request() {
+        let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-delete-request.json");
+        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+
+        let Delete(_) = parsed else { panic!("expected Delete request") };
+
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+}

--- a/lambda-events/src/event/mod.rs
+++ b/lambda-events/src/event/mod.rs
@@ -25,6 +25,10 @@ pub mod chime_bot;
 #[cfg(feature = "clientvpn")]
 pub mod clientvpn;
 
+/// AWS Lambda event definitions for cloudformation.
+#[cfg(feature = "cloudformation")]
+pub mod cloudformation;
+
 /// CloudWatch Events payload
 #[cfg(feature = "cloudwatch_events")]
 pub mod cloudwatch_events;

--- a/lambda-events/src/fixtures/example-cloudformation-custom-resource-create-request.json
+++ b/lambda-events/src/fixtures/example-cloudformation-custom-resource-create-request.json
@@ -1,0 +1,14 @@
+{
+  "ServiceToken": "arn:aws:lambda:eu-west-2:123456789012:function:custom-resource-handler",
+  "RequestType" : "Create",
+  "RequestId" : "82304eb2-bdda-469f-a33b-a3f1406d0a52",
+  "ResponseURL": "https://cr-response-bucket.s3.us-east-1.amazonaws.com/cr-response-key?sig-params=sig-values",
+  "StackId" : "arn:aws:cloudformation:us-east-1:123456789012:stack/stack-name/16580499-7622-4a9c-b32f-4eba35da93da",
+  "ResourceType" : "Custom::MyCustomResourceType",
+  "LogicalResourceId" : "CustomResource",
+  "ResourceProperties" : {
+     "Key1" : "string",
+     "Key2" : [ "list" ],
+     "Key3" : { "Key4" : "map" }
+  }
+}

--- a/lambda-events/src/fixtures/example-cloudformation-custom-resource-delete-request.json
+++ b/lambda-events/src/fixtures/example-cloudformation-custom-resource-delete-request.json
@@ -1,0 +1,15 @@
+{
+  "ServiceToken": "arn:aws:lambda:eu-west-2:123456789012:function:custom-resource-handler",
+  "RequestType" : "Delete",
+  "RequestId" : "ef70561d-d4ba-42a4-801b-33ad88dafc37",
+  "ResponseURL": "https://cr-response-bucket.s3.us-east-1.amazonaws.com/cr-response-key?sig-params=sig-values",
+  "StackId" : "arn:aws:cloudformation:us-east-1:123456789012:stack/stack-name/16580499-7622-4a9c-b32f-4eba35da93da",
+  "ResourceType" : "Custom::MyCustomResourceType",
+  "LogicalResourceId" : "CustomResource",
+  "PhysicalResourceId" : "custom-resource-f4bd5382-3de3-4caf-b7ad-1be06b899647",
+  "ResourceProperties" : {
+     "Key1" : "string",
+     "Key2" : [ "list" ],
+     "Key3" : { "Key4" : "map" }
+  }
+}

--- a/lambda-events/src/fixtures/example-cloudformation-custom-resource-update-request.json
+++ b/lambda-events/src/fixtures/example-cloudformation-custom-resource-update-request.json
@@ -1,0 +1,20 @@
+{
+  "ServiceToken": "arn:aws:lambda:eu-west-2:123456789012:function:custom-resource-handler",
+  "RequestType" : "Update",
+  "RequestId" : "49347ca5-c603-44e5-a34b-10cf1854a887",
+  "ResponseURL": "https://cr-response-bucket.s3.us-east-1.amazonaws.com/cr-response-key?sig-params=sig-values",
+  "StackId" : "arn:aws:cloudformation:us-east-1:123456789012:stack/stack-name/16580499-7622-4a9c-b32f-4eba35da93da",
+  "ResourceType" : "Custom::MyCustomResourceType",
+  "LogicalResourceId" : "CustomResource",
+  "PhysicalResourceId" : "custom-resource-f4bd5382-3de3-4caf-b7ad-1be06b899647",
+  "ResourceProperties" : {
+     "Key1" : "new-string",
+     "Key2" : [ "new-list" ],
+     "Key3" : { "Key4" : "new-map" }
+  },
+  "OldResourceProperties" : {
+     "Key1" : "string",
+     "Key2" : [ "list" ],
+     "Key3" : { "Key4" : "map" }
+  }
+}

--- a/lambda-events/src/lib.rs
+++ b/lambda-events/src/lib.rs
@@ -20,6 +20,7 @@ pub use event::activemq;
 /// AWS Lambda event definitions for alb.
 #[cfg(feature = "alb")]
 pub use event::alb;
+
 /// AWS Lambda event definitions for apigw.
 #[cfg(feature = "apigw")]
 pub use event::apigw;
@@ -39,6 +40,10 @@ pub use event::chime_bot;
 /// AWS Lambda event definitions for clientvpn.
 #[cfg(feature = "clientvpn")]
 pub use event::clientvpn;
+
+/// AWS Lambda event definitions for cloudformation
+#[cfg(feature = "cloudformation")]
+pub use event::cloudformation;
 
 /// CloudWatch Events payload
 #[cfg(feature = "cloudwatch_events")]


### PR DESCRIPTION
*Issue #, if available:*
Related to #680 - see below

*Description of changes:*
This PR adds event definitions for CloudFormation [custom resource request objects](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html). Requests are either a [Create](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requesttypes-create.html), [Update](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requesttypes-update.html), or [Delete](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requesttypes-update.html) event, implemented as enum variants with internally tagged representation.

Note that, in addition to the fields documented in the links above, in practice CloudFormation sends a `ServiceToken` field in every request. Since this isn't documented I've encoded it as an `Option<String>` with `#[serde(default)]`, so deserialisation will tolerate it being missing, but I can change this if desired.

---

This is intended as an initial building block of a framework for implementing Lambda custom resource handlers, of the kind requested in #680. These work by invoking a Lambda with one of the above event types, all of which include an S3 presigned URL to which a response must be posted. Failing to post a response can result in long delays, so tools to make it easy to send a response, and a fallback mechanism to send a failure response if the Lambda is about to time out, are desirable.

I'd appreciate feedback on whether further PRs to add this functionality (probably in a `lambda_cfn` crate) would be appreciated, but either way I think the event definitions are a useful addition.

By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
