### PR TITLE
Update tracing.rs - AWS_LAMBDA_LOG_LEVEL rather than RUST_LOG

### DIFF
--- a/lambda-runtime-api-client/src/tracing.rs
+++ b/lambda-runtime-api-client/src/tracing.rs
@@ -16,7 +16,7 @@ pub use tracing::*;
 pub use tracing_subscriber as subscriber;
 
 /// Initialize `tracing-subscriber` with default options.
-/// The subscriber uses `AWS_LAMBDA_LOG_FORMAT` as the environment variable to determine the log level for your function.
+/// The subscriber uses `AWS_LAMBDA_LOG_LEVEL` as the environment variable to determine the log level for your function.
 /// It also uses [Lambda's advance logging controls](https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/)
 /// if they're configured for your function.
 /// By default, the log level to emit events is `INFO`.

--- a/lambda-runtime-api-client/src/tracing.rs
+++ b/lambda-runtime-api-client/src/tracing.rs
@@ -16,7 +16,7 @@ pub use tracing::*;
 pub use tracing_subscriber as subscriber;
 
 /// Initialize `tracing-subscriber` with default options.
-/// The subscriber uses `RUST_LOG` as the environment variable to determine the log level for your function.
+/// The subscriber uses `AWS_LAMBDA_LOG_FORMAT` as the environment variable to determine the log level for your function.
 /// It also uses [Lambda's advance logging controls](https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/)
 /// if they're configured for your function.
 /// By default, the log level to emit events is `INFO`.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes the comment to mention the actual environment variable `AWS_LAMBDA_LOG_LEVEL`. I believe this is not reflective of the latest version anymore. Am I wrong?

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
