### PR TITLE
Fixed media type suffix detection

### DIFF
--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -282,20 +282,9 @@ where
         }
 
         for suffix in TEXT_ENCODING_SUFFIXES {
-            let parts = content_type.trim().split(';');
-
-            let mut media_type = String::new();
-            for part in parts {
-                let trimmed_part = part.trim();
-
-                // Check if the part is a media type
-                if trimmed_part.contains('/') {
-                    media_type = trimmed_part.to_string();
-                    break;
-                }
-            }
-
-            if media_type.ends_with(suffix) {
+            let mut parts = content_type.trim().split(';');
+            let mime_type = parts.next().unwrap_or_default();
+            if mime_type.ends_with(suffix) {
                 return convert_to_text(self, content_type);
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/awslabs/aws-lambda-web-adapter/issues/265 

*Description of changes:*

Content-Type value contains media type and optional parameters (such as charset, boundary, filename, and Content-Disposition). So we need to extract the media type part and compare its suffix. Otherwise, the response body will be treated as binary. 


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
