### PR TITLE
Remove cfg(test) on with_stage_variables

### DIFF
--- a/lambda-http/src/ext/extensions.rs
+++ b/lambda-http/src/ext/extensions.rs
@@ -108,10 +108,9 @@ pub trait RequestExt {
     /// These will always be `None` for ALB triggered requests.
     fn stage_variables_ref(&self) -> Option<&QueryMap>;
 
-    /// Configures instance with stage variables under `#[cfg(test)]` configurations
+    /// Configures instance with stage variables
     ///
     /// This is intended for use in mock testing contexts.
-    #[cfg(test)]
     fn with_stage_variables<V>(self, variables: V) -> Self
     where
         V: Into<QueryMap>;
@@ -216,7 +215,6 @@ impl RequestExt for http::Extensions {
             .and_then(|StageVariables(vars)| if vars.is_empty() { None } else { Some(vars) })
     }
 
-    #[cfg(test)]
     fn with_stage_variables<V>(self, variables: V) -> Self
     where
         V: Into<QueryMap>,
@@ -318,7 +316,6 @@ impl RequestExt for Parts {
         self.extensions.stage_variables_ref()
     }
 
-    #[cfg(test)]
     fn with_stage_variables<V>(self, variables: V) -> Self
     where
         V: Into<QueryMap>,
@@ -420,7 +417,6 @@ impl<B> RequestExt for http::Request<B> {
         self.extensions().stage_variables_ref()
     }
 
-    #[cfg(test)]
     fn with_stage_variables<V>(self, variables: V) -> Self
     where
         V: Into<QueryMap>,


### PR DESCRIPTION
*Issue #, if available:*
#712 

*Description of changes:*
Tis PRt removes the cf(test) constraint from the `with_stage_variables` method. constraint.

None of the other with_ methods are constrained to test-only, although this method did have a specific comment indicating test-only, so there may have been a reason.

By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
