### PR TITLE
Allow error response customization

### DIFF
--- a/lambda-runtime/src/requests.rs
+++ b/lambda-runtime/src/requests.rs
@@ -194,13 +194,10 @@ pub(crate) struct EventErrorRequest<'a> {
 }
 
 impl<'a> EventErrorRequest<'a> {
-    pub(crate) fn new(request_id: &'a str, error_type: &'a str, error_message: &'a str) -> EventErrorRequest<'a> {
+    pub(crate) fn new(request_id: &'a str, diagnostic: impl Into<Diagnostic<'a>>) -> EventErrorRequest<'a> {
         EventErrorRequest {
             request_id,
-            diagnostic: Diagnostic {
-                error_type,
-                error_message,
-            },
+            diagnostic: diagnostic.into(),
         }
     }
 }
@@ -226,8 +223,8 @@ fn test_event_error_request() {
     let req = EventErrorRequest {
         request_id: "id",
         diagnostic: Diagnostic {
-            error_type: "InvalidEventDataError",
-            error_message: "Error parsing event data",
+            error_type: std::borrow::Cow::Borrowed("InvalidEventDataError"),
+            error_message: std::borrow::Cow::Borrowed("Error parsing event data"),
         },
     };
     let req = req.into_req().unwrap();


### PR DESCRIPTION
*Issue #, if available:*
- #824

*Description of changes:*
- `F::Error` of `Runtime::run` and `run` is required to implement `Into<Diagnostic<'a>>` instead of `std::fmt::Display`
- `Into<Diagnostic<'a>>` is implemented for any types that implement `std::fmt::Display` as a fallback and for backward compatibility
- `Diagnostic` and its fields become public so that users can customize error responses
- `error_type` and `error_message` of `Diagnostic` are wrapped in `std::borrow::Cow` so that they can hold both borrowed and owned strings. An example of the situation where an owned string is necessary is in the fallback implementation of `From<Display>` for `Diagnostic`, which generates `error_message` inside `from` method and it has to outlive the method call.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
