### PR TITLE
fix: Correct Markdown format for Tracing link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Lambdas can be run and debugged locally using a special [Lambda debug proxy](htt
 
 ## Tracing and Logging
 
-The Rust Runtime for Lambda integrates with the (Tracing)[https://tracing.rs] libraries to provide tracing and logging.
+The Rust Runtime for Lambda integrates with the [Tracing](https://tracing.rs) libraries to provide tracing and logging.
 
 By default, the runtime emits `tracing` events that you can collect via `tracing-subscriber`. It also enabled a feature called `tracing` that exposes a default subscriber with sensible options to send logging information to AWS CloudWatch. Follow the next example that shows how to enable the default subscriber:
 


### PR DESCRIPTION
*Issue #, if available:* fix markdown link format

*Description of changes:* fix `Trancing` link format 

```md
 ## Tracing and Logging
 
-The Rust Runtime for Lambda integrates with the (Tracing)[https://tracing.rs] libraries to provide tracing and logging.
+The Rust Runtime for Lambda integrates with the [Tracing](https://tracing.rs) libraries to provide tracing and logging.
```

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
