### PR TITLE
Add an advanced SQS multiple functions with shared data example

### DIFF
--- a/examples/advanced-sqs-multiple-functions-shared-data/Cargo.toml
+++ b/examples/advanced-sqs-multiple-functions-shared-data/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+
+members = [
+    "producer",
+    "consumer",
+    "pizza_lib",
+]
+
+[profile.release]
+opt-level = 'z'
+lto = true
+codegen-units = 1
+panic = 'abort'

--- a/examples/advanced-sqs-multiple-functions-shared-data/README.md
+++ b/examples/advanced-sqs-multiple-functions-shared-data/README.md
@@ -4,7 +4,12 @@
 
 1. Install [cargo-lambda](https://github.com/cargo-lambda/cargo-lambda#installation)
 2. Build the function with `cargo lambda build --release`
-3. Deploy the function to AWS Lambda with `cargo lambda deploy --iam-role YOUR_ROLE`
+4. Make sure to edit the QUEUE_URL env variable in producer/Cargo.toml
+3. Deploy boths functions to AWS Lambda with
+
+`cargo lambda deploy consumer --iam-role YOUR_ROLE`
+
+`cargo lambda deploy producer --iam-role YOUR_ROLE`
 
 ## Build for ARM 64
 
@@ -14,9 +19,10 @@ Build the function with `cargo lambda build --release --arm64`
 
 You can use aws-cli to create an event source mapping:
 
-`aws lambda create-event-source-mapping \
+```bash
+aws lambda create-event-source-mapping \
 --function-name consumer \
 --region <region> \
 --event-source-arn <your-SQS-queue-ARN> \
---batch-size 1`
-
+--batch-size 1
+```

--- a/examples/advanced-sqs-multiple-functions-shared-data/README.md
+++ b/examples/advanced-sqs-multiple-functions-shared-data/README.md
@@ -1,0 +1,22 @@
+# AWS Lambda Function example
+
+## Build & Deploy
+
+1. Install [cargo-lambda](https://github.com/cargo-lambda/cargo-lambda#installation)
+2. Build the function with `cargo lambda build --release`
+3. Deploy the function to AWS Lambda with `cargo lambda deploy --iam-role YOUR_ROLE`
+
+## Build for ARM 64
+
+Build the function with `cargo lambda build --release --arm64`
+
+## Add the SQS trigger to the consumer function
+
+You can use aws-cli to create an event source mapping:
+
+`aws lambda create-event-source-mapping \
+--function-name consumer \
+--region <region> \
+--event-source-arn <your-SQS-queue-ARN> \
+--batch-size 1`
+

--- a/examples/advanced-sqs-multiple-functions-shared-data/consumer/Cargo.toml
+++ b/examples/advanced-sqs-multiple-functions-shared-data/consumer/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "consumer"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+#tracing
+tracing = "0.1.40"
+tracing-subscriber = "0.3.17"
+
+#aws depdencies
+aws-sdk-config = "0.35.0"
+aws-sdk-sqs = "0.35.0"
+aws_lambda_events = { version = "0.11.1", features = ["sqs"], default-features = false }
+
+#lambda runtime
+lambda_runtime = "0.8.1"
+tokio = { version = "1", features = ["macros"] }
+
+#shared lib
+pizza_lib = { path = "../pizza_lib" }

--- a/examples/advanced-sqs-multiple-functions-shared-data/consumer/src/main.rs
+++ b/examples/advanced-sqs-multiple-functions-shared-data/consumer/src/main.rs
@@ -1,0 +1,24 @@
+use aws_lambda_events::event::sqs::SqsEventObj;
+use lambda_runtime::{service_fn, Error, LambdaEvent};
+use pizza_lib::Pizza;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .with_ansi(false)
+        .without_time()
+        .init();
+    let func = service_fn(func);
+    lambda_runtime::run(func).await?;
+    Ok(())
+}
+
+async fn func(event: LambdaEvent<SqsEventObj<Pizza>>) -> Result<(), Error> {
+    for record in event.payload.records.iter() {
+        let pizza = &record.body;
+        println!("Pizza name: {} with toppings: {:?}", pizza.name, pizza.toppings);
+    }
+    Ok(())
+}

--- a/examples/advanced-sqs-multiple-functions-shared-data/pizza_lib/Cargo.toml
+++ b/examples/advanced-sqs-multiple-functions-shared-data/pizza_lib/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "pizza_lib"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0.191", features = ["derive"] }

--- a/examples/advanced-sqs-multiple-functions-shared-data/pizza_lib/src/lib.rs
+++ b/examples/advanced-sqs-multiple-functions-shared-data/pizza_lib/src/lib.rs
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Pizza {
+    pub name: String,
+    pub toppings: Vec<String>,
+}

--- a/examples/advanced-sqs-multiple-functions-shared-data/producer/Cargo.toml
+++ b/examples/advanced-sqs-multiple-functions-shared-data/producer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "producer"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.lambda.deploy]
+env = { "QUEUE_URL" = "https://changeMe" } 
+
+[dependencies]
+#tracing
+tracing = "0.1.40"
+tracing-subscriber = "0.3.17"
+
+#aws dependencies
+aws-config = "0.57.1"
+aws-sdk-config = "0.35.0"
+aws-sdk-sqs = "0.35.0"
+
+#lambda runtime
+lambda_runtime = "0.8.1"
+serde_json = "1.0.108"
+tokio = { version = "1", features = ["macros"] }
+
+#shared lib
+pizza_lib = { path = "../pizza_lib" }

--- a/examples/advanced-sqs-multiple-functions-shared-data/producer/src/main.rs
+++ b/examples/advanced-sqs-multiple-functions-shared-data/producer/src/main.rs
@@ -1,0 +1,45 @@
+use lambda_runtime::{service_fn, Error, LambdaEvent};
+use pizza_lib::Pizza;
+use serde_json::{json, Value};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .with_ansi(false)
+        .without_time()
+        .init();
+    let func = service_fn(func);
+    lambda_runtime::run(func).await?;
+    Ok(())
+}
+
+async fn func(_: LambdaEvent<Value>) -> Result<(), Error> {
+    // read the queue url from the environment
+    let queue_url = std::env::var("QUEUE_URL").expect("could not read QUEUE_URL");
+
+    // let's create our pizza
+    let message = Pizza {
+        name: "margherita".to_string(),
+        toppings: vec![
+            "San Marzano Tomatoes".to_string(),
+            "Fresh Mozzarella".to_string(),
+            "Basil".to_string(),
+        ],
+    };
+
+    // create our SQS client
+    let config = aws_config::from_env().load().await;
+
+    // send our message to SQS
+    let client = aws_sdk_sqs::Client::new(&config);
+    client
+        .send_message()
+        .queue_url(queue_url)
+        .message_body(json!(message).to_string())
+        .send()
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-lambda-rust-runtime/issues/228


*Description of changes:*
Add an example using Cargo worskpace feature to:
- be able to have multiple (here 2) functions in the same project
- be able to share code (here a pizza Struct)
- use this shared Struck to validate a SQS message type

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
