### PR TITLE
Stop using deprecated chrono's api.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["examples"]
 [workspace.dependencies]
 base64 = "0.21"
 bytes = "1"
+chrono = "0.4.35"
 futures = "0.3"
 futures-channel = "0.3"
 futures-util = "0.3"

--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 [dependencies]
 base64 = { workspace = true }
 bytes = { workspace = true, features = ["serde"], optional = true }
-chrono = { version = "0.4.31", default-features = false, features = [
+chrono = { workspace = true, default-features = false, features = [
   "clock",
   "serde",
   "std",

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -20,7 +20,7 @@ tracing = ["lambda_runtime_api_client/tracing"]
 [dependencies]
 async-stream = "0.3"
 bytes = { workspace = true }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true, features = ["serde"] }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client", "server"] }

--- a/lambda-extension/src/logs.rs
+++ b/lambda-extension/src/logs.rs
@@ -233,7 +233,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Duration, TimeZone};
+    use chrono::{TimeDelta, TimeZone};
 
     #[test]
     fn deserialize_full() {
@@ -242,7 +242,7 @@ mod tests {
             time: Utc
                 .with_ymd_and_hms(2020, 8, 20, 12, 31, 32)
                 .unwrap()
-                .checked_add_signed(Duration::milliseconds(123))
+                .checked_add_signed(TimeDelta::try_milliseconds(123).unwrap())
                 .unwrap(),
             record: LambdaLogRecord::Function("hello world".to_string()),
         };

--- a/lambda-extension/src/telemetry.rs
+++ b/lambda-extension/src/telemetry.rs
@@ -316,7 +316,7 @@ where
 #[cfg(test)]
 mod deserialization_tests {
     use super::*;
-    use chrono::{Duration, TimeZone};
+    use chrono::{TimeDelta, TimeZone};
 
     macro_rules! deserialize_tests {
         ($($name:ident: $value:expr,)*) => {
@@ -385,7 +385,7 @@ mod deserialization_tests {
                         start: Utc
                             .with_ymd_and_hms(2022, 10, 21, 14, 5, 3)
                             .unwrap()
-                            .checked_add_signed(Duration::milliseconds(165))
+                            .checked_add_signed(TimeDelta::try_milliseconds(165).unwrap())
                             .unwrap(),
                         duration_ms: 2598.0
                     },
@@ -394,7 +394,7 @@ mod deserialization_tests {
                         start: Utc
                             .with_ymd_and_hms(2022, 10, 21, 14, 5, 5)
                             .unwrap()
-                            .checked_add_signed(Duration::milliseconds(763))
+                            .checked_add_signed(TimeDelta::try_milliseconds(763).unwrap())
                             .unwrap(),
                         duration_ms: 0.0
                     },
@@ -473,7 +473,7 @@ mod deserialization_tests {
 
 #[cfg(test)]
 mod serialization_tests {
-    use chrono::{Duration, TimeZone};
+    use chrono::{TimeDelta, TimeZone};
 
     use super::*;
     macro_rules! serialize_tests {
@@ -557,7 +557,7 @@ mod serialization_tests {
                             start: Utc
                                 .with_ymd_and_hms(2022, 10, 21, 14, 5, 3)
                                 .unwrap()
-                                .checked_add_signed(Duration::milliseconds(165))
+                                .checked_add_signed(TimeDelta::try_milliseconds(165).unwrap())
                                 .unwrap(),
                             duration_ms: 2598.0
                         },
@@ -566,7 +566,7 @@ mod serialization_tests {
                             start: Utc
                                 .with_ymd_and_hms(2022, 10, 21, 14, 5, 5)
                                 .unwrap()
-                                .checked_add_signed(Duration::milliseconds(763))
+                                .checked_add_signed(TimeDelta::try_milliseconds(763).unwrap())
                                 .unwrap(),
                             duration_ms: 0.0
                         },


### PR DESCRIPTION
*Description of changes:*

Upgrade to chrono 0.4.35

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
