### PR TITLE
Upgrade base64 to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["examples"]
 
 [workspace.dependencies]
-base64 = "0.21"
+base64 = "0.22"
 bytes = "1"
 chrono = "0.4.35"
 futures = "0.3"


### PR DESCRIPTION
This updates the base64 dependency to the newest version 0.22.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.
