### PR TITLE
change some properties to optional value

### DIFF
--- a/lambda-events/src/event/bedrock_agent_runtime/mod.rs
+++ b/lambda-events/src/event/bedrock_agent_runtime/mod.rs
@@ -20,9 +20,11 @@ pub struct AgentEvent {
     /// The method of the API operation, as defined in the OpenAPI schema.
     pub http_method: String,
     /// Contains a list of objects. Each object contains the name, type, and value of a parameter in the API operation, as defined in the OpenAPI schema.
-    pub parameters: Vec<Parameter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Vec<Parameter>>,
     /// Contains the request body and its properties, as defined in the OpenAPI schema.
-    pub request_body: RequestBody,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_body: Option<RequestBody>,
     /// Contains session attributes and their values.
     pub session_attributes: HashMap<String, String>,
     /// Contains prompt attributes and their values.
@@ -86,6 +88,24 @@ mod tests {
     #[cfg(feature = "bedrock-agent-runtime")]
     fn example_bedrock_agent__runtime_event() {
         let data = include!("../../fixtures/example-bedrock-agent-runtime-event.json");
+        let parsed: AgentEvent = serde_json::from_str(&data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+    #[test]
+    #[cfg(feature = "bedrock-agent-runtime")]
+    fn example_bedrock_agent_runtime_event_without_parameters() {
+        let data = include!("../../fixtures/example-bedrock-agent-runtime-event-without-parameters.json");
+        let parsed: AgentEvent = serde_json::from_str(&data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+    #[test]
+    #[cfg(feature = "bedrock-agent-runtime")]
+    fn example_bedrock_agent_runtime_event_without_request_body() {
+        let data = include!("../../fixtures/example-bedrock-agent-runtime-event-without-request-body.json");
         let parsed: AgentEvent = serde_json::from_str(&data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();

--- a/lambda-events/src/fixtures/example-bedrock-agent-runtime-event-without-parameters.json
+++ b/lambda-events/src/fixtures/example-bedrock-agent-runtime-event-without-parameters.json
@@ -1,0 +1,33 @@
+{
+  "messageVersion": "1.0",
+  "agent": {
+    "name": "AgentName",
+    "id": "AgentID",
+    "alias": "AgentAlias",
+    "version": "AgentVersion"
+  },
+  "inputText": "InputText",
+  "sessionId": "SessionID",
+  "actionGroup": "ActionGroup",
+  "apiPath": "/api/path",
+  "httpMethod": "POST",
+  "requestBody": {
+    "content": {
+      "application/json": {
+        "properties": [
+          {
+            "name": "prop1",
+            "type": "string",
+            "value": "value1"
+          }
+        ]
+      }
+    }
+  },
+  "sessionAttributes": {
+    "attr1": "value1"
+  },
+  "promptSessionAttributes": {
+    "promptAttr1": "value1"
+  }
+}

--- a/lambda-events/src/fixtures/example-bedrock-agent-runtime-event-without-request-body.json
+++ b/lambda-events/src/fixtures/example-bedrock-agent-runtime-event-without-request-body.json
@@ -1,0 +1,27 @@
+{
+  "messageVersion": "1.0",
+  "agent": {
+    "name": "AgentName",
+    "id": "AgentID",
+    "alias": "AgentAlias",
+    "version": "AgentVersion"
+  },
+  "inputText": "InputText",
+  "sessionId": "SessionID",
+  "actionGroup": "ActionGroup",
+  "apiPath": "/api/path",
+  "httpMethod": "POST",
+  "parameters": [
+    {
+      "name": "param1",
+      "type": "string",
+      "value": "value1"
+    }
+  ],
+  "sessionAttributes": {
+    "attr1": "value1"
+  },
+  "promptSessionAttributes": {
+    "promptAttr1": "value1"
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When I actually created an Event and started it from a Lambda function, I noticed that some parameters were Nullable.

Agents for Amazon Bedrock takes into account the HTTP Method of the configured schema and sets values for the properties.
So I noticed that, for example, if the GET method is configured in the schema, there is usually no Request body.

I don't know if this is correct because the schema page of the document does not specify whether it is Nullable or not, but I think it is safest to set parameters and request_body to Optional.

If anyone knows the details, I would appreciate it if you could let me know.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
