### PR TITLE
Add session_issuer field to SessionContext

### DIFF
--- a/lambda-events/src/event/s3/object_lambda.rs
+++ b/lambda-events/src/event/s3/object_lambda.rs
@@ -102,6 +102,7 @@ pub struct UserIdentity {
 #[serde(rename_all = "camelCase")]
 pub struct SessionContext {
     pub attributes: HashMap<String, String>,
+    pub session_issuer: Option<SessionIssuer>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

add session_issuer field according to this document:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-writing-lambda.html#olap-getobject-response


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
