### PR TITLE
Add OpenTelemetry layer as optional

### DIFF
--- a/examples/opentelemetry-tracing/Cargo.toml
+++ b/examples/opentelemetry-tracing/Cargo.toml
@@ -4,33 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# Library dependencies
-lambda_runtime = { path = "../../lambda-runtime" }
-pin-project = "1"
+lambda_runtime = { path = "../../lambda-runtime", features = ["opentelemetry"] }
 opentelemetry-semantic-conventions = "0.14"
+opentelemetry = "0.22"
+opentelemetry_sdk = { version = "0.22", features = ["rt-tokio"] }
+opentelemetry-stdout = { version = "0.3", features = ["trace"] }
+pin-project = "1"
+serde_json = "1.0"
+tokio = "1"
 tower = "0.4"
 tracing = "0.1"
-
-# Binary dependencies
-opentelemetry = { version = "0.22", optional = true }
-opentelemetry_sdk = { version = "0.22", features = ["rt-tokio"], optional = true }
-opentelemetry-stdout = { version = "0.3", features = ["trace"], optional = true }
-serde_json = { version = "1.0", optional = true }
-tokio = { version = "1", optional = true }
-tracing-opentelemetry = { version = "0.23", optional = true }
-tracing-subscriber = { version = "0.3", optional = true }
-
-[features]
-build-binary = [
-    "opentelemetry",
-    "opentelemetry_sdk",
-    "opentelemetry-stdout",
-    "serde_json",
-    "tokio",
-    "tracing-opentelemetry",
-    "tracing-subscriber",
-]
-
-[[bin]]
-name = "opentelemetry-tracing"
-required-features = ["build-binary"]
+tracing-opentelemetry = "0.23"
+tracing-subscriber = "0.3"

--- a/examples/opentelemetry-tracing/src/main.rs
+++ b/examples/opentelemetry-tracing/src/main.rs
@@ -1,7 +1,6 @@
-use lambda_runtime::{LambdaEvent, Runtime};
+use lambda_runtime::{layers::OpenTelemetryLayer as OtelLayer, LambdaEvent, Runtime};
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::{runtime, trace};
-use opentelemetry_tracing::OpenTelemetryLayer;
 use tower::{service_fn, BoxError};
 use tracing_subscriber::prelude::*;
 
@@ -25,7 +24,7 @@ async fn main() -> Result<(), BoxError> {
         .init();
 
     // Initialize the Lambda runtime and add OpenTelemetry tracing
-    let runtime = Runtime::new(service_fn(echo)).layer(OpenTelemetryLayer::new(|| {
+    let runtime = Runtime::new(service_fn(echo)).layer(OtelLayer::new(|| {
         // Make sure that the trace is exported before the Lambda runtime is frozen
         tracer_provider.force_flush();
     }));

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -16,6 +16,7 @@ readme = "../README.md"
 [features]
 default = ["tracing"]
 tracing = ["lambda_runtime_api_client/tracing"]
+opentelemetry = ["opentelemetry-semantic-conventions"]
 
 [dependencies]
 async-stream = "0.3"
@@ -34,6 +35,7 @@ hyper-util = { workspace = true, features = [
     "tokio",
 ] }
 lambda_runtime_api_client = { version = "0.11.1", path = "../lambda-runtime-api-client", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.14", optional = true }
 pin-project = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "^1"

--- a/lambda-runtime/src/layers/mod.rs
+++ b/lambda-runtime/src/layers/mod.rs
@@ -10,3 +10,8 @@ pub(crate) use api_client::RuntimeApiClientService;
 pub(crate) use api_response::RuntimeApiResponseService;
 pub(crate) use panic::CatchPanicService;
 pub use trace::TracingLayer;
+
+#[cfg(feature = "opentelemetry")]
+mod otel;
+#[cfg(feature = "opentelemetry")]
+pub use otel::OpenTelemetryLayer;

--- a/lambda-runtime/src/layers/trace.rs
+++ b/lambda-runtime/src/layers/trace.rs
@@ -44,6 +44,8 @@ where
     fn call(&mut self, req: LambdaInvocation) -> Self::Future {
         let span = request_span(&req.context);
         let future = {
+            // Enter the span before calling the inner service
+            // to ensure that it's assigned as parent of the inner spans.
             let _guard = span.enter();
             self.inner.call(req)
         };


### PR DESCRIPTION
*Issue #, if available:*

Closes #866 

*Description of changes:*

- Add the OpenTelemetryLayer as an optional module to the runtime.
- Fixes issue creating multiple spans instead of assigning one as parent.

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
