### PR TITLE
Fix transitive dependency version of lambda_runtime.

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.8.2"
+version = "0.8.3"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -29,7 +29,7 @@ futures = "0.3"
 http = "0.2"
 http-body = "0.4"
 hyper = "0.14"
-lambda_runtime = { path = "../lambda-runtime", version = "0.8" }
+lambda_runtime = { path = "../lambda-runtime", version = "0.8.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"


### PR DESCRIPTION
*Issue #, if available:*

Fixes #722 

*Description of changes:*

The newest version of Lambda HTTP requires at least the newest version of the Lambda Runtime.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
