### PR TITLE
Fix parsing failure in CloudWatchAlarmStateValue.

### DIFF
--- a/lambda-events/src/event/cloudwatch_alarms/mod.rs
+++ b/lambda-events/src/event/cloudwatch_alarms/mod.rs
@@ -69,7 +69,8 @@ where
     R: DeserializeOwned,
     R: Serialize,
 {
-    pub value: String,
+    #[serde(default)]
+    pub value: CloudWatchAlarmStateValue,
     pub reason: String,
     #[serde(default, bound = "")]
     pub reason_data: Option<R>,
@@ -129,7 +130,7 @@ pub enum CloudWatchAlarmStateValue {
     #[default]
     Ok,
     Alarm,
-    InsuficientData,
+    InsufficientData,
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When I changed CloudWatchAlarmData.value type from String to CloudWatchAlarmStateValue, `example_cloudwatch_alarm_metric` test failed due to typo, so I fixed it.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
