### PR TITLE
Adds more tests to investigate #797

### DIFF
--- a/lambda-events/src/fixtures/example-apigw-sam-http-request.json
+++ b/lambda-events/src/fixtures/example-apigw-sam-http-request.json
@@ -1,0 +1,52 @@
+{
+  "body": "",
+  "cookies": [],
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "Host": "127.0.0.1:3000",
+    "Pragma": "no-cache",
+    "Sec-Ch-Ua": "\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\"",
+    "Sec-Ch-Ua-Mobile": "?0",
+    "Sec-Ch-Ua-Platform": "\"macOS\"",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "X-Forwarded-Port": "3000",
+    "X-Forwarded-Proto": "http"
+  },
+  "isBase64Encoded": false,
+  "pathParameters": {},
+  "queryStringParameters": {
+    "foo": "bar"
+  },
+  "rawPath": "/dump",
+  "rawQueryString": "foo=bar",
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "1234567890",
+    "domainName": "localhost",
+    "domainPrefix": "localhost",
+    "http": {
+      "method": "GET",
+      "path": "/dump",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "127.0.0.1",
+      "userAgent": "Custom User Agent String"
+    },
+    "requestId": "b3ea2f1a-9f2a-48a4-8791-0db24e5d40e5",
+    "routeKey": "GET /dump",
+    "stage": "$default",
+    "time": "28/Jan/2024:12:09:08 +0000",
+    "timeEpoch": 1706443748
+  },
+  "routeKey": "GET /dump",
+  "stageVariables": null,
+  "version": "2.0"
+}

--- a/lambda-events/src/fixtures/example-apigw-sam-rest-request.json
+++ b/lambda-events/src/fixtures/example-apigw-sam-rest-request.json
@@ -1,0 +1,111 @@
+{
+  "body": null,
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "Connection": "keep-alive",
+    "Host": "127.0.0.1:3000",
+    "Sec-Ch-Ua": "\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\"",
+    "Sec-Ch-Ua-Mobile": "?0",
+    "Sec-Ch-Ua-Platform": "\"macOS\"",
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
+    "Sec-Fetch-User": "?1",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "X-Forwarded-Port": "3000",
+    "X-Forwarded-Proto": "http"
+  },
+  "httpMethod": "GET",
+  "isBase64Encoded": false,
+  "multiValueHeaders": {
+    "Accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+    ],
+    "Accept-Encoding": [
+      "gzip, deflate, br"
+    ],
+    "Accept-Language": [
+      "en-GB,en-US;q=0.9,en;q=0.8"
+    ],
+    "Cache-Control": [
+      "max-age=0"
+    ],
+    "Connection": [
+      "keep-alive"
+    ],
+    "Host": [
+      "127.0.0.1:3000"
+    ],
+    "Sec-Ch-Ua": [
+      "\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\""
+    ],
+    "Sec-Ch-Ua-Mobile": [
+      "?0"
+    ],
+    "Sec-Ch-Ua-Platform": [
+      "\"macOS\""
+    ],
+    "Sec-Fetch-Dest": [
+      "document"
+    ],
+    "Sec-Fetch-Mode": [
+      "navigate"
+    ],
+    "Sec-Fetch-Site": [
+      "none"
+    ],
+    "Sec-Fetch-User": [
+      "?1"
+    ],
+    "Upgrade-Insecure-Requests": [
+      "1"
+    ],
+    "User-Agent": [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ],
+    "X-Forwarded-Port": [
+      "3000"
+    ],
+    "X-Forwarded-Proto": [
+      "http"
+    ]
+  },
+  "multiValueQueryStringParameters": null,
+  "path": "/test",
+  "pathParameters": null,
+  "queryStringParameters": null,
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "1234567890",
+    "domainName": "127.0.0.1:3000",
+    "extendedRequestId": null,
+    "httpMethod": "GET",
+    "identity": {
+      "accountId": null,
+      "apiKey": null,
+      "caller": null,
+      "cognitoAuthenticationProvider": null,
+      "cognitoAuthenticationType": null,
+      "cognitoIdentityPoolId": null,
+      "sourceIp": "127.0.0.1",
+      "user": null,
+      "userAgent": "Custom User Agent String",
+      "userArn": null
+    },
+    "path": "/test",
+    "protocol": "HTTP/1.1",
+    "requestId": "ea86b9eb-c688-4bbb-8309-a1671442bea9",
+    "requestTime": "28/Jan/2024:11:05:46 +0000",
+    "requestTimeEpoch": 1706439946,
+    "resourceId": "123456",
+    "resourcePath": "/test",
+    "stage": "Prod"
+  },
+  "resource": "/test",
+  "stageVariables": null,
+  "version": "1.0"
+}

--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -95,7 +95,7 @@ mod tests {
     fn test_deserialize_sam_http() {
         let data = include_bytes!("../../lambda-events/src/fixtures/example-apigw-sam-http-request.json");
 
-        let req: LambdaRequest = serde_json::from_slice(data).expect("failed to deserialize SAM rest data");
+        let req: LambdaRequest = serde_json::from_slice(data).expect("failed to deserialize SAM http data");
         match req {
             LambdaRequest::ApiGatewayV2(req) => {
                 assert_eq!("123456789012", req.request_context.account_id.unwrap());

--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -79,6 +79,32 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_sam_rest() {
+        let data = include_bytes!("../../lambda-events/src/fixtures/example-apigw-sam-rest-request.json");
+
+        let req: LambdaRequest = serde_json::from_slice(data).expect("failed to deserialize SAM rest data");
+        match req {
+            LambdaRequest::ApiGatewayV1(req) => {
+                assert_eq!("123456789012", req.request_context.account_id.unwrap());
+            }
+            other => panic!("unexpected request variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_sam_http() {
+        let data = include_bytes!("../../lambda-events/src/fixtures/example-apigw-sam-http-request.json");
+
+        let req: LambdaRequest = serde_json::from_slice(data).expect("failed to deserialize SAM rest data");
+        match req {
+            LambdaRequest::ApiGatewayV2(req) => {
+                assert_eq!("123456789012", req.request_context.account_id.unwrap());
+            }
+            other => panic!("unexpected request variant: {:?}", other),
+        }
+    }
+
+    #[test]
     fn test_deserialize_alb() {
         let data = include_bytes!(
             "../../lambda-events/src/fixtures/example-alb-lambda-target-request-multivalue-headers.json"


### PR DESCRIPTION
*Issue #, if available:* #797 

*Description of changes:* Adds more tests on the deserialization of REST and HTTP ApiGw events being generated by `sam local start-api`

By submitting this pull request
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
