### PR TITLE
Implement CloudWatch alarm SNS payloads.

### DIFF
--- a/lambda-events/src/custom_serde/mod.rs
+++ b/lambda-events/src/custom_serde/mod.rs
@@ -80,6 +80,7 @@ where
     feature = "cloudwatch_events",
     feature = "code_commit",
     feature = "cognito",
+    feature = "sns",
     test
 ))]
 pub(crate) fn deserialize_nullish_boolean<'de, D>(deserializer: D) -> Result<bool, D::Error>


### PR DESCRIPTION
*Issue #, if available:*

Fixes #793 

*Description of changes:*

Add the struct definitions based on the Go events: https://github.com/aws/aws-lambda-go/blob/3a93ed1e265b5e368f0d20c3a2b8395d2c9f787d/events/sns.go#L34-L88
It doesn't look like the Java and Dotnet events implement these structs to verify them, but the tests are able to deserialize the example payloads that we've been testing already.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
