### PR TITLE
Allow disabling `tracing` feature

### DIFF
--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -36,7 +36,7 @@ hyper-util = { workspace = true, features = [
     "http1",
     "tokio",
 ] }
-lambda_runtime_api_client = { version = "0.11", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "0.11", path = "../lambda-runtime-api-client", default-features = false }
 pin-project = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "^1"


### PR DESCRIPTION
Without this PR, the `tracing` in the `lambda_runtime_api_client` is not really optional, when that crate is added to the dep tree by the main `lambda_runtime` crate.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
