### PR TITLE
Make trigger reason for Cognito events Enum instead of String

### DIFF
--- a/lambda-events/src/event/cognito/mod.rs
+++ b/lambda-events/src/event/cognito/mod.rs
@@ -44,9 +44,20 @@ pub struct CognitoDatasetRecord {
 pub struct CognitoEventUserPoolsPreSignup {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader<CognitoEventUserPoolsPreSignupTriggerSource>,
     pub request: CognitoEventUserPoolsPreSignupRequest,
     pub response: CognitoEventUserPoolsPreSignupResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsPreSignupTriggerSource {
+    #[serde(rename = "PreSignUp_SignUp")]
+    #[default]
+    SignUp,
+    #[serde(rename = "PreSignUp_AdminCreateUser")]
+    AdminCreateUser,
+    #[serde(rename = "PreSignUp_ExternalProvider")]
+    ExternalProvider,
 }
 
 /// `CognitoEventUserPoolsPreAuthentication` is sent by AWS Cognito User Pools when a user submits their information
@@ -56,9 +67,17 @@ pub struct CognitoEventUserPoolsPreSignup {
 pub struct CognitoEventUserPoolsPreAuthentication {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header:
+        CognitoEventUserPoolsHeader<CognitoEventUserPoolsPreAuthenticationTriggerSource>,
     pub request: CognitoEventUserPoolsPreAuthenticationRequest,
     pub response: CognitoEventUserPoolsPreAuthenticationResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsPreAuthenticationTriggerSource {
+    #[serde(rename = "PreAuthentication_Authentication")]
+    #[default]
+    Authentication,
 }
 
 /// `CognitoEventUserPoolsPostConfirmation` is sent by AWS Cognito User Pools after a user is confirmed,
@@ -68,9 +87,19 @@ pub struct CognitoEventUserPoolsPreAuthentication {
 pub struct CognitoEventUserPoolsPostConfirmation {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header:
+        CognitoEventUserPoolsHeader<CognitoEventUserPoolsPostConfirmationTriggerSource>,
     pub request: CognitoEventUserPoolsPostConfirmationRequest,
     pub response: CognitoEventUserPoolsPostConfirmationResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsPostConfirmationTriggerSource {
+    #[serde(rename = "PostConfirmation_ConfirmForgotPassword")]
+    ConfirmForgotPassword,
+    #[serde(rename = "PostConfirmation_ConfirmSignUp")]
+    #[default]
+    ConfirmSignUp,
 }
 
 /// `CognitoEventUserPoolsPreTokenGen` is sent by AWS Cognito User Pools when a user attempts to retrieve
@@ -80,9 +109,24 @@ pub struct CognitoEventUserPoolsPostConfirmation {
 pub struct CognitoEventUserPoolsPreTokenGen {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader<CognitoEventUserPoolsPreTokenGenTriggerSource>,
     pub request: CognitoEventUserPoolsPreTokenGenRequest,
     pub response: CognitoEventUserPoolsPreTokenGenResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsPreTokenGenTriggerSource {
+    #[serde(rename = "TokenGeneration_HostedAuth")]
+    HostedAuth,
+    #[serde(rename = "TokenGeneration_Authentication")]
+    #[default]
+    Authentication,
+    #[serde(rename = "TokenGeneration_NewPasswordChallenge")]
+    NewPasswordChallenge,
+    #[serde(rename = "TokenGeneration_AuthenticateDevice")]
+    AuthenticateDevice,
+    #[serde(rename = "TokenGeneration_RefreshTokens")]
+    RefreshTokens,
 }
 
 /// `CognitoEventUserPoolsPostAuthentication` is sent by AWS Cognito User Pools after a user is authenticated,
@@ -92,9 +136,17 @@ pub struct CognitoEventUserPoolsPreTokenGen {
 pub struct CognitoEventUserPoolsPostAuthentication {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header:
+        CognitoEventUserPoolsHeader<CognitoEventUserPoolsPostAuthenticationTriggerSource>,
     pub request: CognitoEventUserPoolsPostAuthenticationRequest,
     pub response: CognitoEventUserPoolsPostAuthenticationResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsPostAuthenticationTriggerSource {
+    #[serde(rename = "PostAuthentication_Authentication")]
+    #[default]
+    Authentication,
 }
 
 /// `CognitoEventUserPoolsMigrateUser` is sent by AWS Cognito User Pools when a user does not exist in the
@@ -104,11 +156,20 @@ pub struct CognitoEventUserPoolsPostAuthentication {
 pub struct CognitoEventUserPoolsMigrateUser {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader<CognitoEventUserPoolsMigrateUserTriggerSource>,
     #[serde(rename = "request")]
     pub cognito_event_user_pools_migrate_user_request: CognitoEventUserPoolsMigrateUserRequest,
     #[serde(rename = "response")]
     pub cognito_event_user_pools_migrate_user_response: CognitoEventUserPoolsMigrateUserResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsMigrateUserTriggerSource {
+    #[serde(rename = "UserMigration_Authentication")]
+    #[default]
+    Authentication,
+    #[serde(rename = "UserMigration_ForgotPassword")]
+    ForgotPassword,
 }
 
 /// `CognitoEventUserPoolsCallerContext` contains information about the caller
@@ -125,11 +186,11 @@ pub struct CognitoEventUserPoolsCallerContext {
 /// `CognitoEventUserPoolsHeader` contains common data from events sent by AWS Cognito User Pools
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CognitoEventUserPoolsHeader {
+pub struct CognitoEventUserPoolsHeader<T> {
     #[serde(default)]
     pub version: Option<String>,
     #[serde(default)]
-    pub trigger_source: Option<String>,
+    pub trigger_source: Option<T>,
     #[serde(default)]
     pub region: Option<String>,
     #[serde(default)]
@@ -220,7 +281,7 @@ pub struct CognitoEventUserPoolsPreTokenGenResponse {
 pub struct CognitoEventUserPoolsPreTokenGenV2 {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader<CognitoEventUserPoolsPreTokenGenTriggerSource>,
     pub request: CognitoEventUserPoolsPreTokenGenRequestV2,
     pub response: CognitoEventUserPoolsPreTokenGenResponseV2,
 }
@@ -384,9 +445,17 @@ pub struct CognitoEventUserPoolsDefineAuthChallengeResponse {
 pub struct CognitoEventUserPoolsDefineAuthChallenge {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header:
+        CognitoEventUserPoolsHeader<CognitoEventUserPoolsDefineAuthChallengeTriggerSource>,
     pub request: CognitoEventUserPoolsDefineAuthChallengeRequest,
     pub response: CognitoEventUserPoolsDefineAuthChallengeResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsDefineAuthChallengeTriggerSource {
+    #[serde(rename = "DefineAuthChallenge_Authentication")]
+    #[default]
+    Authentication,
 }
 
 /// `CognitoEventUserPoolsCreateAuthChallengeRequest` defines create auth challenge request parameters
@@ -426,9 +495,17 @@ pub struct CognitoEventUserPoolsCreateAuthChallengeResponse {
 pub struct CognitoEventUserPoolsCreateAuthChallenge {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header:
+        CognitoEventUserPoolsHeader<CognitoEventUserPoolsCreateAuthChallengeTriggerSource>,
     pub request: CognitoEventUserPoolsCreateAuthChallengeRequest,
     pub response: CognitoEventUserPoolsCreateAuthChallengeResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsCreateAuthChallengeTriggerSource {
+    #[serde(rename = "CreateAuthChallenge_Authentication")]
+    #[default]
+    Authentication,
 }
 
 /// `CognitoEventUserPoolsVerifyAuthChallengeRequest` defines verify auth challenge request parameters
@@ -469,9 +546,17 @@ pub struct CognitoEventUserPoolsVerifyAuthChallengeResponse {
 pub struct CognitoEventUserPoolsVerifyAuthChallenge {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header:
+        CognitoEventUserPoolsHeader<CognitoEventUserPoolsVerifyAuthChallengeTriggerSource>,
     pub request: CognitoEventUserPoolsVerifyAuthChallengeRequest,
     pub response: CognitoEventUserPoolsVerifyAuthChallengeResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsVerifyAuthChallengeTriggerSource {
+    #[serde(rename = "VerifyAuthChallengeResponse_Authentication")]
+    #[default]
+    Authentication,
 }
 
 /// `CognitoEventUserPoolsCustomMessage` is sent by AWS Cognito User Pools before a verification or MFA message is sent,
@@ -481,9 +566,28 @@ pub struct CognitoEventUserPoolsVerifyAuthChallenge {
 pub struct CognitoEventUserPoolsCustomMessage {
     #[serde(rename = "CognitoEventUserPoolsHeader")]
     #[serde(flatten)]
-    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader,
+    pub cognito_event_user_pools_header: CognitoEventUserPoolsHeader<CognitoEventUserPoolsCustomMessageTriggerSource>,
     pub request: CognitoEventUserPoolsCustomMessageRequest,
     pub response: CognitoEventUserPoolsCustomMessageResponse,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Default)]
+pub enum CognitoEventUserPoolsCustomMessageTriggerSource {
+    #[serde(rename = "CustomMessage_SignUp")]
+    #[default]
+    SignUp,
+    #[serde(rename = "CustomMessage_AdminCreateUser")]
+    AdminCreateUser,
+    #[serde(rename = "CustomMessage_ResendCode")]
+    ResendCode,
+    #[serde(rename = "CustomMessage_ForgotPassword")]
+    ForgotPassword,
+    #[serde(rename = "CustomMessage_UpdateUserAttribute")]
+    UpdateUserAttribute,
+    #[serde(rename = "CustomMessage_VerifyUserAttribute")]
+    VerifyUserAttribute,
+    #[serde(rename = "CustomMessage_Authentication")]
+    Authentication,
 }
 
 /// `CognitoEventUserPoolsCustomMessageRequest` contains the request portion of a CustomMessage event

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-custommessage.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-custommessage.json
@@ -1,28 +1,27 @@
 {
   "version": "1",
-  "triggerSource": "CustomMessage_SignUp/CustomMessage_ResendCode/CustomMessage_ForgotPassword/CustomMessage_VerifyUserAttribute",
+  "triggerSource": "CustomMessage_VerifyUserAttribute",
   "region": "<region>",
   "userPoolId": "<userPoolId>",
   "userName": "<userName>",
   "callerContext": {
-      "awsSdkVersion": "<calling aws sdk with version>",
-      "clientId": "<apps client id>"
+    "awsSdkVersion": "<calling aws sdk with version>",
+    "clientId": "<apps client id>"
   },
   "request": {
-      "userAttributes": {
-          "phone_number_verified": true,
-          "email_verified": false
-       },
-      "codeParameter": "####",
-      "usernameParameter": "{username}",
-      "clientMetadata": {
-        "exampleMetadataKey": "example metadata value"
-      }
+    "userAttributes": {
+      "phone_number_verified": true,
+      "email_verified": false
+    },
+    "codeParameter": "####",
+    "usernameParameter": "{username}",
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
+    }
   },
   "response": {
-      "smsMessage": "<custom message to be sent in the message with code parameter>",
-      "emailMessage": "<custom message to be sent in the message with code parameter>",
-      "emailSubject": "<custom email subject>"
+    "smsMessage": "<custom message to be sent in the message with code parameter>",
+    "emailMessage": "<custom message to be sent in the message with code parameter>",
+    "emailSubject": "<custom email subject>"
   }
 }
-

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-incoming.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-incoming.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "triggerSource": "PreTokenGen",
+  "triggerSource": "TokenGeneration_Authentication",
   "region": "region",
   "userPoolId": "userPoolId",
   "userName": "userName",
@@ -15,7 +15,11 @@
     },
     "groupConfiguration": {
       "groupsToOverride": ["group-A", "group-B", "group-C"],
-      "iamRolesToOverride": ["arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA", "arn:aws:iam::XXXXXXXXX:role/sns_callerB", "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"],
+      "iamRolesToOverride": [
+        "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+        "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+        "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+      ],
       "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
     },
     "clientMetadata": {
@@ -26,4 +30,3 @@
     "claimsOverrideDetails": null
   }
 }
-

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-v2-incoming.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-v2-incoming.json
@@ -1,33 +1,33 @@
 {
-    "version": "1",
-    "triggerSource": "PreTokenGen",
-    "region": "region",
-    "userPoolId": "userPoolId",
-    "userName": "userName",
-    "callerContext": {
-        "awsSdkVersion": "calling aws sdk with version",
-        "clientId": "apps client id"
+  "version": "1",
+  "triggerSource": "TokenGeneration_HostedAuth",
+  "region": "region",
+  "userPoolId": "userPoolId",
+  "userName": "userName",
+  "callerContext": {
+    "awsSdkVersion": "calling aws sdk with version",
+    "clientId": "apps client id"
+  },
+  "request": {
+    "userAttributes": {
+      "email": "email",
+      "phone_number": "phone_number"
     },
-    "request": {
-        "userAttributes": {
-            "email": "email",
-            "phone_number": "phone_number"
-        },
-        "scopes": ["scope-1", "scope-2"],
-        "groupConfiguration": {
-            "groupsToOverride": ["group-A", "group-B", "group-C"],
-            "iamRolesToOverride": [
-                "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
-                "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
-                "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
-            ],
-            "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
-        },
-        "clientMetadata": {
-            "exampleMetadataKey": "example metadata value"
-        }
+    "scopes": ["scope-1", "scope-2"],
+    "groupConfiguration": {
+      "groupsToOverride": ["group-A", "group-B", "group-C"],
+      "iamRolesToOverride": [
+        "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+        "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+        "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+      ],
+      "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
     },
-    "response": {
-        "claimsOverrideDetails": null
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
     }
+  },
+  "response": {
+    "claimsOverrideDetails": null
+  }
 }

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-v2.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen-v2.json
@@ -1,58 +1,58 @@
 {
-    "version": "1",
-    "triggerSource": "PreTokenGen",
-    "region": "region",
-    "userPoolId": "userPoolId",
-    "userName": "userName",
-    "callerContext": {
-        "awsSdkVersion": "calling aws sdk with version",
-        "clientId": "apps client id"
+  "version": "1",
+  "triggerSource": "TokenGeneration_HostedAuth",
+  "region": "region",
+  "userPoolId": "userPoolId",
+  "userName": "userName",
+  "callerContext": {
+    "awsSdkVersion": "calling aws sdk with version",
+    "clientId": "apps client id"
+  },
+  "request": {
+    "userAttributes": {
+      "email": "email",
+      "phone_number": "phone_number"
     },
-    "request": {
-        "userAttributes": {
-            "email": "email",
-            "phone_number": "phone_number"
-        },
-        "scopes": ["scope-1", "scope-2"],
-        "groupConfiguration": {
-            "groupsToOverride": ["group-A", "group-B", "group-C"],
-            "iamRolesToOverride": [
-                "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
-                "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
-                "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
-            ],
-            "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
-        },
-        "clientMetadata": {
-            "exampleMetadataKey": "example metadata value"
-        }
+    "scopes": ["scope-1", "scope-2"],
+    "groupConfiguration": {
+      "groupsToOverride": ["group-A", "group-B", "group-C"],
+      "iamRolesToOverride": [
+        "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+        "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+        "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+      ],
+      "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
     },
-    "response": {
-        "claimsAndScopeOverrideDetails": {
-            "idTokenGeneration": {
-                "claimsToAddOrOverride": {
-                    "string": "string"
-                },
-                "claimsToSuppress": ["string", "string"]
-            },
-            "accessTokenGeneration": {
-                "claimsToAddOrOverride": {
-                    "attribute_key2": "attribute_value2",
-                    "attribute_key": "attribute_value"
-                },
-                "claimsToSuppress": ["email", "phone"],
-                "scopesToAdd": ["scope-B", "scope-B"],
-                "scopesToSuppress": ["scope-C", "scope-D"]
-            },
-            "groupOverrideDetails": {
-                "groupsToOverride": ["group-A", "group-B", "group-C"],
-                "iamRolesToOverride": [
-                    "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
-                    "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
-                    "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
-                ],
-                "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
-            }
-        }
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
     }
+  },
+  "response": {
+    "claimsAndScopeOverrideDetails": {
+      "idTokenGeneration": {
+        "claimsToAddOrOverride": {
+          "string": "string"
+        },
+        "claimsToSuppress": ["string", "string"]
+      },
+      "accessTokenGeneration": {
+        "claimsToAddOrOverride": {
+          "attribute_key2": "attribute_value2",
+          "attribute_key": "attribute_value"
+        },
+        "claimsToSuppress": ["email", "phone"],
+        "scopesToAdd": ["scope-B", "scope-B"],
+        "scopesToSuppress": ["scope-C", "scope-D"]
+      },
+      "groupOverrideDetails": {
+        "groupsToOverride": ["group-A", "group-B", "group-C"],
+        "iamRolesToOverride": [
+          "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+          "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+          "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+        ],
+        "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
+      }
+    }
+  }
 }

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-pretokengen.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "triggerSource": "PreTokenGen",
+  "triggerSource": "TokenGeneration_HostedAuth",
   "region": "region",
   "userPoolId": "userPoolId",
   "userName": "userName",
@@ -15,7 +15,11 @@
     },
     "groupConfiguration": {
       "groupsToOverride": ["group-A", "group-B", "group-C"],
-      "iamRolesToOverride": ["arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA", "arn:aws:iam::XXXXXXXXX:role/sns_callerB", "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"],
+      "iamRolesToOverride": [
+        "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+        "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+        "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+      ],
       "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
     },
     "clientMetadata": {
@@ -31,10 +35,13 @@
       "claimsToSuppress": ["email"],
       "groupOverrideDetails": {
         "groupsToOverride": ["group-A", "group-B", "group-C"],
-        "iamRolesToOverride": ["arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA", "arn:aws:iam::XXXXXXXXX:role/sns_callerB", "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"],
+        "iamRolesToOverride": [
+          "arn:aws:iam::XXXXXXXXXXXX:role/sns_callerA",
+          "arn:aws:iam::XXXXXXXXX:role/sns_callerB",
+          "arn:aws:iam::XXXXXXXXXX:role/sns_callerC"
+        ],
         "preferredRole": "arn:aws:iam::XXXXXXXXXXX:role/sns_caller"
       }
     }
   }
 }
-


### PR DESCRIPTION
*Description of changes:*

I was building on top of this library and it felt awkward to do the following: 

```Rust
    let payload = event.payload;
    match payload
        .cognito_event_user_pools_header
        .trigger_source
        .as_ref()
        .unwrap()
        .as_str()
    {
        "PostConfirmation_ConfirmSignUp" => { todo!() }
        "It's awkward and error prone to match on strings" => { todo!() }
    }

```

And so I thought I might just suggest a PR making it an enum? 

Let me know what you think.

I didn't really find relevant documentation, so let me know if there any in case this PR is a go.

Thanks!

By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
