### PR TITLE
Lambda http/optimize deserialization

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -38,7 +38,7 @@ mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
+serde_json = { version = "1.0" }
 serde_urlencoded = "0.7"
 tokio-stream = "0.1.2"
 url = "2.2"

--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -8,9 +8,50 @@ use aws_lambda_events::apigw::ApiGatewayV2httpRequest;
 #[cfg(feature = "apigw_websockets")]
 use aws_lambda_events::apigw::ApiGatewayWebsocketProxyRequest;
 use serde::{de::Error, Deserialize};
-use serde_json::value::RawValue;
+use serde_json::value::Value;
 
 const ERROR_CONTEXT: &str = "this function expects a JSON payload from Amazon API Gateway, Amazon Elastic Load Balancer, or AWS Lambda Function URLs, but the data doesn't match any of those services' events";
+
+//
+// This enum duplicates the purpose of "request::RequestOrigin" - i.e. the
+// "from_value" could be implemented on that enum. But in the interests of keeping
+// all serde references in this module, we use a separate private enum. 
+//
+enum RequestType {
+    #[cfg(feature = "apigw_rest")]
+    ApiGatewayProxyRequest,
+    #[cfg(feature = "apigw_http")]
+    ApiGatewayV2httpRequest,
+    #[cfg(feature = "alb")]
+    AlbTargetGroupRequest,
+    #[cfg(feature = "apigw_websockets")]
+    ApiGatewayWebsocketProxyRequest
+}
+
+impl RequestType {
+    //
+    // The type determinants were established by what errors Serde deserialization threw
+    // in the previous implementation. Therefore we are being a little arbitrary here but
+    // this should significantly improve performance since we don't attempt the full
+    // deserialization of each kind, we simply look for fields in the already-partially
+    // deserialized data.
+    //
+    // They are also in a very specific order - API Gateway V1 requests will deserialize with
+    // just "httpMethod" in the context, but websocket requests contain that too.
+    //
+    fn from_value(value: &Value) -> Option<Self> {
+        #[cfg(feature = "apigw_websockets")]
+        if value.pointer("/requestContext/connectedAt").is_some() { return Some(Self::ApiGatewayWebsocketProxyRequest) }
+        #[cfg(feature = "apigw_rest")]
+        if value.pointer("/requestContext/httpMethod").is_some() { return Some(Self::ApiGatewayProxyRequest) }
+        #[cfg(feature = "apigw_http")]
+        if value.pointer("/requestContext/http").is_some() { return Some(Self::ApiGatewayV2httpRequest) }
+        #[cfg(feature = "alb")]
+        if value.pointer("/requestContext/elb").is_some() { return Some(Self::AlbTargetGroupRequest) }
+        None
+    }
+}
+
 
 #[cfg(feature = "pass_through")]
 const PASS_THROUGH_ENABLED: bool = true;
@@ -20,31 +61,29 @@ impl<'de> Deserialize<'de> for LambdaRequest {
     where
         D: serde::Deserializer<'de>,
     {
-        let raw_value: Box<RawValue> = Box::deserialize(deserializer)?;
-        let data = raw_value.get();
-
-        #[cfg(feature = "apigw_rest")]
-        if let Ok(res) = serde_json::from_str::<ApiGatewayProxyRequest>(data) {
-            return Ok(LambdaRequest::ApiGatewayV1(res));
-        }
-        #[cfg(feature = "apigw_http")]
-        if let Ok(res) = serde_json::from_str::<ApiGatewayV2httpRequest>(data) {
-            return Ok(LambdaRequest::ApiGatewayV2(res));
-        }
-        #[cfg(feature = "alb")]
-        if let Ok(res) = serde_json::from_str::<AlbTargetGroupRequest>(data) {
-            return Ok(LambdaRequest::Alb(res));
-        }
-        #[cfg(feature = "apigw_websockets")]
-        if let Ok(res) = serde_json::from_str::<ApiGatewayWebsocketProxyRequest>(data) {
-            return Ok(LambdaRequest::WebSocket(res));
-        }
-        #[cfg(feature = "pass_through")]
-        if PASS_THROUGH_ENABLED {
-            return Ok(LambdaRequest::PassThrough(data.to_string()));
-        }
-
-        Err(Error::custom(ERROR_CONTEXT))
+        let data = Value::deserialize(deserializer)?;
+        match RequestType::from_value(&data) {
+            #[cfg(feature = "apigw_rest")]
+            Some(RequestType::ApiGatewayProxyRequest) => serde_json::from_value::<ApiGatewayProxyRequest>(data)
+                .map(|r| LambdaRequest::ApiGatewayV1(r)),
+            #[cfg(feature = "apigw_http")]
+            Some(RequestType::ApiGatewayV2httpRequest) => serde_json::from_value::<ApiGatewayV2httpRequest>(data)
+                .map(|r| LambdaRequest::ApiGatewayV2(r)),
+            #[cfg(feature = "alb")]
+            Some(RequestType::AlbTargetGroupRequest) => serde_json::from_value::<AlbTargetGroupRequest>(data)
+                .map(|r| LambdaRequest::Alb(r)),
+            #[cfg(feature = "apigw_websockets")]
+            Some(RequestType::ApiGatewayWebsocketProxyRequest) => serde_json::from_value::<ApiGatewayWebsocketProxyRequest>(data)
+                .map(|r| LambdaRequest::WebSocket(r)),
+            None => {
+                #[cfg(feature = "pass_through")]
+                if PASS_THROUGH_ENABLED {
+                    return Ok(LambdaRequest::PassThrough(data.to_string()));
+                }
+                Err(Error::custom(ERROR_CONTEXT))
+            },
+        }.map_err(|_| Error::custom(ERROR_CONTEXT))
+ 
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#792 

*Description of changes:*
Identifying different Lambda events that pertain to HTTP requests is notoriously
hard since they don't contain a simple `kind` property to help out. This is generally
true - not just a problem in Rust.

In lambda-http a full deserialization of each enabled request type is attempted in
turn, trying the next on failure of the previous, which has the possibility of being a
bit of a performance hog when multiple features are enabled.

Up to 0.8 of lambda-http, the deserialization was made in two stages - firstly using a 
private deserializer available in the serde crate to deserialize to an interim value. That
value was then passed to each enabled types's own `deserialize` associated function.

In 0.9 this was modified to be far cleaner, deserializing into a serde_json::RawValue
to check the general structure of the request JSON, then deserializing the contained
string slice into the type using standard serde_json functions..

However, this latter implementation entails two more downsides:

* The attempted type deserializations use the original string rather than already partially parsed-data
* The unintended consequence of disabling the possibility of using simd_json as the
  incoming deserializer - not exactly a supported feature anyway, but simd_json has a problem
  with RawValue.

This PR attempts to solve all these issues by:

* Deserializing into a serde_json::Value using the incoming deserializer - this fixes the simd_json issue
* Testing for "type determinants" in the Value instead of trying full deserialization - this avoids invoking the
  the full Serde deserialization framework multiple times until one works.
* Completing the deserialization to the discovered type from the Value - i.e. a partially -parsed internal 
  structure is used for for the second deserialization phase - much faster using using a string slice.
* This also allows for a much simpler "adoption" of simd_json, at least in the lambda_http package, because
  simd_json gets to do what it is design for - the string->Value parsing, while serde_json completes the 
  Value->event parsing.

The one possible drawback I can see in this PR is that if `Passthru` is enabled, rather than passing through
the original JSON string, that string is reconstructed from the parsed Value. You still get a JSON string but
it won't be _exactly_ the same as the input string. Others who know the project better than I can chime in on that.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
