### PR TITLE
Add example route for Axum query extractors.

### DIFF
--- a/examples/http-axum/Cargo.toml
+++ b/examples/http-axum/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 axum = "0.7"
 lambda_http = { path = "../../lambda-http" }
 lambda_runtime = { path = "../../lambda-runtime" }
+serde = "1.0.196"
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1", features = ["log"] }


### PR DESCRIPTION
This helps us verify the query integration with Axum.

*Issue #, if available:*

More data about #802 

*Description of changes:*

Adds a new route to the Axum example that uses Query extractor.

You can see that the runtime and the app do what's expected in this screenshot:

![image](https://github.com/awslabs/aws-lambda-rust-runtime/assets/1050/bba12a94-250c-49f9-a4f1-5d43774b547c)


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
