### PR TITLE
Fix: Missing userNotFound field in "create/verify auth challenge" Cognito user pool events

### DIFF
--- a/lambda-events/src/event/cognito/mod.rs
+++ b/lambda-events/src/event/cognito/mod.rs
@@ -343,6 +343,8 @@ pub struct CognitoEventUserPoolsCreateAuthChallengeRequest {
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     pub client_metadata: HashMap<String, String>,
+    #[serde(default)]
+    pub user_not_found: bool,
 }
 
 /// `CognitoEventUserPoolsCreateAuthChallengeResponse` defines create auth challenge response parameters
@@ -389,6 +391,8 @@ where
     #[serde(deserialize_with = "deserialize_lambda_map")]
     #[serde(default)]
     pub client_metadata: HashMap<String, String>,
+    #[serde(default)]
+    pub user_not_found: bool,
 }
 
 /// `CognitoEventUserPoolsVerifyAuthChallengeResponse` defines verify auth challenge response parameters
@@ -484,6 +488,19 @@ mod test {
 
     #[test]
     #[cfg(feature = "cognito")]
+    fn example_cognito_event_userpools_create_auth_challenge_user_not_found() {
+        let data = include_bytes!("../../fixtures/example-cognito-event-userpools-create-auth-challenge-user-not-found.json");
+        let parsed: CognitoEventUserPoolsCreateAuthChallenge = serde_json::from_slice(data).unwrap();
+
+        assert!(parsed.request.user_not_found);
+
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsCreateAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_custommessage() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-custommessage.json");
         let parsed: CognitoEventUserPoolsCustomMessage = serde_json::from_slice(data).unwrap();
@@ -512,6 +529,21 @@ mod test {
 
         assert!(!parsed.response.fail_authentication);
         assert!(!parsed.response.issue_tokens);
+
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "cognito")]
+    fn example_cognito_event_userpools_define_auth_challenge_user_not_found() {
+        let data = include_bytes!(
+            "../../fixtures/example-cognito-event-userpools-define-auth-challenge-user-not-found.json"
+        );
+        let parsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(data).unwrap();
+
+        assert!(parsed.request.user_not_found);
 
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
@@ -607,6 +639,19 @@ mod test {
         let parsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(data).unwrap();
 
         assert!(!parsed.response.answer_correct);
+
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "cognito")]
+    fn example_cognito_event_userpools_verify_auth_challenge_user_not_found() {
+        let data = include_bytes!("../../fixtures/example-cognito-event-userpools-verify-auth-challenge-user-not-found.json");
+        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(data).unwrap();
+
+        assert!(parsed.request.user_not_found);
 
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-create-auth-challenge-user-not-found.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-create-auth-challenge-user-not-found.json
@@ -27,7 +27,7 @@
     "clientMetadata": {
       "exampleMetadataKey": "example metadata value"
     },
-    "userNotFound": false
+    "userNotFound": true
   },
   "response": {
     "publicChallengeParameters": {

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-define-auth-challenge-user-not-found.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-define-auth-challenge-user-not-found.json
@@ -7,7 +7,7 @@
     "awsSdkVersion": "aws-sdk-unknown-unknown",
     "clientId": "<clientId>"
   },
-  "triggerSource": "CreateAuthChallenge_Authentication",
+  "triggerSource": "DefineAuthChallenge_Authentication",
   "request": {
     "userAttributes": {
       "sub": "<sub>",
@@ -16,7 +16,6 @@
       "cognito:phone_number_alias": "+12223334455",
       "phone_number": "+12223334455"
     },
-    "challengeName": "CUSTOM_CHALLENGE",
     "session": [
       {
         "challengeName": "PASSWORD_VERIFIER",
@@ -27,15 +26,11 @@
     "clientMetadata": {
       "exampleMetadataKey": "example metadata value"
     },
-    "userNotFound": false
+    "userNotFound": true
   },
   "response": {
-    "publicChallengeParameters": {
-      "a": "b"
-    },
-    "privateChallengeParameters": {
-      "c": "d"
-    },
-    "challengeMetadata": "challengeMetadata"
+    "challengeName": "challengeName",
+    "issueTokens": true,
+    "failAuthentication": true
   }
 }

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-verify-auth-challenge-optional-answer-correct.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-verify-auth-challenge-optional-answer-correct.json
@@ -22,7 +22,8 @@
     "challengeAnswer": "123xxxx",
     "clientMetadata": {
       "exampleMetadataKey": "example metadata value"
-    }
+    },
+    "userNotFound": false
   },
   "response": {
   }

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-verify-auth-challenge-user-not-found.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-verify-auth-challenge-user-not-found.json
@@ -7,7 +7,7 @@
     "awsSdkVersion": "aws-sdk-unknown-unknown",
     "clientId": "<clientId>"
   },
-  "triggerSource": "CreateAuthChallenge_Authentication",
+  "triggerSource": "VerifyAuthChallengeResponse_Authentication",
   "request": {
     "userAttributes": {
       "sub": "<sub>",
@@ -16,26 +16,16 @@
       "cognito:phone_number_alias": "+12223334455",
       "phone_number": "+12223334455"
     },
-    "challengeName": "CUSTOM_CHALLENGE",
-    "session": [
-      {
-        "challengeName": "PASSWORD_VERIFIER",
-        "challengeResult": true,
-        "challengeMetadata": "metadata"
-      }
-    ],
+    "privateChallengeParameters": {
+      "secret": "11122233"
+    },
+    "challengeAnswer": "123xxxx",
     "clientMetadata": {
       "exampleMetadataKey": "example metadata value"
     },
-    "userNotFound": false
+    "userNotFound": true
   },
   "response": {
-    "publicChallengeParameters": {
-      "a": "b"
-    },
-    "privateChallengeParameters": {
-      "c": "d"
-    },
-    "challengeMetadata": "challengeMetadata"
+    "answerCorrect": true
   }
 }

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-verify-auth-challenge.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-verify-auth-challenge.json
@@ -22,7 +22,8 @@
     "challengeAnswer": "123xxxx",
     "clientMetadata": {
       "exampleMetadataKey": "example metadata value"
-    }
+    },
+    "userNotFound": false
   },
   "response": {
     "answerCorrect": true


### PR DESCRIPTION
*Issue*
- fixes #718

*Description of changes:*
- Add `user_not_found` field to:
    - `CognitoEventUserPoolsCreateAuthChallengeRequest`
    - `CognitoEventUserPoolsVerifyAuthChallengeRequest`
- Add test cases where `user_not_found` becomes `true` for:
    - `CognitoEventUserPoolsDefineAuthChallengeRequest`
    - `CognitoEventUserPoolsCreateAuthChallengeRequest`
    - `CognitoEventUserPoolsVerifyAuthChallengeRequest`

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
