### PR TITLE
Remove `#[serde(deny_unknown_fields)]`

### DIFF
--- a/lambda-events/src/event/alb/mod.rs
+++ b/lambda-events/src/event/alb/mod.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 /// `AlbTargetGroupRequest` contains data originating from the ALB Lambda target group integration
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
 pub struct AlbTargetGroupRequest {
     #[serde(with = "http_method")]
     pub http_method: Method,

--- a/lambda-events/src/event/apigw/mod.rs
+++ b/lambda-events/src/event/apigw/mod.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 /// `ApiGatewayProxyRequest` contains data coming from the API Gateway proxy
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
 pub struct ApiGatewayProxyRequest<T1 = Value>
 where
     T1: DeserializeOwned,
@@ -120,7 +119,6 @@ where
 /// `ApiGatewayV2httpRequest` contains data coming from the new HTTP API Gateway
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
 pub struct ApiGatewayV2httpRequest {
     #[serde(default, rename = "type")]
     pub kind: Option<String>,
@@ -335,7 +333,6 @@ pub struct ApiGatewayRequestIdentity {
 /// `ApiGatewayWebsocketProxyRequest` contains data coming from the API Gateway proxy
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
 pub struct ApiGatewayWebsocketProxyRequest<T1 = Value, T2 = Value>
 where
     T1: DeserializeOwned,

--- a/lambda-events/src/event/cloudformation/mod.rs
+++ b/lambda-events/src/event/cloudformation/mod.rs
@@ -18,7 +18,6 @@ where
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
-#[serde(deny_unknown_fields)]
 pub struct CreateRequest<P2 = Value>
 where
     P2: DeserializeOwned + Serialize,
@@ -37,7 +36,6 @@ where
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
-#[serde(deny_unknown_fields)]
 pub struct UpdateRequest<P1 = Value, P2 = Value>
 where
     P1: DeserializeOwned + Serialize,
@@ -60,7 +58,6 @@ where
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
-#[serde(deny_unknown_fields)]
 pub struct DeleteRequest<P2 = Value>
 where
     P2: DeserializeOwned + Serialize,
@@ -87,7 +84,6 @@ mod test {
 
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     #[serde(rename_all = "PascalCase")]
-    #[serde(deny_unknown_fields)]
     struct TestProperties {
         key_1: String,
         key_2: Vec<String>,

--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_error() {
-        let err = serde_json::from_str::<LambdaRequest>("{\"command\": \"hi\"}").unwrap_err();
+        let err = serde_json::from_str::<LambdaRequest>("{\"body\": {}}").unwrap_err();
 
         assert_eq!(ERROR_CONTEXT, err.to_string());
     }


### PR DESCRIPTION
Adding new fields to request payloads is typically not considered to be a breaking change, but using `#[serde(deny_unknown_fields)]` would cause all Lambda functions to start failing immediately in production if a new feature were deployed that added a new request field.

Fixes #750.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
