### PR TITLE
Release lambda-http 0.9.1

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",


### PR DESCRIPTION
Bump lambda-http to v0.9.1

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
