### PR TITLE
Add Event Definition for CognitoEventUserPoolsPreTokenGenV2

### DIFF
--- a/lambda-events/src/event/cognito/mod.rs
+++ b/lambda-events/src/event/cognito/mod.rs
@@ -213,6 +213,65 @@ pub struct CognitoEventUserPoolsPreTokenGenResponse {
     pub claims_override_details: Option<ClaimsOverrideDetails>,
 }
 
+/// `CognitoEventUserPoolsPreTokenGenV2` is sent by AWS Cognito User Pools when a user attempts to retrieve
+/// credentials, allowing a Lambda to perform insert, suppress or override claims.  This is the Version 2 Payload
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CognitoEventUserPoolsPreTokenGenV2 {
+    #[serde(rename = "CognitoEventUserPoolsHeader")]
+    #[serde(flatten)]
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub request: CognitoEventUserPoolsPreTokenGenRequestV2,
+    pub response: CognitoEventUserPoolsPreTokenGenResponseV2,
+}
+
+/// `CognitoEventUserPoolsPreTokenGenRequestV2` contains request portion of PreTokenGenV2 event
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CognitoEventUserPoolsPreTokenGenRequestV2 {
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    pub user_attributes: HashMap<String, String>,
+    pub group_configuration: GroupConfiguration,
+    #[serde(deserialize_with = "deserialize_lambda_map")]
+    #[serde(default)]
+    pub client_metadata: HashMap<String, String>,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CognitoEventUserPoolsPreTokenGenResponseV2 {
+    pub claims_and_scope_override_details: Option<ClaimsAndScopeOverrideDetailsV2>,
+}
+
+/// `ClaimsAndScopeOverrideDetailsV2` allows lambda to add, suppress or override claims in the token
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaimsAndScopeOverrideDetailsV2 {
+    pub group_override_details: GroupConfiguration,
+    pub id_token_generation: Option<CognitoIdTokenGenerationV2>,
+    pub access_token_generation: Option<CognitoAccessTokenGenerationV2>,
+}
+
+/// `CognitoIdTokenGenerationV2` allows lambda to customize the ID Token before generation
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CognitoIdTokenGenerationV2 {
+    pub claims_to_add_or_override: HashMap<String, String>,
+    pub claims_to_suppress: Vec<String>,
+}
+
+/// `CognitoAccessTokenGenerationV2` allows lambda to customize the Access Token before generation
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CognitoAccessTokenGenerationV2 {
+    pub claims_to_add_or_override: HashMap<String, String>,
+    pub claims_to_suppress: Vec<String>,
+    pub scopes_to_add: Vec<String>,
+    pub scopes_to_suppress: Vec<String>,
+}
+
 /// `CognitoEventUserPoolsPostAuthenticationRequest` contains the request portion of a PostAuthentication event
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -610,11 +669,31 @@ mod test {
 
     #[test]
     #[cfg(feature = "cognito")]
+    fn example_cognito_event_userpools_pretokengen_v2_incoming() {
+        let data = include_bytes!("../../fixtures/example-cognito-event-userpools-pretokengen-v2-incoming.json");
+        let parsed: CognitoEventUserPoolsPreTokenGenV2 = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreTokenGenV2 = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_pretokengen() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-pretokengen.json");
         let parsed: CognitoEventUserPoolsPreTokenGen = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: CognitoEventUserPoolsPreTokenGen = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "cognito")]
+    fn example_cognito_event_userpools_v2_pretokengen() {
+        let data = include_bytes!("../../fixtures/example-cognito-event-userpools-pretokengen-v2.json");
+        let parsed: CognitoEventUserPoolsPreTokenGenV2 = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreTokenGenV2 = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-v2-incoming.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-v2-incoming.json
@@ -1,0 +1,33 @@
+{
+    "version": "1",
+    "triggerSource": "PreTokenGen",
+    "region": "region",
+    "userPoolId": "userPoolId",
+    "userName": "userName",
+    "callerContext": {
+        "awsSdkVersion": "calling aws sdk with version",
+        "clientId": "apps client id"
+    },
+    "request": {
+        "userAttributes": {
+            "email": "email",
+            "phone_number": "phone_number"
+        },
+        "scopes": ["scope-1", "scope-2"],
+        "groupConfiguration": {
+            "groupsToOverride": ["group-A", "group-B", "group-C"],
+            "iamRolesToOverride": [
+                "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+                "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+                "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+            ],
+            "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
+        },
+        "clientMetadata": {
+            "exampleMetadataKey": "example metadata value"
+        }
+    },
+    "response": {
+        "claimsOverrideDetails": null
+    }
+}

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-v2.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-v2.json
@@ -1,0 +1,58 @@
+{
+    "version": "1",
+    "triggerSource": "PreTokenGen",
+    "region": "region",
+    "userPoolId": "userPoolId",
+    "userName": "userName",
+    "callerContext": {
+        "awsSdkVersion": "calling aws sdk with version",
+        "clientId": "apps client id"
+    },
+    "request": {
+        "userAttributes": {
+            "email": "email",
+            "phone_number": "phone_number"
+        },
+        "scopes": ["scope-1", "scope-2"],
+        "groupConfiguration": {
+            "groupsToOverride": ["group-A", "group-B", "group-C"],
+            "iamRolesToOverride": [
+                "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+                "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+                "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+            ],
+            "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
+        },
+        "clientMetadata": {
+            "exampleMetadataKey": "example metadata value"
+        }
+    },
+    "response": {
+        "claimsAndScopeOverrideDetails": {
+            "idTokenGeneration": {
+                "claimsToAddOrOverride": {
+                    "string": "string"
+                },
+                "claimsToSuppress": ["string", "string"]
+            },
+            "accessTokenGeneration": {
+                "claimsToAddOrOverride": {
+                    "attribute_key2": "attribute_value2",
+                    "attribute_key": "attribute_value"
+                },
+                "claimsToSuppress": ["email", "phone"],
+                "scopesToAdd": ["scope-B", "scope-B"],
+                "scopesToSuppress": ["scope-C", "scope-D"]
+            },
+            "groupOverrideDetails": {
+                "groupsToOverride": ["group-A", "group-B", "group-C"],
+                "iamRolesToOverride": [
+                    "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+                    "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+                    "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+                ],
+                "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Pull request in support of #763 

With the Cognito release to support customizing Access tokens described [here](https://aws.amazon.com/about-aws/whats-new/2023/12/amazon-cognito-user-pools-customize-access-tokens/), a new Payload definition is required.  The structs in this PR support the [described request and response](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) in the AWS Documentation.  The V2 payloads allow for customization of the Access Token in addition to the ID Token which was already supported

No changes were made to the original structs.  

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
