### PR TITLE
Use base64 0.21.

### DIFF
--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -43,5 +43,5 @@ tokio-stream = "0.1.2"
 lambda_runtime_api_client = { version = "0.8", path = "../lambda-runtime-api-client" }
 serde_path_to_error = "0.1.11"
 http-serde = "1.1.3"
-base64 = "0.20.0"
+base64 = "0.21.0"
 http-body = "0.4"


### PR DESCRIPTION
Seems like an oversight when this code was added. 0.21 is already in use elsewhere in this repository.