### PR TITLE
Make child-spans work as expected when using the lambda-runtime

### DIFF
--- a/lambda-runtime/src/layers/trace.rs
+++ b/lambda-runtime/src/layers/trace.rs
@@ -43,7 +43,11 @@ where
 
     fn call(&mut self, req: LambdaInvocation) -> Self::Future {
         let span = request_span(&req.context);
-        self.inner.call(req).instrument(span)
+        let future = {
+            let _guard = span.enter();
+            self.inner.call(req)
+        };
+        future.instrument(span)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Implementing a sub-span directly in the `service_fn` does not currently set the parent-span in the expected way. Example:

```rust
let func = service_fn(move |event: LambdaEvent<T>| {
    let event_span = create_event_span(outer_variable);
    inner_handler(event, state.clone()).instrument(event_span)
});
```

The problem is, that at the time where the `create_event_span()` function is called, the span returned by `request_span()` has not been entered, so it will be not be set as the parent.

The solution is to enter the span before calling the inner service. This also matches e.g. how [`tower_http` does it](https://github.com/tower-rs/tower-http/blob/a1e3f8a28bdb118c98627b8fa2d05180049dc981/tower-http/src/trace/service.rs#L308).

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
