### PR TITLE
Implement Serialize for lambda telemetry

### DIFF
--- a/lambda-extension/src/telemetry.rs
+++ b/lambda-extension/src/telemetry.rs
@@ -37,8 +37,10 @@ pub enum LambdaTelemetryRecord {
         /// Phase of initialisation
         phase: InitPhase,
         /// Lambda runtime version
+        #[serde(skip_serializing_if = "Option::is_none")]
         runtime_version: Option<String>,
         /// Lambda runtime version ARN
+        #[serde(skip_serializing_if = "Option::is_none")]
         runtime_version_arn: Option<String>,
     },
     /// Platform init runtime done record
@@ -47,10 +49,12 @@ pub enum LambdaTelemetryRecord {
         /// Type of initialization
         initialization_type: InitType,
         /// Phase of initialisation
+        #[serde(skip_serializing_if = "Option::is_none")]
         phase: Option<InitPhase>,
         /// Status of initalization
         status: Status,
         /// When the status = failure, the error_type describes what kind of error occurred
+        #[serde(skip_serializing_if = "Option::is_none")]
         error_type: Option<String>,
         /// Spans
         #[serde(default)]
@@ -75,8 +79,10 @@ pub enum LambdaTelemetryRecord {
         /// Request identifier
         request_id: String,
         /// Version of the Lambda function
+        #[serde(skip_serializing_if = "Option::is_none")]
         version: Option<String>,
         /// Trace Context
+        #[serde(skip_serializing_if = "Option::is_none")]
         tracing: Option<TraceContext>,
     },
     /// Record marking the completion of an invocation
@@ -87,13 +93,16 @@ pub enum LambdaTelemetryRecord {
         /// Status of the invocation
         status: Status,
         /// When unsuccessful, the error_type describes what kind of error occurred
+        #[serde(skip_serializing_if = "Option::is_none")]
         error_type: Option<String>,
         /// Metrics corresponding to the runtime
+        #[serde(skip_serializing_if = "Option::is_none")]
         metrics: Option<RuntimeDoneMetrics>,
         /// Spans
         #[serde(default)]
         spans: Vec<Span>,
         /// Trace Context
+        #[serde(skip_serializing_if = "Option::is_none")]
         tracing: Option<TraceContext>,
     },
     /// Platfor report record
@@ -104,6 +113,7 @@ pub enum LambdaTelemetryRecord {
         /// Status of the invocation
         status: Status,
         /// When unsuccessful, the error_type describes what kind of error occurred
+        #[serde(skip_serializing_if = "Option::is_none")]
         error_type: Option<String>,
         /// Metrics
         metrics: ReportMetrics,
@@ -111,6 +121,7 @@ pub enum LambdaTelemetryRecord {
         #[serde(default)]
         spans: Vec<Span>,
         /// Trace Context
+        #[serde(skip_serializing_if = "Option::is_none")]
         tracing: Option<TraceContext>,
     },
 
@@ -237,10 +248,10 @@ pub struct ReportMetrics {
     #[serde(rename = "maxMemoryUsedMB")]
     pub max_memory_used_mb: u64,
     /// Init duration in case of a cold start
-    #[serde(default = "Option::default")]
+    #[serde(default = "Option::default", skip_serializing_if = "Option::is_none")]
     pub init_duration_ms: Option<f64>,
     /// Restore duration in milliseconds
-    #[serde(default = "Option::default")]
+    #[serde(default = "Option::default", skip_serializing_if = "Option::is_none")]
     pub restore_duration_ms: Option<f64>,
 }
 

--- a/lambda-extension/src/telemetry.rs
+++ b/lambda-extension/src/telemetry.rs
@@ -301,9 +301,41 @@ where
 
     Ok(hyper::Response::new(Body::empty()))
 }
+#[cfg(test)]
+mod se_tests {
+    use chrono::TimeZone;
+
+    use super::*;
+    macro_rules! serialize_tests {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (input, expected) = $value;
+                    let actual = serde_json::to_string(&input).expect("unable to serialize");
+                    println!("Input: {:?}", input);
+                    println!("Expected: {:?}", expected);
+                    println!("Actual: {:?}", actual);
+
+                    assert!(actual == expected);
+                }
+            )*
+        }
+    }
+
+    serialize_tests! {
+        function: (
+            LambdaTelemetry {
+                time: Utc.with_ymd_and_hms(2023, 11, 28, 12, 0, 9).unwrap(),
+                record: LambdaTelemetryRecord::Function("hello world".to_string()),
+            },
+            r#"{"time":"2023-11-28T12:00:09Z","type":"function","record":"hello world"}"#,
+        ),
+    }
+}
 
 #[cfg(test)]
-mod tests {
+mod de_tests {
     use super::*;
     use chrono::{Duration, TimeZone};
 
@@ -320,6 +352,7 @@ mod tests {
             )*
         }
     }
+
 
     deserialize_tests! {
         // function

--- a/lambda-extension/src/telemetry.rs
+++ b/lambda-extension/src/telemetry.rs
@@ -3,14 +3,14 @@ use http::{Request, Response};
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use lambda_runtime_api_client::body::Body;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{boxed::Box, fmt, sync::Arc};
 use tokio::sync::Mutex;
 use tower::Service;
 use tracing::{error, trace};
 
 /// Payload received from the Telemetry API
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct LambdaTelemetry {
     /// Time when the telemetry was generated
     pub time: DateTime<Utc>,
@@ -20,7 +20,7 @@ pub struct LambdaTelemetry {
 }
 
 /// Record in a LambdaTelemetry entry
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type", content = "record", rename_all = "lowercase")]
 pub enum LambdaTelemetryRecord {
     /// Function log records
@@ -147,7 +147,7 @@ pub enum LambdaTelemetryRecord {
 }
 
 /// Type of Initialization
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum InitType {
     /// Initialised on demand
@@ -159,7 +159,7 @@ pub enum InitType {
 }
 
 /// Phase in which initialization occurs
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum InitPhase {
     /// Initialization phase
@@ -169,7 +169,7 @@ pub enum InitPhase {
 }
 
 /// Status of invocation/initialization
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Status {
     /// Success
@@ -183,7 +183,7 @@ pub enum Status {
 }
 
 /// Span
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Span {
     /// Duration of the span
@@ -195,7 +195,7 @@ pub struct Span {
 }
 
 /// Tracing Context
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct TraceContext {
     /// Span ID
@@ -207,7 +207,7 @@ pub struct TraceContext {
 }
 
 /// Type of tracing
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub enum TracingType {
     /// Amazon trace type
     #[serde(rename = "X-Amzn-Trace-Id")]
@@ -215,7 +215,7 @@ pub enum TracingType {
 }
 
 ///Init report metrics
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct InitReportMetrics {
     /// Duration of initialization
@@ -223,7 +223,7 @@ pub struct InitReportMetrics {
 }
 
 /// Report metrics
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ReportMetrics {
     /// Duration in milliseconds
@@ -245,7 +245,7 @@ pub struct ReportMetrics {
 }
 
 /// Runtime done metrics
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeDoneMetrics {
     /// Duration in milliseconds


### PR DESCRIPTION
Issue #757 Lambda Extension - Implement Serialize for LambdaTelemetryRecord

Description of changes:
This PR implements the Serialize trait for the [LambdaTelemetry](https://docs.rs/lambda-extension/latest/lambda_extension/struct.LambdaTelemetry.html) struct, as well as its fields, most importantly the [LambdaTelemetryRecord](https://docs.rs/lambda-extension/latest/lambda_extension/enum.LambdaTelemetryRecord.html) enum and its component variants.

I have made a couple choices here and I'm not sure that they are necessarily the best, I'm happy to hear any comments on them:
- On variants of LambdaTelemetryRecord, I have skipped serialization on fields which are `Option::None`, as opposed to serializing them to `null`
- I have included empty arrays of spans on those variants that have spans

By submitting this pull request:

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
