### PR TITLE
add provided.al2023 integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ You can find the resulting zip file in `target/lambda/YOUR_PACKAGE/bootstrap.zip
 $ aws lambda create-function --function-name rustTest \
   --handler bootstrap \
   --zip-file fileb://./target/lambda/basic/bootstrap.zip \
-  --runtime provided.al2 \ # Change this to provided.al if you would like to use Amazon Linux 1.
+  --runtime provided.al2023 \ # Change this to provided.al2 if you would like to use Amazon Linux 2 (or to provided.al for Amazon Linux 1).
   --role arn:aws:iam::XXXXXXXXXXXXX:role/your_lambda_execution_role \
   --environment Variables={RUST_BACKTRACE=1} \
   --tracing-config Mode=Active
@@ -202,7 +202,7 @@ Resources:
       MemorySize: 128
       Architectures: ["arm64"]
       Handler: bootstrap
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Timeout: 5
       CodeUri: target/lambda/basic/
 

--- a/lambda-integration-tests/template.yaml
+++ b/lambda-integration-tests/template.yaml
@@ -8,6 +8,17 @@ Globals:
     Timeout: 5
 
 Resources:
+  # Rust function using runtime_fn running on AL2023
+  RuntimeFnAl2023:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/runtime-fn/
+      Runtime: provided.al2023
+      Layers:
+        - !Ref LogsTrait
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
   # Rust function using runtime_fn running on AL2
   RuntimeFnAl2:
     Type: AWS::Serverless::Function
@@ -25,6 +36,17 @@ Resources:
     Properties:
       CodeUri: ../build/runtime-fn/
       Runtime: provided
+      Layers:
+        - !Ref LogsTrait
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
+  # Rust function using a Service implementation running on AL2023
+  RuntimeTraitAl2023:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/runtime-trait/
+      Runtime: provided.al2023
       Layers:
         - !Ref LogsTrait
         - !Ref ExtensionFn
@@ -52,6 +74,38 @@ Resources:
         - !Ref ExtensionFn
         - !Ref ExtensionTrait
   
+  # Rust function using lambda_http::service_fn running on AL2023
+  HttpFnAl2023:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/http-fn/
+      Runtime: provided.al2023
+      Events:
+        ApiGet:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /al2/get
+        ApiPost:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /al2/post
+        ApiV2Get:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /al2/get
+        ApiV2Post:
+          Type: HttpApi
+          Properties:
+            Method: POST
+            Path: /al2/post
+      Layers:
+        - !Ref LogsTrait
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
   # Rust function using lambda_http::service_fn running on AL2
   HttpFnAl2:
     Type: AWS::Serverless::Function
@@ -84,6 +138,38 @@ Resources:
         - !Ref ExtensionFn
         - !Ref ExtensionTrait
   
+  # Rust function using lambda_http with Service running on AL2023
+  HttpTraitAl2023:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../build/http-trait/
+      Runtime: provided.al2023
+      Events:
+        ApiGet:
+          Type: Api
+          Properties:
+            Method: GET
+            Path: /al2-trait/get
+        ApiPost:
+          Type: Api
+          Properties:
+            Method: POST
+            Path: /al2-trait/post
+        ApiV2Get:
+          Type: HttpApi
+          Properties:
+            Method: GET
+            Path: /al2-trait/get
+        ApiV2Post:
+          Type: HttpApi
+          Properties:
+            Method: POST
+            Path: /al2-trait/post
+      Layers:
+        - !Ref LogsTrait
+        - !Ref ExtensionFn
+        - !Ref ExtensionTrait
+
   # Rust function using lambda_http with Service running on AL2
   HttpTraitAl2:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
*Description of changes:*
- Add `provided.al2023` integration tests 
https://aws.amazon.com/fr/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/
- Update README.md

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
