### PR TITLE
ApiGatewayV2CustomAuthorizerV2Request identity_source as optional

### DIFF
--- a/lambda-events/src/event/apigw/mod.rs
+++ b/lambda-events/src/event/apigw/mod.rs
@@ -1011,6 +1011,16 @@ mod test {
 
     #[test]
     #[cfg(feature = "apigw")]
+    fn example_apigw_v2_custom_authorizer_v2_request_without_identity_source() {
+        let data = include_bytes!("../../fixtures/example-apigw-v2-custom-authorizer-v2-request-without-identity-source.json");
+        let parsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "apigw")]
     fn example_apigw_console_request() {
         let data = include_bytes!("../../fixtures/example-apigw-console-request.json");
         let parsed: ApiGatewayProxyRequest = serde_json::from_slice(data).unwrap();

--- a/lambda-events/src/event/apigw/mod.rs
+++ b/lambda-events/src/event/apigw/mod.rs
@@ -565,7 +565,8 @@ pub struct ApiGatewayV2CustomAuthorizerV2Request {
     /// nolint: stylecheck
     #[serde(default)]
     pub route_arn: Option<String>,
-    pub identity_source: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identity_source: Option<Vec<String>>,
     #[serde(default)]
     pub route_key: Option<String>,
     #[serde(default)]

--- a/lambda-events/src/event/apigw/mod.rs
+++ b/lambda-events/src/event/apigw/mod.rs
@@ -1012,7 +1012,8 @@ mod test {
     #[test]
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_custom_authorizer_v2_request_without_identity_source() {
-        let data = include_bytes!("../../fixtures/example-apigw-v2-custom-authorizer-v2-request-without-identity-source.json");
+        let data =
+            include_bytes!("../../fixtures/example-apigw-v2-custom-authorizer-v2-request-without-identity-source.json");
         let parsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(output.as_bytes()).unwrap();

--- a/lambda-events/src/fixtures/example-apigw-v2-custom-authorizer-v2-request-without-identity-source.json
+++ b/lambda-events/src/fixtures/example-apigw-v2-custom-authorizer-v2-request-without-identity-source.json
@@ -1,0 +1,50 @@
+{
+  "version": "2.0",
+  "type": "REQUEST",
+  "routeArn": "arn:aws:execute-api:us-east-1:123456789012:abcdef123/test/GET/request",
+  "routeKey": "$default",
+  "rawPath": "/my/path",
+  "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+  "cookies": ["cookie1", "cookie2"],
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2"
+  },
+  "queryStringParameters": {
+    "parameter1": "value1,value2",
+    "parameter2": "value"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "api-id",
+    "authentication": {
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "http": {
+      "method": "POST",
+      "path": "/my/path",
+      "protocol": "HTTP/1.1",
+      "sourceIp": "IP",
+      "userAgent": "agent"
+    },
+    "requestId": "id",
+    "routeKey": "$default",
+    "stage": "$default",
+    "time": "12/Mar/2020:19:03:58 +0000",
+    "timeEpoch": 1583348638390
+  },
+  "pathParameters": { "parameter1": "value1" },
+  "stageVariables": { "stageVariable1": "value1", "stageVariable2": "value2" }
+}
+


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Fixes typing issue with `ApiGatewayV2CustomAuthorizerV2Request` not allowing for `None` as the `identity_source`. I suspect this being an issue as per the [docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/configure-api-gateway-lambda-authorization-with-console.html)

> When caching is turned off, it is not necessary to specify an identity source. API Gateway directly passes the request to the authorizer Lambda function.

Also, I have run into issues with this in the wild as not having the identity source in the API Gateway Terraform configuration results in `DeserializeError { inner: Error { path: Path { segments: [Map { key: \"identitySource\" }] }, original: Error(\"invalid type: null, expected a sequence\"` in my Authorizer code. And after specifying an arbitrary field from the API Gateway event as the identity source it worked fine. 

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
