### PR TITLE
Added LogBuffering validation.

### DIFF
--- a/lambda-extension/src/extension.rs
+++ b/lambda-extension/src/extension.rs
@@ -225,6 +225,12 @@ where
 
         if let Some(mut log_processor) = self.logs_processor {
             trace!("Log processor found");
+
+            let log_buffering_validation_result = validate_buffering_configuration(self.log_buffering);
+            if log_buffering_validation_result.is_err() {
+                return log_buffering_validation_result;
+            }
+
             // Spawn task to run processor
             let addr = SocketAddr::from(([0, 0, 0, 0], self.log_port_number));
             let make_service = service_fn(move |_socket: &AddrStream| {
@@ -261,6 +267,12 @@ where
 
         if let Some(mut telemetry_processor) = self.telemetry_processor {
             trace!("Telemetry processor found");
+
+            let telemetry_buffering_validation_result = validate_buffering_configuration(self.telemetry_buffering);
+            if telemetry_buffering_validation_result.is_err() {
+                return telemetry_buffering_validation_result;
+            }
+
             // Spawn task to run processor
             let addr = SocketAddr::from(([0, 0, 0, 0], self.telemetry_port_number));
             let make_service = service_fn(move |_socket: &AddrStream| {


### PR DESCRIPTION
The validation will provide a meaningful error in case the `LogBuffering` is not configured according to [telemetry-api-buffering](https://docs.aws.amazon.com/lambda/latest/dg/telemetry-api.html\#telemetry-api-buffering) docs.

*Issue #, if available:*

*Description of changes:*
Updated the `LogBuffering` struct in. Added validation and unit tests. Also update the `run` method of the extension to utilize the validation and return an error if applicable.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
