### PR TITLE
Fix typo in LogBuffering struct documentation

### DIFF
--- a/lambda-extension/src/logs.rs
+++ b/lambda-extension/src/logs.rs
@@ -111,7 +111,7 @@ pub struct LogPlatformReportMetrics {
 }
 
 /// Log buffering configuration.
-/// Allows Lambda to buffer logs before deliverying them to a subscriber.
+/// Allows Lambda to buffer logs before delivering them to a subscriber.
 #[derive(Debug, Serialize, Copy, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LogBuffering {


### PR DESCRIPTION
While looking at the docs for [LogBuffering](https://docs.rs/lambda-extension/0.8.1/lambda_extension/struct.LambdaLog.html) I found a small typo. "deliverying" should be "delivering". 

Looking forward to working more with this repo!

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
