### PR TITLE
Improve Kinesis event recort type

### DIFF
--- a/lambda-events/src/fixtures/example-kinesis-event-encrypted.json
+++ b/lambda-events/src/fixtures/example-kinesis-event-encrypted.json
@@ -1,0 +1,37 @@
+{
+	"Records": [
+		{
+			"kinesis": {
+				"kinesisSchemaVersion": "1.0",
+				"partitionKey": "s1",
+				"sequenceNumber": "49568167373333333333333333333333333333333333333333333333",
+				"data": "SGVsbG8gV29ybGQ=",
+				"approximateArrivalTimestamp": 1480641523.477,
+				"encryptionType": "KMS"
+			},
+			"eventSource": "aws:kinesis",
+			"eventVersion": "1.0",
+			"eventID": "shardId-000000000000:49568167373333333333333333333333333333333333333333333333",
+			"eventName": "aws:kinesis:record",
+			"invokeIdentityArn": "arn:aws:iam::123456789012:role/LambdaRole",
+			"awsRegion": "us-east-1",
+			"eventSourceARN": "arn:aws:kinesis:us-east-1:123456789012:stream/simple-stream"
+		},
+		{
+			"kinesis": {
+				"kinesisSchemaVersion": "1.0",
+				"partitionKey": "s1",
+				"sequenceNumber": "49568167373333333334444444444444444444444444444444444444",
+				"data": "SGVsbG8gV29ybGQ=",
+				"approximateArrivalTimestamp": 1480841523.477
+			},
+			"eventSource": "aws:kinesis",
+			"eventVersion": "1.0",
+			"eventID": "shardId-000000000000:49568167373333333334444444444444444444444444444444444444",
+			"eventName": "aws:kinesis:record",
+			"invokeIdentityArn": "arn:aws:iam::123456789012:role/LambdaRole",
+			"awsRegion": "us-east-1",
+			"eventSourceARN": "arn:aws:kinesis:us-east-1:123456789012:stream/simple-stream"
+		}
+	]
+}


### PR DESCRIPTION
*Issue #, if available:*

Fixes #858

*Description of changes:*

Make the encryption type an enum.
Make sequence number and partition key non-optional.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
