### PR TITLE
feat: Add default Value type for EventBridgeEvent detail

### DIFF
--- a/lambda-events/src/event/eventbridge/mod.rs
+++ b/lambda-events/src/event/eventbridge/mod.rs
@@ -1,15 +1,20 @@
 use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Parse EventBridge events.
 /// Deserialize the event detail into a structure that's `DeserializeOwned`.
 ///
 /// See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html for structure details.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(bound(deserialize = "T: DeserializeOwned"))]
+#[serde(bound(deserialize = "T1: DeserializeOwned"))]
 #[serde(rename_all = "kebab-case")]
-pub struct EventBridgeEvent<T: Serialize> {
+pub struct EventBridgeEvent<T1 = Value>
+where
+    T1: Serialize,
+    T1: DeserializeOwned,
+{
     #[serde(default)]
     pub version: Option<String>,
     #[serde(default)]
@@ -24,8 +29,8 @@ pub struct EventBridgeEvent<T: Serialize> {
     pub region: Option<String>,
     #[serde(default)]
     pub resources: Option<Vec<String>>,
-    #[serde(bound(deserialize = "T: DeserializeOwned"))]
-    pub detail: T,
+    #[serde(bound = "")]
+    pub detail: T1,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
*Issue #, if available:* N/D

*Description of changes:*

When creating a new lambda using `cargo lambda new` and selecting the event type `eventbridge::EventBridgeEvent` you end up with broken code:

![Screenshot 2024-03-13 at 09 28 57](https://github.com/awslabs/aws-lambda-rust-runtime/assets/205629/5d3fab56-f7f0-4d69-ab7b-bd9ac65040e4)

> missing generics for struct `aws_lambda_events::eventbridge::EventBridgeEvent`
> expected 1 generic argument

This makes sense because an EventBridge `detail` event field is an arbitrary JSON object, so it could vary widely in shape and therefore it is implemented as a generic type that we need to provide ourselves.

So an easy fix would be something like:

```rust
// ...
use serde_json::Value;

async fn function_handler(event: LambdaEvent<EventBridgeEvent<Value>>) -> Result<(), Error> {
    // Extract some useful information from the request

    Ok(())
}
```

except `serde_json` also needs to be installed with `cargo add serde_json`, so there's a bit of friction for the user.

CloudWatch events are very similar (unsurprisingly since EventBrigde has spun off CloudWatch events, AFAIK) because they also have a generic `detail` field which can contain pretty much arbitrary content.

I noticed that the current implementation of the `CloudWatchEvent` provides a default type and that type is `serde_json::Value`.

I really like this approach because it provides a smoother starting point for the developer.

So, this PR proposes to adopt the same approach also to the `EventBridgeEvent` type and default `detail` to be of type `serde_json::Value` when no explicit type is provided for the associated generic type.

I hope this makes sense, but IMHO it can make things a little bit more frictionless when wanting to scaffold an eventbridge Lambda.

---

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
