### PR TITLE
Add missing fields for suppressor alarm

### DIFF
--- a/lambda-events/src/event/cloudwatch_alarms/mod.rs
+++ b/lambda-events/src/event/cloudwatch_alarms/mod.rs
@@ -301,4 +301,19 @@ mod test {
         let reparsed: CloudWatchCompositeAlarm = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
+
+    #[test]
+    #[cfg(feature = "cloudwatch_alarms")]
+    fn example_cloudwatch_alarm_composite_with_suppressor_alarm() {
+        let data = include_bytes!("../../fixtures/example-cloudwatch-alarm-composite-with-suppressor-alarm.json");
+        let parsed: CloudWatchCompositeAlarm = serde_json::from_slice(data).unwrap();
+        let state = parsed.alarm_data.state.clone().unwrap();
+        assert_eq!("WaitPeriod", state.actions_suppressed_by.unwrap());
+        assert_eq!("Actions suppressed by WaitPeriod", state.actions_suppressed_reason.unwrap());
+
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CloudWatchCompositeAlarm = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
 }

--- a/lambda-events/src/event/cloudwatch_alarms/mod.rs
+++ b/lambda-events/src/event/cloudwatch_alarms/mod.rs
@@ -75,6 +75,8 @@ where
     #[serde(default, bound = "")]
     pub reason_data: Option<R>,
     pub timestamp: DateTime<Utc>,
+    pub actions_suppressed_by: Option<String>,
+    pub actions_suppressed_reason: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/lambda-events/src/fixtures/example-cloudwatch-alarm-composite-with-suppressor-alarm.json
+++ b/lambda-events/src/fixtures/example-cloudwatch-alarm-composite-with-suppressor-alarm.json
@@ -1,0 +1,35 @@
+{
+    "version": "0",
+    "id": "d3dfc86d-384d-24c8-0345-9f7986db0b80",
+    "detail-type": "CloudWatch Alarm State Change",
+    "source": "aws.cloudwatch",
+    "account": "123456789012",
+    "time": "2022-07-22T15:57:45Z",
+    "region": "us-east-1",
+    "resources": [
+        "arn:aws:cloudwatch:us-east-1:123456789012:alarm:ServiceAggregatedAlarm"
+    ],
+    "alarmData": {
+        "alarmName": "ServiceAggregatedAlarm",
+        "state": {
+            "actionsSuppressedBy": "WaitPeriod",
+            "actionsSuppressedReason": "Actions suppressed by WaitPeriod",
+            "value": "ALARM",
+            "reason": "arn:aws:cloudwatch:us-east-1:123456789012:alarm:SuppressionDemo.EventBridge.FirstChild transitioned to ALARM at Friday 22 July, 2022 15:57:45 UTC",
+            "reasonData": "{\"triggeringAlarms\":[{\"arn\":\"arn:aws:cloudwatch:us-east-1:123456789012:alarm:ServerCpuTooHigh\",\"state\":{\"value\":\"ALARM\",\"timestamp\":\"2022-07-22T15:57:45.394+0000\"}}]}",
+            "timestamp": "2022-07-22T15:57:45.394+0000"
+        },
+        "previousState": {
+            "value": "OK",
+            "reason": "arn:aws:cloudwatch:us-east-1:123456789012:alarm:SuppressionDemo.EventBridge.Main was created and its alarm rule evaluates to OK",
+            "reasonData": "{\"triggeringAlarms\":[{\"arn\":\"arn:aws:cloudwatch:us-east-1:123456789012:alarm:TotalNetworkTrafficTooHigh\",\"state\":{\"value\":\"OK\",\"timestamp\":\"2022-07-14T16:28:57.770+0000\"}},{\"arn\":\"arn:aws:cloudwatch:us-east-1:123456789012:alarm:ServerCpuTooHigh\",\"state\":{\"value\":\"OK\",\"timestamp\":\"2022-07-14T16:28:54.191+0000\"}}]}",
+            "timestamp": "2022-07-22T15:56:14.552+0000"
+        },
+        "configuration": {
+            "alarmRule": "ALARM(ServerCpuTooHigh) OR ALARM(TotalNetworkTrafficTooHigh)",
+            "actionsSuppressor": "ServiceMaintenanceAlarm",
+            "actionsSuppressorWaitPeriod": 120,
+            "actionsSuppressorExtensionPeriod": 180
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`actionsSuppressedBy` and `actionsSuppressedReason` are in [the example json file](https://github.com/awslabs/aws-lambda-rust-runtime/blob/main/lambda-events/src/fixtures/example-cloudwatch-alarm-composite.json#L20).

example-cloudwatch-alarm-composite-with-suppressor-alarm.json
is from [this document](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch-and-eventbridge.html).

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
