### PR TITLE
Add events pass-through feature in lambda-http crate

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -21,6 +21,7 @@ apigw_rest = []
 apigw_http = []
 apigw_websockets = []
 alb = []
+pass_through = []
 
 [dependencies]
 base64 = { workspace = true }
@@ -37,7 +38,7 @@ mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 serde_urlencoded = "0.7"
 tokio-stream = "0.1.2"
 url = "2.2"

--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -1,42 +1,47 @@
 use crate::request::LambdaRequest;
+#[cfg(feature = "alb")]
+use aws_lambda_events::alb::AlbTargetGroupRequest;
+#[cfg(feature = "apigw_rest")]
+use aws_lambda_events::apigw::ApiGatewayProxyRequest;
+#[cfg(feature = "apigw_http")]
+use aws_lambda_events::apigw::ApiGatewayV2httpRequest;
+#[cfg(feature = "apigw_websockets")]
+use aws_lambda_events::apigw::ApiGatewayWebsocketProxyRequest;
 use serde::{de::Error, Deserialize};
+use serde_json::value::RawValue;
 
 const ERROR_CONTEXT: &str = "this function expects a JSON payload from Amazon API Gateway, Amazon Elastic Load Balancer, or AWS Lambda Function URLs, but the data doesn't match any of those services' events";
+
+#[cfg(feature = "pass_through")]
+const PASS_THROUGH_ENABLED: bool = true;
 
 impl<'de> Deserialize<'de> for LambdaRequest {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        let content = match serde::__private::de::Content::deserialize(deserializer) {
-            Ok(content) => content,
-            Err(err) => return Err(err),
-        };
+        let raw_value: Box<RawValue> = Box::deserialize(deserializer)?;
+        let data = raw_value.get();
+
         #[cfg(feature = "apigw_rest")]
-        if let Ok(res) = aws_lambda_events::apigw::ApiGatewayProxyRequest::deserialize(
-            serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
-        ) {
+        if let Ok(res) = serde_json::from_str::<ApiGatewayProxyRequest>(data) {
             return Ok(LambdaRequest::ApiGatewayV1(res));
         }
         #[cfg(feature = "apigw_http")]
-        if let Ok(res) = aws_lambda_events::apigw::ApiGatewayV2httpRequest::deserialize(
-            serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
-        ) {
+        if let Ok(res) = serde_json::from_str::<ApiGatewayV2httpRequest>(data) {
             return Ok(LambdaRequest::ApiGatewayV2(res));
         }
         #[cfg(feature = "alb")]
-        if let Ok(res) =
-            aws_lambda_events::alb::AlbTargetGroupRequest::deserialize(serde::__private::de::ContentRefDeserializer::<
-                D::Error,
-            >::new(&content))
-        {
+        if let Ok(res) = serde_json::from_str::<AlbTargetGroupRequest>(data) {
             return Ok(LambdaRequest::Alb(res));
         }
         #[cfg(feature = "apigw_websockets")]
-        if let Ok(res) = aws_lambda_events::apigw::ApiGatewayWebsocketProxyRequest::deserialize(
-            serde::__private::de::ContentRefDeserializer::<D::Error>::new(&content),
-        ) {
+        if let Ok(res) = serde_json::from_str::<ApiGatewayWebsocketProxyRequest>(data) {
             return Ok(LambdaRequest::WebSocket(res));
+        }
+        #[cfg(feature = "pass_through")]
+        if PASS_THROUGH_ENABLED == true {
+            return Ok(LambdaRequest::PassThrough(data.to_string()));
         }
 
         Err(Error::custom(ERROR_CONTEXT))


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/awslabs/aws-lambda-web-adapter/issues/216 and https://github.com/awslabs/aws-lambda-web-adapter/issues/317 

*Description of changes:*

To support addtional event triggers in lambda web adapter, such as SQS or Bedrock Agents, we need to pass-through events from those triggers. This PR adds a `pass-through` feature to `lambda-http` crate. When enabled, the events payloads will be translated to a HTTP post request (event payloads in the HTTP body). 

This PR also improves the deserializer.rs. It uses `RawValue` to get the data from `deserializer`, not relay on private serde_json functions. 


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
