### PR TITLE
Add CloudFormationCustomResourceResponse struct.

### DIFF
--- a/lambda-events/src/event/cloudformation/mod.rs
+++ b/lambda-events/src/event/cloudformation/mod.rs
@@ -1,5 +1,6 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "RequestType")]
@@ -75,6 +76,26 @@ where
     pub resource_properties: P2,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct CloudFormationCustomResourceResponse {
+    pub status: CloudFormationCustomResourceResponseStatus,
+    pub reason: Option<String>,
+    pub physical_resource_id: String,
+    pub stack_id: String,
+    pub request_id: String,
+    pub logical_resource_id: String,
+    pub no_echo: bool,
+    pub data: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum CloudFormationCustomResourceResponseStatus {
+    Success,
+    Failed,
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
@@ -134,6 +155,15 @@ mod test {
 
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    fn example_cloudformation_custom_resource_response() {
+        let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-response.json");
+        let parsed: CloudFormationCustomResourceResponse = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: CloudFormationCustomResourceResponse = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/fixtures/example-cloudformation-custom-resource-response.json
+++ b/lambda-events/src/fixtures/example-cloudformation-custom-resource-response.json
@@ -1,0 +1,14 @@
+{
+  "Status": "FAILED",
+  "Reason": "This is a test failure.",
+  "PhysicalResourceId": "custom-resource-f4bd5382-3de3-4caf-b7ad-1be06b899647",
+  "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/stack-name/16580499-7622-4a9c-b32f-4eba35da93da",
+  "RequestId": "49347ca5-c603-44e5-a34b-10cf1854a887",
+  "LogicalResourceId": "CustomResource",
+  "NoEcho": false,
+  "Data": {
+    "Key1": "a",
+    "Key2": "b",
+    "Key3": "c"
+  }
+}


### PR DESCRIPTION
*Description of changes:*

This adds a `CloudFormationCustomResourceResponse` struct for responding to custom resource requests.

See the relevant documentation on the response format here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
