### PR TITLE
feat: Implement RFC for layering of runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
     "lambda-runtime-api-client",
     "lambda-runtime",
     "lambda-extension",
-    "lambda-events"
+    "lambda-events",
 ]
 
 exclude = ["examples"]
@@ -26,4 +26,5 @@ hyper = "1.0"
 hyper-util = "0.1.1"
 pin-project-lite = "0.2"
 tower = "0.4"
+tower-layer = "0.3"
 tower-service = "0.3"

--- a/examples/opentelemetry-tracing/Cargo.toml
+++ b/examples/opentelemetry-tracing/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "opentelemetry-tracing"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lambda_runtime = { path = "../../lambda-runtime" }
+pin-project = "1"
+opentelemetry-semantic-conventions = "0.14"
+tower = "0.4"
+tracing = "0.1"

--- a/examples/opentelemetry-tracing/src/lib.rs
+++ b/examples/opentelemetry-tracing/src/lib.rs
@@ -1,0 +1,113 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task;
+
+use lambda_runtime::LambdaInvocation;
+use opentelemetry_semantic_conventions::trace as traceconv;
+use pin_project::pin_project;
+use tower::{Layer, Service};
+use tracing::instrument::Instrumented;
+use tracing::Instrument;
+
+/// Tower layer to add OpenTelemetry tracing to a Lambda function invocation. The layer accepts
+/// a function to flush OpenTelemetry after the end of the invocation.
+pub struct OpenTelemetryLayer<F> {
+    flush_fn: F,
+}
+
+impl<F> OpenTelemetryLayer<F>
+where
+    F: Fn() + Clone,
+{
+    pub fn new(flush_fn: F) -> Self {
+        Self { flush_fn }
+    }
+}
+
+impl<S, F> Layer<S> for OpenTelemetryLayer<F>
+where
+    F: Fn() + Clone,
+{
+    type Service = OpenTelemetryService<S, F>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        OpenTelemetryService {
+            inner,
+            flush_fn: self.flush_fn.clone(),
+            coldstart: true,
+        }
+    }
+}
+
+/// Tower service created by [OpenTelemetryLayer].
+pub struct OpenTelemetryService<S, F> {
+    inner: S,
+    flush_fn: F,
+    coldstart: bool,
+}
+
+impl<S, F> Service<LambdaInvocation> for OpenTelemetryService<S, F>
+where
+    S: Service<LambdaInvocation, Response = ()>,
+    F: Fn() + Clone,
+{
+    type Error = S::Error;
+    type Response = ();
+    type Future = OpenTelemetryFuture<Instrumented<S::Future>, F>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: LambdaInvocation) -> Self::Future {
+        let span = tracing::info_span!(
+            "Lambda function invocation",
+            "otel.name" = req.context.env_config.function_name,
+            { traceconv::FAAS_TRIGGER } = "http",
+            { traceconv::FAAS_INVOCATION_ID } = req.context.request_id,
+            { traceconv::FAAS_COLDSTART } = self.coldstart
+        );
+
+        // After the first execution, we can set 'coldstart' to false
+        self.coldstart = false;
+
+        let fut = self.inner.call(req).instrument(span);
+        OpenTelemetryFuture {
+            future: Some(fut),
+            flush_fn: self.flush_fn.clone(),
+        }
+    }
+}
+
+/// Future created by [OpenTelemetryService].
+#[pin_project]
+pub struct OpenTelemetryFuture<Fut, F> {
+    #[pin]
+    future: Option<Fut>,
+    flush_fn: F,
+}
+
+impl<Fut, F> Future for OpenTelemetryFuture<Fut, F>
+where
+    Fut: Future,
+    F: Fn(),
+{
+    type Output = Fut::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        // First, try to get the ready value of the future
+        let ready = task::ready!(self
+            .as_mut()
+            .project()
+            .future
+            .as_pin_mut()
+            .expect("`Ready` polled after completion")
+            .poll(cx));
+
+        // If we got the ready value, we first drop the future: this ensures that the
+        // OpenTelemetry span attached to it is closed and included in the subsequent flush.
+        Pin::set(&mut self.as_mut().project().future, None);
+        (self.project().flush_fn)();
+        task::Poll::Ready(ready)
+    }
+}

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -143,7 +143,7 @@ where
 #[doc(hidden)]
 pub struct Adapter<'a, R, S> {
     service: S,
-    _phantom_data: PhantomData<&'a R>,
+    _phantom_data: PhantomData<(&'a (), R)>,
 }
 
 impl<'a, R, S, E> From<S> for Adapter<'a, R, S>
@@ -188,12 +188,12 @@ where
 ///
 /// This takes care of transforming the LambdaEvent into a [`Request`] and then
 /// converting the result into a [`LambdaResponse`].
-pub async fn run<'a, R, S, E>(handler: S) -> Result<(), Error>
+pub async fn run<R, S, E>(handler: S) -> Result<(), Error>
 where
-    S: Service<Request, Response = R, Error = E>,
-    S::Future: Send + 'a,
-    R: IntoResponse,
-    E: std::fmt::Debug + std::fmt::Display,
+    S: Service<Request, Response = R, Error = E> + Send + 'static,
+    S::Future: Send + 'static,
+    R: IntoResponse + Send + 'static,
+    E: std::fmt::Debug + std::fmt::Display + 'static,
 {
     lambda_runtime::run(Adapter::from(handler)).await
 }

--- a/lambda-http/src/streaming.rs
+++ b/lambda-http/src/streaming.rs
@@ -16,10 +16,10 @@ use tokio_stream::Stream;
 ///
 /// This takes care of transforming the LambdaEvent into a [`Request`] and
 /// accepts [`http::Response<http_body::Body>`] as response.
-pub async fn run_with_streaming_response<'a, S, B, E>(handler: S) -> Result<(), Error>
+pub async fn run_with_streaming_response<S, B, E>(handler: S) -> Result<(), Error>
 where
-    S: Service<Request, Response = Response<B>, Error = E>,
-    S::Future: Send + 'a,
+    S: Service<Request, Response = Response<B>, Error = E> + Send + 'static,
+    S::Future: Send + 'static,
     E: Debug + Display,
     B: Body + Unpin + Send + 'static,
     B::Data: Into<Bytes> + Send,

--- a/lambda-integration-tests/src/bin/runtime-trait.rs
+++ b/lambda-integration-tests/src/bin/runtime-trait.rs
@@ -46,7 +46,7 @@ impl Clone for MyHandler {
 
 impl Service<LambdaEvent<Request>> for MyHandler {
     type Error = Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Error>>>>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Error>> + Send>>;
     type Response = Response;
 
     fn poll_ready(&mut self, _cx: &mut core::task::Context<'_>) -> core::task::Poll<Result<(), Self::Error>> {

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -37,6 +37,7 @@ hyper-util = { workspace = true, features = [
     "tokio",
 ] }
 lambda_runtime_api_client = { version = "0.10", path = "../lambda-runtime-api-client" }
+pin-project = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "^1"
 serde_path_to_error = "0.1.11"
@@ -48,6 +49,7 @@ tokio = { version = "1.0", features = [
 ] }
 tokio-stream = "0.1.2"
 tower = { workspace = true, features = ["util"] }
+tower-layer = { workspace = true }
 tracing = { version = "0.1", features = ["log"] }
 
 [dev-dependencies]

--- a/lambda-runtime/src/layers/api_client.rs
+++ b/lambda-runtime/src/layers/api_client.rs
@@ -1,0 +1,53 @@
+use crate::LambdaInvocation;
+use futures::{future::BoxFuture, FutureExt};
+use lambda_runtime_api_client::{body::Body, BoxError, Client};
+use std::future::Future;
+use std::sync::Arc;
+use std::task;
+use tower::Service;
+use tracing::error;
+
+/// Tower service that sends a Lambda Runtime API response to the Lambda Runtime HTTP API using
+/// a previously initialized client.
+///
+/// This type is only meant for internal use in the Lambda runtime crate. It neither augments the
+/// inner service's request type nor its error type. However, this service returns an empty
+/// response `()` as the Lambda request has been completed.
+pub struct RuntimeApiClientService<S> {
+    inner: S,
+    client: Arc<Client>,
+}
+
+impl<S> RuntimeApiClientService<S> {
+    pub fn new(inner: S, client: Arc<Client>) -> Self {
+        Self { inner, client }
+    }
+}
+
+impl<S> Service<LambdaInvocation> for RuntimeApiClientService<S>
+where
+    S: Service<LambdaInvocation, Error = BoxError>,
+    S::Future: Future<Output = Result<http::Request<Body>, BoxError>> + Send + 'static,
+{
+    type Response = ();
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: LambdaInvocation) -> Self::Future {
+        let request_fut = self.inner.call(req);
+        let client = self.client.clone();
+        async move {
+            let request = request_fut.await?;
+            client.call(request).await.map_err(|err| {
+                error!(error = ?err, "failed to send request to Lambda Runtime API");
+                err
+            })?;
+            Ok(())
+        }
+        .boxed()
+    }
+}

--- a/lambda-runtime/src/layers/api_response.rs
+++ b/lambda-runtime/src/layers/api_response.rs
@@ -1,0 +1,139 @@
+use crate::requests::{EventCompletionRequest, IntoRequest};
+use crate::runtime::LambdaInvocation;
+use crate::types::Diagnostic;
+use crate::{deserializer, IntoFunctionResponse};
+use crate::{EventErrorRequest, LambdaEvent};
+use futures::{future::BoxFuture, FutureExt, Stream};
+use lambda_runtime_api_client::{body::Body, BoxError};
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::future;
+use std::marker::PhantomData;
+use std::task;
+use tower::Service;
+use tracing::{debug, error, trace};
+
+/// Tower service that turns the result or an error of a handler function into a Lambda Runtime API
+/// response.
+///
+/// This type is only meant for internal use in the Lambda runtime crate. The service augments both
+/// inputs and outputs: the input is converted from a [LambdaInvocation] into a [LambdaEvent]
+/// while any errors encountered during the conversion are turned into error responses. The service
+/// outputs either a HTTP request to send to the Lambda Runtime API or a boxed error which ought to
+/// be propagated to the caller to terminate the runtime.
+pub struct RuntimeApiResponseService<
+    S,
+    EventPayload,
+    Response,
+    BufferedResponse,
+    StreamingResponse,
+    StreamItem,
+    StreamError,
+> {
+    inner: S,
+    _phantom: PhantomData<(
+        EventPayload,
+        Response,
+        BufferedResponse,
+        StreamingResponse,
+        StreamItem,
+        StreamError,
+    )>,
+}
+
+impl<S, EventPayload, Response, BufferedResponse, StreamingResponse, StreamItem, StreamError>
+    RuntimeApiResponseService<S, EventPayload, Response, BufferedResponse, StreamingResponse, StreamItem, StreamError>
+{
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, S, EventPayload, Response, BufferedResponse, StreamingResponse, StreamItem, StreamError>
+    Service<LambdaInvocation>
+    for RuntimeApiResponseService<
+        S,
+        EventPayload,
+        Response,
+        BufferedResponse,
+        StreamingResponse,
+        StreamItem,
+        StreamError,
+    >
+where
+    S: Service<LambdaEvent<EventPayload>, Response = Response, Error = Diagnostic<'a>>,
+    S::Future: Send + 'static,
+    EventPayload: for<'de> Deserialize<'de>,
+    Response: IntoFunctionResponse<BufferedResponse, StreamingResponse>,
+    BufferedResponse: Serialize,
+    StreamingResponse: Stream<Item = Result<StreamItem, StreamError>> + Unpin + Send + 'static,
+    StreamItem: Into<bytes::Bytes> + Send,
+    StreamError: Into<BoxError> + Send + Debug,
+{
+    type Response = http::Request<Body>;
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner
+            .poll_ready(cx)
+            .map_err(|err| BoxError::from(format!("{}: {}", err.error_type, err.error_message)))
+    }
+
+    fn call(&mut self, req: LambdaInvocation) -> Self::Future {
+        #[cfg(debug_assertions)]
+        if req.parts.status.is_server_error() {
+            error!("Lambda Runtime server returned an unexpected error");
+            return future::ready(Err(req.parts.status.to_string().into())).boxed();
+        }
+
+        // Utility closure to propagate potential error from conditionally executed trace
+        let trace_fn = || {
+            trace!(
+                body = std::str::from_utf8(&req.body)?,
+                "raw JSON event received from Lambda"
+            );
+            Ok(())
+        };
+        match trace_fn() {
+            Err(err) => {
+                error!(error = ?err, "failed to parse raw JSON event received from Lambda");
+                return future::ready(Err(err)).boxed();
+            }
+            _ => {}
+        };
+
+        let request_id = req.context.request_id.clone();
+        let lambda_event = match deserializer::deserialize::<EventPayload>(&req.body, req.context) {
+            Ok(lambda_event) => lambda_event,
+            Err(err) => match build_event_error_request(&request_id, err) {
+                Ok(request) => return future::ready(Ok(request)).boxed(),
+                Err(err) => {
+                    error!(error = ?err, "failed to build error response for Lambda Runtime API");
+                    return future::ready(Err(err)).boxed();
+                }
+            },
+        };
+
+        // Once the handler input has been generated successfully, the
+        let fut = self.inner.call(lambda_event);
+        async move {
+            match fut.await {
+                Ok(result) => EventCompletionRequest::new(&request_id, result).into_req(),
+                Err(err) => EventErrorRequest::new(&request_id, err).into_req(),
+            }
+        }
+        .boxed()
+    }
+}
+
+fn build_event_error_request<'a, T>(request_id: &'a str, err: T) -> Result<http::Request<Body>, BoxError>
+where
+    T: Into<Diagnostic<'a>> + Debug,
+{
+    debug!(error = ?err, "building error response for Lambda Runtime API");
+    EventErrorRequest::new(request_id, err).into_req()
+}

--- a/lambda-runtime/src/layers/mod.rs
+++ b/lambda-runtime/src/layers/mod.rs
@@ -1,0 +1,12 @@
+// Internally used services.
+mod api_client;
+mod api_response;
+mod panic;
+
+// Publicly available services.
+mod tracing;
+
+pub(crate) use api_client::RuntimeApiClientService;
+pub(crate) use api_response::RuntimeApiResponseService;
+pub(crate) use panic::CatchPanicService;
+pub use tracing::TracingLayer;

--- a/lambda-runtime/src/layers/panic.rs
+++ b/lambda-runtime/src/layers/panic.rs
@@ -1,0 +1,114 @@
+use crate::{Diagnostic, LambdaEvent};
+use futures::{future::CatchUnwind, FutureExt};
+use pin_project::pin_project;
+use std::any::Any;
+use std::borrow::Cow;
+use std::fmt::Debug;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
+use std::task;
+use tower::Service;
+use tracing::error;
+
+/// Tower service that transforms panics into an error. Panics are converted to errors both when
+/// constructed in [tower::Service::call] and when constructed in the returned
+/// [tower::Service::Future].
+///
+/// This type is only meant for internal use in the Lambda runtime crate. It neither augments the
+/// inner service's request type, nor its response type. It merely transforms the error type
+/// from `Into<Diagnostic<'_> + Debug` into `Diagnostic<'a>` to turn panics into diagnostics.
+#[derive(Clone)]
+pub struct CatchPanicService<'a, S> {
+    inner: S,
+    _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a, S> CatchPanicService<'a, S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, S, Payload> Service<LambdaEvent<Payload>> for CatchPanicService<'a, S>
+where
+    S: Service<LambdaEvent<Payload>>,
+    S::Future: 'a,
+    S::Error: Into<Diagnostic<'a>> + Debug,
+{
+    type Error = Diagnostic<'a>;
+    type Response = S::Response;
+    type Future = CatchPanicFuture<'a, S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(|err| err.into())
+    }
+
+    fn call(&mut self, req: LambdaEvent<Payload>) -> Self::Future {
+        // Catch panics that result from calling `call` on the service
+        let task = std::panic::catch_unwind(AssertUnwindSafe(|| self.inner.call(req)));
+
+        // Catch panics that result from polling the future returned from `call`
+        match task {
+            Ok(task) => {
+                let fut = AssertUnwindSafe(task).catch_unwind();
+                CatchPanicFuture::Future(fut, PhantomData)
+            }
+            Err(err) => {
+                error!(error = ?err, "user handler panicked");
+                CatchPanicFuture::Error(err)
+            }
+        }
+    }
+}
+
+/// Future returned by [CatchPanicService].
+#[pin_project(project = CatchPanicFutureProj)]
+pub enum CatchPanicFuture<'a, F> {
+    Future(#[pin] CatchUnwind<AssertUnwindSafe<F>>, PhantomData<&'a ()>),
+    Error(Box<dyn Any + Send + 'static>),
+}
+
+impl<'a, F, T, E> Future for CatchPanicFuture<'a, F>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<Diagnostic<'a>> + Debug,
+{
+    type Output = Result<T, Diagnostic<'a>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<Self::Output> {
+        use task::Poll;
+        match self.project() {
+            CatchPanicFutureProj::Future(fut, _) => match fut.poll(cx) {
+                Poll::Ready(ready) => match ready {
+                    Ok(inner_result) => Poll::Ready(inner_result.map_err(|err| err.into())),
+                    Err(err) => {
+                        error!(error = ?err, "user handler panicked");
+                        Poll::Ready(Err(Self::build_panic_diagnostic(&err)))
+                    }
+                },
+                Poll::Pending => Poll::Pending,
+            },
+            CatchPanicFutureProj::Error(err) => Poll::Ready(Err(Self::build_panic_diagnostic(err))),
+        }
+    }
+}
+
+impl<'a, F> CatchPanicFuture<'a, F> {
+    fn build_panic_diagnostic(err: &Box<dyn Any + Send>) -> Diagnostic<'a> {
+        let error_type = std::any::type_name_of_val(&err);
+        let msg = if let Some(msg) = err.downcast_ref::<&str>() {
+            format!("Lambda panicked: {msg}")
+        } else {
+            "Lambda panicked".to_string()
+        };
+        Diagnostic {
+            error_type: Cow::Borrowed(error_type),
+            error_message: Cow::Owned(msg),
+        }
+    }
+}

--- a/lambda-runtime/src/layers/tracing.rs
+++ b/lambda-runtime/src/layers/tracing.rs
@@ -1,0 +1,67 @@
+use std::env;
+use tower::{Layer, Service};
+use tracing::{instrument::Instrumented, Instrument};
+
+use crate::{Context, LambdaInvocation};
+use lambda_runtime_api_client::BoxError;
+use std::task;
+
+/// Tower middleware to create a tracing span for invocations of the Lambda function.
+pub struct TracingLayer {}
+
+impl TracingLayer {
+    /// Create a new tracing layer.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<S> Layer<S> for TracingLayer {
+    type Service = TracingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TracingService { inner }
+    }
+}
+
+/// Tower service returned by [TracingLayer].
+pub struct TracingService<S> {
+    inner: S,
+}
+
+impl<S> Service<LambdaInvocation> for TracingService<S>
+where
+    S: Service<LambdaInvocation, Response = (), Error = BoxError>,
+{
+    type Response = ();
+    type Error = BoxError;
+    type Future = Instrumented<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: LambdaInvocation) -> Self::Future {
+        let span = request_span(&req.context);
+        self.inner.call(req).instrument(span)
+    }
+}
+
+/* ------------------------------------------- UTILS ------------------------------------------- */
+
+fn request_span(ctx: &Context) -> tracing::Span {
+    match &ctx.xray_trace_id {
+        Some(trace_id) => {
+            env::set_var("_X_AMZN_TRACE_ID", trace_id);
+            tracing::info_span!(
+                "Lambda runtime invoke",
+                requestId = &ctx.request_id,
+                xrayTraceId = trace_id
+            )
+        }
+        None => {
+            env::remove_var("_X_AMZN_TRACE_ID");
+            tracing::info_span!("Lambda runtime invoke", requestId = &ctx.request_id)
+        }
+    }
+}

--- a/lambda-runtime/src/runtime.rs
+++ b/lambda-runtime/src/runtime.rs
@@ -1,0 +1,437 @@
+use super::requests::{IntoRequest, NextEventRequest};
+use super::types::{invoke_request_id, Diagnostic, IntoFunctionResponse, LambdaEvent};
+use crate::layers::{CatchPanicService, RuntimeApiClientService, RuntimeApiResponseService};
+use crate::{Config, Context};
+use http_body_util::BodyExt;
+use lambda_runtime_api_client::BoxError;
+use lambda_runtime_api_client::Client as ApiClient;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::future::Future;
+use std::sync::Arc;
+use tokio_stream::{Stream, StreamExt};
+use tower::util::BoxService;
+use tower::Layer;
+use tower::{Service, ServiceExt};
+use tracing::trace;
+
+/* ----------------------------------------- INVOCATION ---------------------------------------- */
+
+/// A simple container that provides information about a single invocation of a Lambda function.
+pub struct LambdaInvocation {
+    /// The header of the request sent to invoke the Lambda function.
+    pub parts: http::response::Parts,
+    /// The body of the request sent to invoke the Lambda function.
+    pub body: bytes::Bytes,
+    /// The context of the Lambda invocation.
+    pub context: Context,
+}
+
+/* ------------------------------------------ RUNTIME ------------------------------------------ */
+
+/// Lambda runtime executing a handler function on incoming requests.
+///
+/// Middleware can be added to a runtime using the [Runtime::layer] method in order to execute
+/// logic prior to processing the incoming request and/or after the response has been sent back
+/// to the Lambda Runtime API.
+///
+/// # Example
+/// ```no_run
+/// use lambda_runtime::{Error, LambdaEvent, Runtime};
+/// use serde_json::Value;
+/// use tower::service_fn;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
+///     let func = service_fn(func);
+///     Runtime::new(func).run().await?;
+///     Ok(())
+/// }
+///
+/// async fn func(event: LambdaEvent<Value>) -> Result<Value, Error> {
+///     Ok(event.payload)
+/// }
+/// ````
+pub struct Runtime<S> {
+    service: S,
+    config: Arc<Config>,
+    client: Arc<ApiClient>,
+}
+
+impl Runtime<BoxService<LambdaInvocation, (), BoxError>> {
+    /// Create a new runtime that executes the provided handler for incoming requests.
+    ///
+    /// In order to start the runtime and poll for events on the [Lambda Runtime
+    /// APIs](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html), you must call
+    /// [Runtime::run].
+    pub fn new<F, EventPayload, Response, BufferedResponse, StreamingResponse, StreamItem, StreamError>(
+        handler: F,
+    ) -> Self
+    where
+        F: Service<LambdaEvent<EventPayload>, Response = Response> + Send + 'static,
+        F::Future: Future<Output = Result<Response, F::Error>> + Send + 'static,
+        F::Error: for<'a> Into<Diagnostic<'a>> + Debug,
+        EventPayload: for<'de> Deserialize<'de> + Send + 'static,
+        Response: IntoFunctionResponse<BufferedResponse, StreamingResponse> + Send + 'static,
+        BufferedResponse: Serialize + Send + 'static,
+        StreamingResponse: Stream<Item = Result<StreamItem, StreamError>> + Unpin + Send + 'static,
+        StreamItem: Into<bytes::Bytes> + Send + 'static,
+        StreamError: Into<BoxError> + Send + Debug + 'static,
+    {
+        trace!("Loading config from env");
+        let config = Arc::new(Config::from_env());
+        let client = Arc::new(ApiClient::builder().build().expect("Unable to create a runtime client"));
+        Self {
+            service: wrap_handler(handler, client.clone()),
+            config,
+            client,
+        }
+    }
+}
+
+impl<S> Runtime<S> {
+    /// Add a new layer to this runtime. For an incoming request, this layer will be executed
+    /// before any layer that has been added prior.
+    pub fn layer<L>(self, layer: L) -> Runtime<L::Service>
+    where
+        L: Layer<S>,
+        L::Service: Service<LambdaInvocation, Response = (), Error = BoxError>,
+    {
+        Runtime {
+            client: self.client,
+            config: self.config,
+            service: layer.layer(self.service),
+        }
+    }
+}
+
+impl<S> Runtime<S>
+where
+    S: Service<LambdaInvocation, Response = (), Error = BoxError>,
+{
+    /// Start the runtime and begin polling for events on the Lambda Runtime API.
+    pub async fn run(self) -> Result<(), BoxError> {
+        let incoming = incoming(&self.client);
+        Self::run_with_incoming(self.service, self.config, incoming).await
+    }
+
+    /// Internal utility function to start the runtime with a customized incoming stream.
+    /// This implements the core of the [Runtime::run] method.
+    pub(crate) async fn run_with_incoming(
+        mut service: S,
+        config: Arc<Config>,
+        incoming: impl Stream<Item = Result<http::Response<hyper::body::Incoming>, BoxError>> + Send,
+    ) -> Result<(), BoxError> {
+        tokio::pin!(incoming);
+        while let Some(next_event_response) = incoming.next().await {
+            trace!("New event arrived (run loop)");
+            let event = next_event_response?;
+            let (parts, incoming) = event.into_parts();
+
+            #[cfg(debug_assertions)]
+            if parts.status == http::StatusCode::NO_CONTENT {
+                // Ignore the event if the status code is 204.
+                // This is a way to keep the runtime alive when
+                // there are no events pending to be processed.
+                continue;
+            }
+
+            // Build the invocation such that it can be sent to the service right away
+            // when it is ready
+            let body = incoming.collect().await?.to_bytes();
+            let context = Context::new(invoke_request_id(&parts.headers)?, config.clone(), &parts.headers)?;
+            let invocation = LambdaInvocation { parts, body, context };
+
+            // Wait for service to be ready
+            let ready = service.ready().await?;
+
+            // Once ready, call the service which will respond to the Lambda runtime API
+            ready.call(invocation).await?;
+        }
+        Ok(())
+    }
+}
+
+/* ------------------------------------------- UTILS ------------------------------------------- */
+
+fn wrap_handler<F, EventPayload, Response, BufferedResponse, StreamingResponse, StreamItem, StreamError>(
+    handler: F,
+    client: Arc<ApiClient>,
+) -> BoxService<LambdaInvocation, (), BoxError>
+where
+    F: Service<LambdaEvent<EventPayload>, Response = Response> + Send + 'static,
+    F::Future: Future<Output = Result<Response, F::Error>> + Send + 'static,
+    F::Error: for<'a> Into<Diagnostic<'a>> + Debug,
+    EventPayload: for<'de> Deserialize<'de> + Send + 'static,
+    Response: IntoFunctionResponse<BufferedResponse, StreamingResponse> + Send + 'static,
+    BufferedResponse: Serialize + Send + 'static,
+    StreamingResponse: Stream<Item = Result<StreamItem, StreamError>> + Unpin + Send + 'static,
+    StreamItem: Into<bytes::Bytes> + Send + 'static,
+    StreamError: Into<BoxError> + Send + Debug + 'static,
+{
+    let safe_service = CatchPanicService::new(handler);
+    let response_service = RuntimeApiResponseService::new(safe_service);
+    let client_service = RuntimeApiClientService::new(response_service, client.clone());
+    client_service.boxed()
+}
+
+fn incoming(
+    client: &ApiClient,
+) -> impl Stream<Item = Result<http::Response<hyper::body::Incoming>, BoxError>> + Send + '_ {
+    async_stream::stream! {
+        loop {
+            trace!("Waiting for next event (incoming loop)");
+            let req = NextEventRequest.into_req().expect("Unable to construct request");
+            let res = client.call(req).await;
+            yield res;
+        }
+    }
+}
+
+/* --------------------------------------------------------------------------------------------- */
+/*                                             TESTS                                             */
+/* --------------------------------------------------------------------------------------------- */
+
+#[cfg(test)]
+mod endpoint_tests {
+    use super::{incoming, wrap_handler};
+    use crate::{
+        requests::{EventCompletionRequest, EventErrorRequest, IntoRequest, NextEventRequest},
+        types::Diagnostic,
+        Config, Error, Runtime,
+    };
+    use futures::future::BoxFuture;
+    use http::{HeaderValue, StatusCode};
+    use http_body_util::BodyExt;
+    use httpmock::prelude::*;
+
+    use lambda_runtime_api_client::Client;
+    use std::{borrow::Cow, env, sync::Arc};
+    use tokio_stream::StreamExt;
+
+    #[tokio::test]
+    async fn test_next_event() -> Result<(), Error> {
+        let server = MockServer::start();
+        let request_id = "156cb537-e2d4-11e8-9b34-d36013741fb9";
+        let deadline = "1542409706888";
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/2018-06-01/runtime/invocation/next");
+            then.status(200)
+                .header("content-type", "application/json")
+                .header("lambda-runtime-aws-request-id", request_id)
+                .header("lambda-runtime-deadline-ms", deadline)
+                .body("{}");
+        });
+
+        let base = server.base_url().parse().expect("Invalid mock server Uri");
+        let client = Client::builder().with_endpoint(base).build()?;
+
+        let req = NextEventRequest.into_req()?;
+        let rsp = client.call(req).await.expect("Unable to send request");
+
+        mock.assert_async().await;
+        assert_eq!(rsp.status(), StatusCode::OK);
+        assert_eq!(
+            rsp.headers()["lambda-runtime-aws-request-id"],
+            &HeaderValue::from_static(request_id)
+        );
+        assert_eq!(
+            rsp.headers()["lambda-runtime-deadline-ms"],
+            &HeaderValue::from_static(deadline)
+        );
+
+        let body = rsp.into_body().collect().await?.to_bytes();
+        assert_eq!("{}", std::str::from_utf8(&body)?);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ok_response() -> Result<(), Error> {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/2018-06-01/runtime/invocation/156cb537-e2d4-11e8-9b34-d36013741fb9/response")
+                .body("\"{}\"");
+            then.status(200).body("");
+        });
+
+        let base = server.base_url().parse().expect("Invalid mock server Uri");
+        let client = Client::builder().with_endpoint(base).build()?;
+
+        let req = EventCompletionRequest::new("156cb537-e2d4-11e8-9b34-d36013741fb9", "{}");
+        let req = req.into_req()?;
+
+        let rsp = client.call(req).await?;
+
+        mock.assert_async().await;
+        assert_eq!(rsp.status(), StatusCode::OK);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_error_response() -> Result<(), Error> {
+        let diagnostic = Diagnostic {
+            error_type: Cow::Borrowed("InvalidEventDataError"),
+            error_message: Cow::Borrowed("Error parsing event data"),
+        };
+        let body = serde_json::to_string(&diagnostic)?;
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/2018-06-01/runtime/invocation/156cb537-e2d4-11e8-9b34-d36013741fb9/error")
+                .header("lambda-runtime-function-error-type", "unhandled")
+                .body(body);
+            then.status(200).body("");
+        });
+
+        let base = server.base_url().parse().expect("Invalid mock server Uri");
+        let client = Client::builder().with_endpoint(base).build()?;
+
+        let req = EventErrorRequest {
+            request_id: "156cb537-e2d4-11e8-9b34-d36013741fb9",
+            diagnostic,
+        };
+        let req = req.into_req()?;
+        let rsp = client.call(req).await?;
+
+        mock.assert_async().await;
+        assert_eq!(rsp.status(), StatusCode::OK);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn successful_end_to_end_run() -> Result<(), Error> {
+        let server = MockServer::start();
+        let request_id = "156cb537-e2d4-11e8-9b34-d36013741fb9";
+        let deadline = "1542409706888";
+
+        let next_request = server.mock(|when, then| {
+            when.method(GET).path("/2018-06-01/runtime/invocation/next");
+            then.status(200)
+                .header("content-type", "application/json")
+                .header("lambda-runtime-aws-request-id", request_id)
+                .header("lambda-runtime-deadline-ms", deadline)
+                .body("{}");
+        });
+        let next_response = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/2018-06-01/runtime/invocation/{}/response", request_id))
+                .body("{}");
+            then.status(200).body("");
+        });
+
+        let base = server.base_url().parse().expect("Invalid mock server Uri");
+        let client = Client::builder().with_endpoint(base).build()?;
+
+        async fn func(event: crate::LambdaEvent<serde_json::Value>) -> Result<serde_json::Value, Error> {
+            let (event, _) = event.into_parts();
+            Ok(event)
+        }
+        let f = crate::service_fn(func);
+
+        // set env vars needed to init Config if they are not already set in the environment
+        if env::var("AWS_LAMBDA_RUNTIME_API").is_err() {
+            env::set_var("AWS_LAMBDA_RUNTIME_API", server.base_url());
+        }
+        if env::var("AWS_LAMBDA_FUNCTION_NAME").is_err() {
+            env::set_var("AWS_LAMBDA_FUNCTION_NAME", "test_fn");
+        }
+        if env::var("AWS_LAMBDA_FUNCTION_MEMORY_SIZE").is_err() {
+            env::set_var("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128");
+        }
+        if env::var("AWS_LAMBDA_FUNCTION_VERSION").is_err() {
+            env::set_var("AWS_LAMBDA_FUNCTION_VERSION", "1");
+        }
+        if env::var("AWS_LAMBDA_LOG_STREAM_NAME").is_err() {
+            env::set_var("AWS_LAMBDA_LOG_STREAM_NAME", "test_stream");
+        }
+        if env::var("AWS_LAMBDA_LOG_GROUP_NAME").is_err() {
+            env::set_var("AWS_LAMBDA_LOG_GROUP_NAME", "test_log");
+        }
+        let config = Config::from_env();
+
+        let client = Arc::new(client);
+        let runtime = Runtime {
+            client: client.clone(),
+            config: Arc::new(config),
+            service: wrap_handler(f, client),
+        };
+        let client = &runtime.client;
+        let incoming = incoming(client).take(1);
+        Runtime::run_with_incoming(runtime.service, runtime.config, incoming).await?;
+
+        next_request.assert_async().await;
+        next_response.assert_async().await;
+        Ok(())
+    }
+
+    async fn run_panicking_handler<F>(func: F) -> Result<(), Error>
+    where
+        F: FnMut(crate::LambdaEvent<serde_json::Value>) -> BoxFuture<'static, Result<serde_json::Value, Error>>
+            + Send
+            + 'static,
+    {
+        let server = MockServer::start();
+        let request_id = "156cb537-e2d4-11e8-9b34-d36013741fb9";
+        let deadline = "1542409706888";
+
+        let next_request = server.mock(|when, then| {
+            when.method(GET).path("/2018-06-01/runtime/invocation/next");
+            then.status(200)
+                .header("content-type", "application/json")
+                .header("lambda-runtime-aws-request-id", request_id)
+                .header("lambda-runtime-deadline-ms", deadline)
+                .body("{}");
+        });
+
+        let next_response = server.mock(|when, then| {
+            when.method(POST)
+                .path(format!("/2018-06-01/runtime/invocation/{}/error", request_id))
+                .header("lambda-runtime-function-error-type", "unhandled");
+            then.status(200).body("");
+        });
+
+        let base = server.base_url().parse().expect("Invalid mock server Uri");
+        let client = Client::builder().with_endpoint(base).build()?;
+
+        let f = crate::service_fn(func);
+
+        let config = Arc::new(Config {
+            function_name: "test_fn".to_string(),
+            memory: 128,
+            version: "1".to_string(),
+            log_stream: "test_stream".to_string(),
+            log_group: "test_log".to_string(),
+        });
+
+        let client = Arc::new(client);
+        let runtime = Runtime {
+            client: client.clone(),
+            config,
+            service: wrap_handler(f, client),
+        };
+        let client = &runtime.client;
+        let incoming = incoming(client).take(1);
+        Runtime::run_with_incoming(runtime.service, runtime.config, incoming).await?;
+
+        next_request.assert_async().await;
+        next_response.assert_async().await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn panic_in_async_run() -> Result<(), Error> {
+        run_panicking_handler(|_| Box::pin(async { panic!("This is intentionally here") })).await
+    }
+
+    #[tokio::test]
+    async fn panic_outside_async_run() -> Result<(), Error> {
+        run_panicking_handler(|_| {
+            panic!("This is intentionally here");
+        })
+        .await
+    }
+}

--- a/lambda-runtime/src/types.rs
+++ b/lambda-runtime/src/types.rs
@@ -7,12 +7,10 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     collections::HashMap,
-    env,
     fmt::{Debug, Display},
     time::{Duration, SystemTime},
 };
 use tokio_stream::Stream;
-use tracing::Span;
 
 /// Diagnostic information about an error.
 ///
@@ -208,24 +206,6 @@ impl Context {
     /// The execution deadline for the current invocation.
     pub fn deadline(&self) -> SystemTime {
         SystemTime::UNIX_EPOCH + Duration::from_millis(self.deadline)
-    }
-
-    /// Create a new [`tracing::Span`] for an incoming invocation.
-    pub(crate) fn request_span(&self) -> Span {
-        match &self.xray_trace_id {
-            Some(trace_id) => {
-                env::set_var("_X_AMZN_TRACE_ID", trace_id);
-                tracing::info_span!(
-                    "Lambda runtime invoke",
-                    requestId = &self.request_id,
-                    xrayTraceId = trace_id
-                )
-            }
-            None => {
-                env::remove_var("_X_AMZN_TRACE_ID");
-                tracing::info_span!("Lambda runtime invoke", requestId = &self.request_id)
-            }
-        }
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* #747, #691

*Description of changes:* This PR implements the layering RFC presented by @calavera in #747 with minor modifications to get the implementation running.

Notes about the current implementation:

- The public interface hardly changes: user handlers must now be `Send` and `'static` but that's it. Using the top-level `run` function should result in functionally (almost) equivalent code (except for some logging statements).
- The now-public `Runtime` type adds a few internal layers upon initialization to (1) catch panics in user handlers, (2) transform user handler responses into Runtime API requests, and (3) send completion/error requests to the Runtime API. Users can add their own layers on top: the service input is a custom `LambdaInvocation` type which provides request-specific information along with the `Config` of the Lambda environment for convenience.
- Some services could probably be implemented a little easier if one would accept that any services wrapped in the runtime implement `Clone`.

I also added an example on how one could implement a custom layer to create OpenTelemetry spans and flush telemetry after each invocation, hence, this PR is also closely related to #691.

---

Thanks a lot for originally outlining the implementation @calavera, that helped a lot! Please regard this PR as a proposal for implementation, I'm happy to make both minor and major adjustments. I mainly wanted to share this to further #747.

---

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
