### PR TITLE
Draft: update hyper/http

### DIFF
--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -17,9 +17,9 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.21"
-http = { version = "0.2", optional = true }
-http-body = { version = "0.4", optional = true }
-http-serde = { version = "^1", optional = true }
+http = { version = "1.0", optional = true }
+http-body = { version = "1.0", optional = true }
+http-serde = { version = "2.0", optional = true }
 serde = { version = "^1", features = ["derive"] }
 serde_with = { version = "^3", features = ["json"], optional = true }
 serde_json = "^1"

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -17,13 +17,23 @@ readme = "README.md"
 async-stream = "0.3"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-http = "0.2"
-hyper = { version = "0.14.20", features = ["http1", "client", "server", "stream", "runtime"] }
+http = "1.0"
+hyper = { version = "0.14.20", features = [
+    "http1",
+    "client",
+    "server",
+    "stream",
+    "runtime",
+] }
 lambda_runtime_api_client = { version = "0.8", path = "../lambda-runtime-api-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "^1"
 tracing = { version = "0.1", features = ["log"] }
-tokio = { version = "1.0", features = ["macros", "io-util", "sync", "rt-multi-thread"] }
+tokio = { version = "1.0", features = [
+    "macros",
+    "io-util",
+    "sync",
+    "rt-multi-thread",
+] }
 tokio-stream = "0.1.2"
 tower = { version = "0.4", features = ["make", "util"] }
-

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -26,9 +26,9 @@ alb = []
 base64 = "0.21"
 bytes = "1.4"
 futures = "0.3"
-http = "0.2"
-http-body = "0.4"
-hyper = "0.14"
+http = "1.0"
+http-body = "1.0"
+hyper = "1.0"
 lambda_runtime = { path = "../lambda-runtime", version = "0.8.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.8.0"
 edition = "2021"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
-    "Harold Sun <sunhua@amazon.com>"
+    "Harold Sun <sunhua@amazon.com>",
 ]
 description = "AWS Lambda Runtime interaction API"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ keywords = ["AWS", "Lambda", "API"]
 readme = "README.md"
 
 [dependencies]
-http = "0.2"
-hyper = { version = "0.14.20", features = ["http1", "client", "stream", "tcp"] }
+http = "1.0"
+hyper = { version = "1.0", features = ["http1", "client"] }
 tower-service = "0.3"
 tokio = { version = "1.0", features = ["io-util"] }

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -35,7 +35,7 @@ futures = "0.3"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "^1"
 bytes = "1.0"
-http = "0.2"
+http = "1.0"
 async-stream = "0.3"
 tracing = { version = "0.1.37", features = ["log"] }
 tower = { version = "0.4", features = ["util"] }


### PR DESCRIPTION
*Issue #, if available:*
#737 

*Description of changes:*
Updates a good bit of #737 -
Hit a snag, though. I don't fully understand `hyper::Client` and how it worked, likewise for `Connector`s, and it seems they were removed with the update to 1.0.

This means attention is needed in `lambda-runtime-api-client/lib.rs`.
Perhaps @calavera is able to update that file?

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
