### PR TITLE
Release lambda-http 0.9.2

### DIFF
--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_lambda_events"
-version = "0.13.0"
+version = "0.13.1"
 description = "AWS Lambda event definitions"
 authors = [
   "Christian Legnitto <christian@legnitto.com>",

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.9.1"
+version = "0.9.2"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -45,7 +45,7 @@ url = "2.2"
 
 [dependencies.aws_lambda_events]
 path = "../lambda-events"
-version = "0.13"
+version = "0.13.1"
 default-features = false
 features = ["alb", "apigw"]
 


### PR DESCRIPTION
Release lambda-http 0.9.2 to use lambda-events 0.13.1. 

This PR should be merged after PR #789 

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
