### PR TITLE
fix: do not duplicate headers (single val, multi val) on return

### DIFF
--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -69,7 +69,7 @@ impl LambdaResponse {
                 body,
                 is_base64_encoded,
                 status_code: status_code as i64,
-                headers: headers.clone(),
+                headers: HeaderMap::new(),
                 multi_value_headers: headers,
             }),
             #[cfg(feature = "apigw_http")]
@@ -91,7 +91,7 @@ impl LambdaResponse {
                     is_base64_encoded,
                     status_code: status_code as i64,
                     cookies,
-                    headers: headers.clone(),
+                    headers: HeaderMap::new(), 
                     multi_value_headers: headers,
                 })
             }
@@ -100,7 +100,7 @@ impl LambdaResponse {
                 body,
                 status_code: status_code as i64,
                 is_base64_encoded,
-                headers: headers.clone(),
+                headers: HeaderMap::new(),
                 multi_value_headers: headers,
                 status_description: Some(format!(
                     "{} {}",
@@ -113,7 +113,7 @@ impl LambdaResponse {
                 body,
                 is_base64_encoded,
                 status_code: status_code as i64,
-                headers: headers.clone(),
+                headers: HeaderMap::new(),
                 multi_value_headers: headers,
             }),
             #[cfg(feature = "pass_through")]
@@ -465,7 +465,7 @@ mod tests {
         let json = serde_json::to_string(&response).expect("failed to serialize to json");
         assert_eq!(
             json,
-            r#"{"statusCode":200,"headers":{"content-encoding":"gzip"},"multiValueHeaders":{"content-encoding":["gzip"]},"body":"MDAwMDAw","isBase64Encoded":true,"cookies":[]}"#
+            r#"{"statusCode":200,"headers":{},"multiValueHeaders":{"content-encoding":["gzip"]},"body":"MDAwMDAw","isBase64Encoded":true,"cookies":[]}"#
         )
     }
 
@@ -483,7 +483,7 @@ mod tests {
         let json = serde_json::to_string(&response).expect("failed to serialize to json");
         assert_eq!(
             json,
-            r#"{"statusCode":200,"headers":{"content-type":"application/json"},"multiValueHeaders":{"content-type":["application/json"]},"body":"000000","isBase64Encoded":false,"cookies":[]}"#
+            r#"{"statusCode":200,"headers":{},"multiValueHeaders":{"content-type":["application/json"]},"body":"000000","isBase64Encoded":false,"cookies":[]}"#
         )
     }
 
@@ -501,7 +501,7 @@ mod tests {
         let json = serde_json::to_string(&response).expect("failed to serialize to json");
         assert_eq!(
             json,
-            r#"{"statusCode":200,"headers":{"content-type":"application/json; charset=utf-16"},"multiValueHeaders":{"content-type":["application/json; charset=utf-16"]},"body":"〰〰〰","isBase64Encoded":false,"cookies":[]}"#
+            r#"{"statusCode":200,"headers":{},"multiValueHeaders":{"content-type":["application/json; charset=utf-16"]},"body":"〰〰〰","isBase64Encoded":false,"cookies":[]}"#
         )
     }
 
@@ -519,7 +519,7 @@ mod tests {
         let json = serde_json::to_string(&response).expect("failed to serialize to json");
         assert_eq!(
             json,
-            r#"{"statusCode":200,"headers":{"content-type":"application/graphql-response+json; charset=utf-16"},"multiValueHeaders":{"content-type":["application/graphql-response+json; charset=utf-16"]},"body":"〰〰〰","isBase64Encoded":false,"cookies":[]}"#
+            r#"{"statusCode":200,"headers":{},"multiValueHeaders":{"content-type":["application/graphql-response+json; charset=utf-16"]},"body":"〰〰〰","isBase64Encoded":false,"cookies":[]}"#
         )
     }
 
@@ -553,7 +553,7 @@ mod tests {
         let json = serde_json::to_string(&res).expect("failed to serialize to json");
         assert_eq!(
             json,
-            r#"{"statusCode":200,"headers":{"multi":"a"},"multiValueHeaders":{"multi":["a","b"]},"isBase64Encoded":false}"#
+            r#"{"statusCode":200,"headers":{},"multiValueHeaders":{"multi":["a","b"]},"isBase64Encoded":false}"#
         )
     }
 


### PR DESCRIPTION
*Issue*

This is the Rust equivalent to these changes made in the Go runtime library for lambda HTTP: https://github.com/awslabs/aws-lambda-go-api-proxy/pull/73 

The issue here is that the API Gateway does not properly merge single-value headers and multi-value returned by the Lambda and instead returns both to the client. Since this library just puts the same headers into both, this means that every header is returned twice (more or less, in the case of actual multi-value headers, only the first element is duplicated). In the case of CORS, this is fatal, as browsers rejects duplicate CORS headers. Unless this change can go through, we would be forced to turn off application-level CORS handling and rely on the API gateway instead. 

*Description of changes:*

Adapts the code to return all headers as multi-value headers only, returning an empty `HeaderMap` for the single-value headers. 

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
