### PR TITLE
Add websocket event fields for  route

### DIFF
--- a/lambda-events/src/event/apigw/mod.rs
+++ b/lambda-events/src/event/apigw/mod.rs
@@ -433,6 +433,10 @@ where
     pub route_key: Option<String>,
     #[serde(default)]
     pub status: Option<String>,
+    #[serde(default)]
+    pub disconnect_status_code: Option<i64>,
+    #[serde(default)]
+    pub disconnect_reason: Option<String>,
 }
 
 /// `ApiGatewayCustomAuthorizerRequestTypeRequestIdentity` contains identity information for the request caller including certificate information if using mTLS.
@@ -930,6 +934,16 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_websocket_request_without_method() {
         let data = include_bytes!("../../fixtures/example-apigw-websocket-request-without-method.json");
+        let parsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "apigw")]
+    fn example_apigw_websocket_request_disconnect_route() {
+        let data = include_bytes!("../../fixtures/example-apigw-websocket-request-disconnect-route.json");
         let parsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();

--- a/lambda-events/src/fixtures/example-apigw-websocket-request-disconnect-route.json
+++ b/lambda-events/src/fixtures/example-apigw-websocket-request-disconnect-route.json
@@ -1,0 +1,33 @@
+{
+  "headers": {
+    "Host": "abcd1234.execute-api.us-east-1.amazonaws.com",
+    "x-api-key": "",
+    "X-Forwarded-For": "",
+    "x-restapi": ""
+  },
+  "multiValueHeaders": {
+    "Host": [ "abcd1234.execute-api.us-east-1.amazonaws.com" ],
+    "x-api-key": [ "" ],
+    "X-Forwarded-For": [ "" ],
+    "x-restapi": [ "" ]
+  },
+  "requestContext": {
+    "routeKey": "$disconnect",
+    "disconnectStatusCode": 1005,
+    "eventType": "DISCONNECT",
+    "extendedRequestId": "ABCD1234=",
+    "requestTime": "09/Feb/2024:18:23:28 +0000",
+    "messageDirection": "IN",
+    "disconnectReason": "Client-side close frame status not set",
+    "stage": "prod",
+    "connectedAt": 1707503007396,
+    "requestTimeEpoch": 1707503008941,
+    "identity": { "sourceIp": "192.0.2.1" },
+    "requestId": "ABCD1234=",
+    "domainName": "abcd1234.execute-api.us-east-1.amazonaws.com",
+    "connectionId": "AAAA1234=",
+    "apiId": "abcd1234"
+  },
+  "isBase64Encoded": false
+}
+  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added two fields from [this document](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-integration-requests.html#api-gateway-simple-proxy-for-lambda-input-format-websocket).

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
