### PR TITLE
Allow null answerCorrect when deserializing CognitoEventUserPoolsVerifyAuthChallengeResponse.

### DIFF
--- a/lambda-events/src/event/cognito/mod.rs
+++ b/lambda-events/src/event/cognito/mod.rs
@@ -535,7 +535,7 @@ where
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CognitoEventUserPoolsVerifyAuthChallengeResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullish_boolean")]
     pub answer_correct: bool,
 }
 
@@ -816,6 +816,21 @@ mod test {
     fn example_cognito_event_userpools_verify_auth_challenge_optional_answer_correct() {
         let data = include_bytes!(
             "../../fixtures/example-cognito-event-userpools-verify-auth-challenge-optional-answer-correct.json"
+        );
+        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(data).unwrap();
+
+        assert!(!parsed.response.answer_correct);
+
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "cognito")]
+    fn example_cognito_event_userpools_verify_auth_challenge_null_answer_correct() {
+        let data = include_bytes!(
+            "../../fixtures/example-cognito-event-userpools-verify-auth-challenge-null-answer-correct.json"
         );
         let parsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(data).unwrap();
 

--- a/lambda-events/src/fixtures/example-cognito-event-userpools-verify-auth-challenge-null-answer-correct.json
+++ b/lambda-events/src/fixtures/example-cognito-event-userpools-verify-auth-challenge-null-answer-correct.json
@@ -1,0 +1,31 @@
+{
+  "version": "1",
+  "region": "us-west-2",
+  "userPoolId": "<userPoolId>",
+  "userName": "<userName>",
+  "callerContext": {
+    "awsSdkVersion": "aws-sdk-unknown-unknown",
+    "clientId": "<clientId>"
+  },
+  "triggerSource": "VerifyAuthChallengeResponse_Authentication",
+  "request": {
+    "userAttributes": {
+      "sub": "<sub>",
+      "cognito:user_status": "CONFIRMED",
+      "phone_number_verified": "true",
+      "cognito:phone_number_alias": "+12223334455",
+      "phone_number": "+12223334455"
+    },
+    "privateChallengeParameters": {
+      "secret": "11122233"
+    },
+    "challengeAnswer": "123xxxx",
+    "clientMetadata": {
+      "exampleMetadataKey": "example metadata value"
+    },
+    "userNotFound": false
+  },
+  "response": {
+    "answerCorrect": null
+  }
+}


### PR DESCRIPTION
CognitoEventUserPoolsVerifyAuthChallengeResponse.

*Issue #, if available:* #825

*Description of changes:* Allows for deserialization of `CognitoEventUserPoolsVerifyAuthChallengeResponse` when `response.answerCorrect` is explicitly `null` (not just missing). Cognito does send events with this field set to `null`, and this change will prevent errors when this does occur.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
