### PR TITLE
[DynamoDB event] Makes ApproximateCreationDateTime optional in StreamRecord

### DIFF
--- a/lambda-events/src/event/dynamodb/mod.rs
+++ b/lambda-events/src/event/dynamodb/mod.rs
@@ -213,9 +213,11 @@ pub struct UserIdentity {
 #[serde(rename_all = "camelCase")]
 pub struct StreamRecord {
     /// The approximate date and time when the stream record was created, in UNIX
-    /// epoch time (http://www.epochconverter.com/) format.
+    /// epoch time (http://www.epochconverter.com/) format. Might not be present in
+    /// the record: https://github.com/awslabs/aws-lambda-rust-runtime/issues/889
     #[serde(rename = "ApproximateCreationDateTime")]
     #[serde(with = "float_unix_epoch")]
+    #[serde(default)]
     pub approximate_creation_date_time: DateTime<Utc>,
     /// The primary key attribute(s) for the DynamoDB item that was modified.
     #[serde(deserialize_with = "deserialize_lambda_dynamodb_item")]
@@ -274,5 +276,7 @@ mod test {
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: EventRecord = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
+        let date = Utc.timestamp_micros(0).unwrap(); // 1970-01-01T00:00:00Z
+        assert_eq!(date, reparsed.change.approximate_creation_date_time);
     }
 }

--- a/lambda-events/src/fixtures/example-dynamodb-event-record-with-optional-fields.json
+++ b/lambda-events/src/fixtures/example-dynamodb-event-record-with-optional-fields.json
@@ -6,7 +6,6 @@
   "recordFormat":"application/json",
   "tableName":"examples",
   "dynamodb":{
-    "ApproximateCreationDateTime":1649809356015,
     "Keys":{
       "id":{
         "S":"00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
*Issue #, if available:* closes https://github.com/awslabs/aws-lambda-rust-runtime/issues/889

*Description of changes:* Makes the DDB event [StreamRecord](https://github.com/awslabs/aws-lambda-rust-runtime/blob/main/lambda-events/src/event/dynamodb/mod.rs#L214-L247) more robust, b/c it appears that `ApproximateCreationDateTime` can be absent. The DDB docs are ambiguous in this matter as they suggest it is not required but also say:

> In the following list, the required parameters are described first.

Maybe we can get more guidance from DDB team?

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that I've run the tests locally using `cargo test`
- [x] I confirm that I've run the lint locally using `cargo fmt`
