### PR TITLE
Update lib.rs: Response vs Request in trace! log

### DIFF
--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -126,7 +126,7 @@ impl Runtime {
             // Group the handling in one future and instrument it with the span
             async {
                 let body = body.collect().await?.to_bytes();
-                trace!("response body - {}", std::str::from_utf8(&body)?);
+                trace!("request body - {}", std::str::from_utf8(&body)?);
 
                 #[cfg(debug_assertions)]
                 if parts.status.is_server_error() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* If I understand the code correctly, the tracing line reports the content of the **request**, NOT the response.

If that's correct, I believe we should apply this change to make debugging a little bit easier.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
