### PR TITLE
chore: a more polite closed issue message

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -11,7 +11,5 @@ jobs:
             # These inputs are both required
             repo-token: "${{ secrets.GITHUB_TOKEN }}"
             message: |
-                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
-                     Comments on closed issues are hard for the maintainers of this repository to see. 
-                     If you need more assistance, please open a new issue that references this one. 
-                     If you wish to keep having a conversation with other community members under this issue feel free to do so.
+              This issue is now closed. Comments on closed issues are hard for our team to see. 
+              If you need more assistance, please either tag a team member or open a new issue that references this one.


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
In the AWS SDKs, we received some customer feedback that the closed issue message is too loud and too full of emoji. You use a similar message. This message is slightly more polite. If you disagree, please disregard this PR.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
