### PR TITLE
Use compile_error if no http features are enabled

### DIFF
--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -1,8 +1,4 @@
 use crate::request::LambdaRequest;
-use aws_lambda_events::{
-    alb::AlbTargetGroupRequest,
-    apigw::{ApiGatewayProxyRequest, ApiGatewayV2httpRequest, ApiGatewayWebsocketProxyRequest},
-};
 use serde::{de::Error, Deserialize};
 
 const ERROR_CONTEXT: &str = "this function expects a JSON payload from Amazon API Gateway, Amazon Elastic Load Balancer, or AWS Lambda Function URLs, but the data doesn't match any of those services' events";
@@ -17,28 +13,29 @@ impl<'de> Deserialize<'de> for LambdaRequest {
             Err(err) => return Err(err),
         };
         #[cfg(feature = "apigw_rest")]
-        if let Ok(res) =
-            ApiGatewayProxyRequest::deserialize(serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content))
-        {
+        if let Ok(res) = aws_lambda_events::apigw::ApiGatewayProxyRequest::deserialize(
+            serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
+        ) {
             return Ok(LambdaRequest::ApiGatewayV1(res));
         }
         #[cfg(feature = "apigw_http")]
-        if let Ok(res) = ApiGatewayV2httpRequest::deserialize(
+        if let Ok(res) = aws_lambda_events::apigw::ApiGatewayV2httpRequest::deserialize(
             serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
         ) {
             return Ok(LambdaRequest::ApiGatewayV2(res));
         }
         #[cfg(feature = "alb")]
         if let Ok(res) =
-            AlbTargetGroupRequest::deserialize(serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content))
+            aws_lambda_events::alb::AlbTargetGroupRequest::deserialize(serde::__private::de::ContentRefDeserializer::<
+                D::Error,
+            >::new(&content))
         {
             return Ok(LambdaRequest::Alb(res));
         }
         #[cfg(feature = "apigw_websockets")]
-        if let Ok(res) = ApiGatewayWebsocketProxyRequest::deserialize(serde::__private::de::ContentRefDeserializer::<
-            D::Error,
-        >::new(&content))
-        {
+        if let Ok(res) = aws_lambda_events::apigw::ApiGatewayWebsocketProxyRequest::deserialize(
+            serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
+        ) {
             return Ok(LambdaRequest::WebSocket(res));
         }
 

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -114,6 +114,13 @@ impl LambdaResponse {
                 headers: headers.clone(),
                 multi_value_headers: headers,
             }),
+            #[cfg(not(any(
+                feature = "apigw_rest",
+                feature = "apigw_http",
+                feature = "alb",
+                feature = "apigw_websockets"
+            )))]
+            _ => compile_error!("Either feature `apigw_rest`, `apigw_http`, `alb`, or `apigw_websockets` must be enabled for the `lambda-http` crate."),
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

Fixes #697 

*Description of changes:*

- Provide help so people know that they have to enable a feature.
- Put imports in place so conditional compilation doesn't try to compile unnecessary code.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.

/cc @jdisanti
