### PR TITLE
Organize imports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
-*Issue #, if available:*
+📬 *Issue #, if available:*
 
-*Description of changes:*
+✍️ *Description of changes:*
 
-By submitting this pull request
+🔏 *By submitting this pull request*
 
-- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
+- [ ] I confirm that I've ran `cargo +nightly fmt`.
+- [ ] I confirm that I've ran `cargo clippy --fix`.
 - [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
+- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,53 +3,29 @@ name: Formatting and Linting
 on: [push, pull_request]
 
 jobs:
-  check:
+  fmt:
+    name: Cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Run fmt check
+        id: cargoFmt
+        shell: bash
+        run: cargo +nightly fmt --all -- --check
+  clippy:
+    name: Cargo clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-
-      - name: Run fmt check
-        id: cargoFmt
-        shell: bash
-        run: cargo fmt --all -- --check
-      - name: Notify fmt check
-        if: failure() && steps.cargoFmt.outcome == 'failure'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const message = `👋 It looks like your code is not formatted like we expect.
-              
-              Please run \`cargo fmt\` and push the code again.`;
-      
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: message,
-            });
-            core.setFailed('It looks like there are formatting errors');
-      
       - name: Run clippy check
         id: cargoClippy
         shell: bash
         run: cargo clippy --workspace --all-features -- -D warnings
-      - name: Notify fmt check
-        if: failure() && steps.cargoClippy.outcome == 'failure'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const message = `👋 It looks like your code has some linting issues.
-              
-              Please run \`cargo clippy --fix\` and push the code again.`;
-      
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: message,
-            });
-            core.setFailed('It looks like there are linting errors');
       
       

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,14 @@
 edition = "2021"
-# imports_granularity is unstable
-# # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports
-# imports_granularity = "Crate"
+
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#max_width
 max_width = 120
+
+#https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#reorder_imports
+reorder_imports = true
+
+#https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#unstable_features
+unstable_features = true
+
+# imports_granularity is unstable
+# https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports
+imports_granularity = "Crate"

--- a/lambda-events/src/custom_serde/codebuild_time.rs
+++ b/lambda-events/src/custom_serde/codebuild_time.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
-use serde::ser::Serializer;
 use serde::{
     de::{Deserializer, Error as DeError, Visitor},
+    ser::Serializer,
     Deserialize,
 };
 use std::fmt;

--- a/lambda-events/src/custom_serde/float_unix_epoch.rs
+++ b/lambda-events/src/custom_serde/float_unix_epoch.rs
@@ -1,8 +1,7 @@
 use serde::{de, ser};
 use std::fmt;
 
-use chrono::offset::TimeZone;
-use chrono::{DateTime, LocalResult, Utc};
+use chrono::{offset::TimeZone, DateTime, LocalResult, Utc};
 
 enum SerdeError<V: fmt::Display, D: fmt::Display> {
     NonExistent { timestamp: V },

--- a/lambda-events/src/custom_serde/headers.rs
+++ b/lambda-events/src/custom_serde/headers.rs
@@ -1,7 +1,8 @@
-use http::header::HeaderName;
-use http::{HeaderMap, HeaderValue};
-use serde::de::{self, Deserializer, Error as DeError, MapAccess, Unexpected, Visitor};
-use serde::ser::{Error as SerError, SerializeMap, Serializer};
+use http::{header::HeaderName, HeaderMap, HeaderValue};
+use serde::{
+    de::{self, Deserializer, Error as DeError, MapAccess, Unexpected, Visitor},
+    ser::{Error as SerError, SerializeMap, Serializer},
+};
 use std::{borrow::Cow, fmt};
 
 /// Serialize a http::HeaderMap into a serde str => Vec<str> map

--- a/lambda-events/src/custom_serde/http_method.rs
+++ b/lambda-events/src/custom_serde/http_method.rs
@@ -1,6 +1,8 @@
 use http::Method;
-use serde::de::{Deserialize, Deserializer, Error as DeError, Unexpected, Visitor};
-use serde::ser::Serializer;
+use serde::{
+    de::{Deserialize, Deserializer, Error as DeError, Unexpected, Visitor},
+    ser::Serializer,
+};
 use std::fmt;
 
 pub fn serialize<S: Serializer>(method: &Method, ser: S) -> Result<S::Ok, S::Error> {

--- a/lambda-events/src/custom_serde/mod.rs
+++ b/lambda-events/src/custom_serde/mod.rs
@@ -1,6 +1,8 @@
 use base64::Engine;
-use serde::de::{Deserialize, Deserializer, Error as DeError};
-use serde::ser::Serializer;
+use serde::{
+    de::{Deserialize, Deserializer, Error as DeError},
+    ser::Serializer,
+};
 use std::collections::HashMap;
 
 #[cfg(feature = "codebuild")]

--- a/lambda-events/src/encodings/http.rs
+++ b/lambda-events/src/encodings/http.rs
@@ -1,8 +1,10 @@
 use base64::display::Base64Display;
 use bytes::Bytes;
 use http_body::{Body as HttpBody, SizeHint};
-use serde::de::{Deserialize, Deserializer, Error as DeError, Visitor};
-use serde::ser::{Error as SerError, Serialize, Serializer};
+use serde::{
+    de::{Deserialize, Deserializer, Error as DeError, Visitor},
+    ser::{Error as SerError, Serialize, Serializer},
+};
 use std::{borrow::Cow, mem::take, ops::Deref, pin::Pin, task::Poll};
 
 /// Representation of http request and response bodies as supported

--- a/lambda-events/src/encodings/mod.rs
+++ b/lambda-events/src/encodings/mod.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{ops::Deref, ops::DerefMut};
+use std::ops::{Deref, DerefMut};
 
 #[cfg(feature = "chrono")]
 mod time;

--- a/lambda-events/src/encodings/time.rs
+++ b/lambda-events/src/encodings/time.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, TimeDelta, TimeZone, Utc};
-use serde::ser::Serializer;
 use serde::{
     de::{Deserializer, Error as DeError},
+    ser::Serializer,
     Deserialize, Serialize,
 };
 use std::ops::{Deref, DerefMut};

--- a/lambda-events/src/event/alb/mod.rs
+++ b/lambda-events/src/event/alb/mod.rs
@@ -1,7 +1,9 @@
-use crate::custom_serde::{
-    deserialize_headers, deserialize_nullish_boolean, http_method, serialize_headers, serialize_multi_value_headers,
+use crate::{
+    custom_serde::{
+        deserialize_headers, deserialize_nullish_boolean, http_method, serialize_headers, serialize_multi_value_headers,
+    },
+    encodings::Body,
 };
-use crate::encodings::Body;
 use http::{HeaderMap, Method};
 use query_map::QueryMap;
 use serde::{Deserialize, Serialize};

--- a/lambda-events/src/event/apigw/mod.rs
+++ b/lambda-events/src/event/apigw/mod.rs
@@ -1,9 +1,11 @@
-use crate::custom_serde::{
-    deserialize_headers, deserialize_lambda_map, deserialize_nullish_boolean, http_method, serialize_headers,
-    serialize_multi_value_headers,
+use crate::{
+    custom_serde::{
+        deserialize_headers, deserialize_lambda_map, deserialize_nullish_boolean, http_method, serialize_headers,
+        serialize_multi_value_headers,
+    },
+    encodings::Body,
+    iam::IamPolicyStatement,
 };
-use crate::encodings::Body;
-use crate::iam::IamPolicyStatement;
 use http::{HeaderMap, Method};
 use query_map::QueryMap;
 use serde::{de::DeserializeOwned, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};

--- a/lambda-events/src/event/appsync/mod.rs
+++ b/lambda-events/src/event/appsync/mod.rs
@@ -1,5 +1,4 @@
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/lambda-events/src/event/autoscaling/mod.rs
+++ b/lambda-events/src/event/autoscaling/mod.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/lambda-events/src/event/cloudformation/mod.rs
+++ b/lambda-events/src/event/cloudformation/mod.rs
@@ -102,8 +102,7 @@ pub enum CloudFormationCustomResourceResponseStatus {
 mod test {
     use std::collections::HashMap;
 
-    use super::CloudFormationCustomResourceRequest::*;
-    use super::*;
+    use super::{CloudFormationCustomResourceRequest::*, *};
 
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     #[serde(rename_all = "PascalCase")]

--- a/lambda-events/src/event/cloudformation/provider.rs
+++ b/lambda-events/src/event/cloudformation/provider.rs
@@ -90,8 +90,7 @@ where
 mod test {
     use std::collections::HashMap;
 
-    use super::CloudFormationCustomResourceRequest::*;
-    use super::*;
+    use super::{CloudFormationCustomResourceRequest::*, *};
 
     #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     #[serde(rename_all = "PascalCase")]

--- a/lambda-events/src/event/cloudwatch_events/mod.rs
+++ b/lambda-events/src/event/cloudwatch_events/mod.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 
 pub mod cloudtrail;

--- a/lambda-events/src/event/codebuild/mod.rs
+++ b/lambda-events/src/event/codebuild/mod.rs
@@ -1,8 +1,9 @@
-use crate::custom_serde::{codebuild_time, CodeBuildNumber};
-use crate::encodings::{MinuteDuration, SecondDuration};
+use crate::{
+    custom_serde::{codebuild_time, CodeBuildNumber},
+    encodings::{MinuteDuration, SecondDuration},
+};
 use chrono::{DateTime, Utc};
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 
 pub type CodeBuildPhaseStatus = String;

--- a/lambda-events/src/event/cognito/mod.rs
+++ b/lambda-events/src/event/cognito/mod.rs
@@ -1,5 +1,4 @@
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/lambda-events/src/event/dynamodb/mod.rs
+++ b/lambda-events/src/event/dynamodb/mod.rs
@@ -1,6 +1,8 @@
-use crate::custom_serde::deserialize_lambda_dynamodb_item;
-use crate::time_window::*;
-use crate::{custom_serde::float_unix_epoch, streams::DynamoDbBatchItemFailure};
+use crate::{
+    custom_serde::{deserialize_lambda_dynamodb_item, float_unix_epoch},
+    streams::DynamoDbBatchItemFailure,
+    time_window::*,
+};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/lambda-events/src/event/eventbridge/mod.rs
+++ b/lambda-events/src/event/eventbridge/mod.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 
 /// Parse EventBridge events.

--- a/lambda-events/src/event/iot/mod.rs
+++ b/lambda-events/src/event/iot/mod.rs
@@ -1,6 +1,4 @@
-use crate::custom_serde::serialize_headers;
-use crate::encodings::Base64Data;
-use crate::iam::IamPolicyDocument;
+use crate::{custom_serde::serialize_headers, encodings::Base64Data, iam::IamPolicyDocument};
 use http::HeaderMap;
 use serde::{Deserialize, Serialize};
 

--- a/lambda-events/src/event/kinesis/event.rs
+++ b/lambda-events/src/event/kinesis/event.rs
@@ -1,5 +1,7 @@
-use crate::encodings::{Base64Data, SecondTimestamp};
-use crate::time_window::{TimeWindowEventResponseProperties, TimeWindowProperties};
+use crate::{
+    encodings::{Base64Data, SecondTimestamp},
+    time_window::{TimeWindowEventResponseProperties, TimeWindowProperties},
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/lambda-events/src/event/rabbitmq/mod.rs
+++ b/lambda-events/src/event/rabbitmq/mod.rs
@@ -1,5 +1,4 @@
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/lambda-events/src/event/s3/object_lambda.rs
+++ b/lambda-events/src/event/s3/object_lambda.rs
@@ -1,6 +1,5 @@
 use http::HeaderMap;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 

--- a/lambda-events/src/event/sns/mod.rs
+++ b/lambda-events/src/event/sns/mod.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::custom_serde::{deserialize_lambda_map, deserialize_nullish_boolean};

--- a/lambda-events/src/event/sqs/mod.rs
+++ b/lambda-events/src/event/sqs/mod.rs
@@ -1,7 +1,5 @@
-use crate::custom_serde::deserialize_lambda_map;
-use crate::encodings::Base64Data;
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
+use crate::{custom_serde::deserialize_lambda_map, encodings::Base64Data};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// The Event sent to Lambda from SQS. Contains 1 or more individual SQS Messages

--- a/lambda-extension/src/extension.rs
+++ b/lambda-extension/src/extension.rs
@@ -1,14 +1,18 @@
 use http::Request;
 use http_body_util::BodyExt;
-use hyper::body::Incoming;
-use hyper::server::conn::http1;
-use hyper::service::service_fn;
+use hyper::{body::Incoming, server::conn::http1, service::service_fn};
 
 use hyper_util::rt::tokio::TokioIo;
 use lambda_runtime_api_client::Client;
 use serde::Deserialize;
 use std::{
-    convert::Infallible, fmt, future::ready, future::Future, net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc,
+    convert::Infallible,
+    fmt,
+    future::{ready, Future},
+    net::SocketAddr,
+    path::PathBuf,
+    pin::Pin,
+    sync::Arc,
 };
 use tokio::{net::TcpListener, sync::Mutex};
 use tokio_stream::StreamExt;

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -26,15 +26,12 @@ use aws_lambda_events::apigw::{ApiGatewayV2httpRequest, ApiGatewayV2httpRequestC
 #[cfg(feature = "apigw_websockets")]
 use aws_lambda_events::apigw::{ApiGatewayWebsocketProxyRequest, ApiGatewayWebsocketProxyRequestContext};
 use aws_lambda_events::{encodings::Body, query_map::QueryMap};
-use http::header::HeaderName;
-use http::{HeaderMap, HeaderValue};
+use http::{header::HeaderName, HeaderMap, HeaderValue};
 
 use serde::{Deserialize, Serialize};
 use serde_json::error::Error as JsonError;
 
-use std::future::Future;
-use std::pin::Pin;
-use std::{env, io::Read};
+use std::{env, future::Future, io::Read, pin::Pin};
 use url::Url;
 
 /// Internal representation of an Lambda http event from

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -9,16 +9,20 @@ use aws_lambda_events::apigw::ApiGatewayProxyResponse;
 use aws_lambda_events::apigw::ApiGatewayV2httpResponse;
 use aws_lambda_events::encodings::Body;
 use encoding_rs::Encoding;
-use http::header::CONTENT_ENCODING;
-use http::HeaderMap;
-use http::{header::CONTENT_TYPE, Response, StatusCode};
+use http::{
+    header::{CONTENT_ENCODING, CONTENT_TYPE},
+    HeaderMap, Response, StatusCode,
+};
 use http_body::Body as HttpBody;
 use http_body_util::BodyExt;
 use mime::{Mime, CHARSET};
 use serde::Serialize;
-use std::borrow::Cow;
-use std::future::ready;
-use std::{fmt, future::Future, pin::Pin};
+use std::{
+    borrow::Cow,
+    fmt,
+    future::{ready, Future},
+    pin::Pin,
+};
 
 const X_LAMBDA_HTTP_CONTENT_ENCODING: &str = "x-lambda-http-content-encoding";
 

--- a/lambda-http/src/streaming.rs
+++ b/lambda-http/src/streaming.rs
@@ -1,15 +1,14 @@
-use crate::http::header::SET_COOKIE;
-use crate::tower::ServiceBuilder;
-use crate::Request;
-use crate::{request::LambdaRequest, RequestExt};
+use crate::{http::header::SET_COOKIE, request::LambdaRequest, tower::ServiceBuilder, Request, RequestExt};
 use bytes::Bytes;
 pub use http::{self, Response};
 use http_body::Body;
 use lambda_runtime::Diagnostic;
 pub use lambda_runtime::{self, tower::ServiceExt, Error, LambdaEvent, MetadataPrelude, Service, StreamResponse};
-use std::fmt::Debug;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    fmt::Debug,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use tokio_stream::Stream;
 
 /// Starts the Lambda Rust runtime and stream response back [Configure Lambda

--- a/lambda-runtime-api-client/src/body/channel.rs
+++ b/lambda-runtime-api-client/src/body/channel.rs
@@ -1,19 +1,17 @@
 //! Body::channel utilities. Extracted from Hyper under MIT license.
 //! https://github.com/hyperium/hyper/blob/master/LICENSE
 
-use std::pin::Pin;
-use std::task::Context;
-use std::task::Poll;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use crate::body::{sender, watch};
 use bytes::Bytes;
-use futures_channel::mpsc;
-use futures_channel::oneshot;
+use futures_channel::{mpsc, oneshot};
 use futures_util::{stream::FusedStream, Future, Stream};
 use http::HeaderMap;
-use http_body::Body;
-use http_body::Frame;
-use http_body::SizeHint;
+use http_body::{Body, Frame, SizeHint};
 pub use sender::Sender;
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/lambda-runtime-api-client/src/body/mod.rs
+++ b/lambda-runtime-api-client/src/body/mod.rs
@@ -6,8 +6,10 @@ use bytes::Bytes;
 use futures_util::stream::Stream;
 use http_body::{Body as _, Frame};
 use http_body_util::{BodyExt, Collected};
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use self::channel::Sender;
 

--- a/lambda-runtime-api-client/src/body/watch.rs
+++ b/lambda-runtime-api-client/src/body/watch.rs
@@ -8,11 +8,13 @@
 //! - The value `0` is reserved for closed.
 
 use futures_util::task::AtomicWaker;
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task,
 };
-use std::task;
 
 type Value = usize;
 

--- a/lambda-runtime-api-client/src/lib.rs
+++ b/lambda-runtime-api-client/src/lib.rs
@@ -5,7 +5,10 @@
 //! This crate includes a base HTTP client to interact with
 //! the AWS Lambda Runtime API.
 use futures_util::{future::BoxFuture, FutureExt, TryFutureExt};
-use http::{uri::PathAndQuery, uri::Scheme, Request, Response, Uri};
+use http::{
+    uri::{PathAndQuery, Scheme},
+    Request, Response, Uri,
+};
 use hyper::body::Incoming;
 use hyper_util::client::legacy::connect::HttpConnector;
 use std::{convert::TryInto, fmt::Debug, future};

--- a/lambda-runtime/src/layers/api_client.rs
+++ b/lambda-runtime/src/layers/api_client.rs
@@ -3,10 +3,7 @@ use futures::{future::BoxFuture, ready, FutureExt, TryFutureExt};
 use hyper::body::Incoming;
 use lambda_runtime_api_client::{body::Body, BoxError, Client};
 use pin_project::pin_project;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task;
+use std::{future::Future, pin::Pin, sync::Arc, task};
 use tower::Service;
 use tracing::error;
 

--- a/lambda-runtime/src/layers/api_response.rs
+++ b/lambda-runtime/src/layers/api_response.rs
@@ -4,16 +4,11 @@ use crate::{
     runtime::LambdaInvocation,
     Diagnostic, EventErrorRequest, IntoFunctionResponse, LambdaEvent,
 };
-use futures::ready;
-use futures::Stream;
+use futures::{ready, Stream};
 use lambda_runtime_api_client::{body::Body, BoxError};
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task;
+use std::{fmt::Debug, future::Future, marker::PhantomData, pin::Pin, task};
 use tower::Service;
 use tracing::{error, trace};
 

--- a/lambda-runtime/src/layers/otel.rs
+++ b/lambda-runtime/src/layers/otel.rs
@@ -1,13 +1,10 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::task;
+use std::{future::Future, pin::Pin, task};
 
 use crate::LambdaInvocation;
 use opentelemetry_semantic_conventions::trace as traceconv;
 use pin_project::pin_project;
 use tower::{Layer, Service};
-use tracing::instrument::Instrumented;
-use tracing::Instrument;
+use tracing::{instrument::Instrumented, Instrument};
 
 /// Tower layer to add OpenTelemetry tracing to a Lambda function invocation. The layer accepts
 /// a function to flush OpenTelemetry after the end of the invocation.

--- a/lambda-runtime/src/layers/panic.rs
+++ b/lambda-runtime/src/layers/panic.rs
@@ -1,14 +1,9 @@
 use crate::{Diagnostic, LambdaEvent};
 use futures::{future::CatchUnwind, FutureExt};
 use pin_project::pin_project;
-use std::any::Any;
-use std::borrow::Cow;
-use std::fmt::Debug;
-use std::future::Future;
-use std::marker::PhantomData;
-use std::panic::AssertUnwindSafe;
-use std::pin::Pin;
-use std::task;
+use std::{
+    any::Any, borrow::Cow, fmt::Debug, future::Future, marker::PhantomData, panic::AssertUnwindSafe, pin::Pin, task,
+};
 use tower::Service;
 use tracing::error;
 

--- a/lambda-runtime/src/requests.rs
+++ b/lambda-runtime/src/requests.rs
@@ -1,12 +1,9 @@
 use crate::{types::ToStreamErrorTrailer, Diagnostic, Error, FunctionResponse, IntoFunctionResponse};
 use bytes::Bytes;
-use http::header::CONTENT_TYPE;
-use http::{Method, Request, Uri};
+use http::{header::CONTENT_TYPE, Method, Request, Uri};
 use lambda_runtime_api_client::{body::Body, build_request};
 use serde::Serialize;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::str::FromStr;
+use std::{fmt::Debug, marker::PhantomData, str::FromStr};
 use tokio_stream::{Stream, StreamExt};
 
 pub(crate) trait IntoRequest {

--- a/lambda-runtime/src/runtime.rs
+++ b/lambda-runtime/src/runtime.rs
@@ -1,18 +1,15 @@
-use crate::layers::{CatchPanicService, RuntimeApiClientService, RuntimeApiResponseService};
-use crate::requests::{IntoRequest, NextEventRequest};
-use crate::types::{invoke_request_id, IntoFunctionResponse, LambdaEvent};
-use crate::{Config, Context, Diagnostic};
+use crate::{
+    layers::{CatchPanicService, RuntimeApiClientService, RuntimeApiResponseService},
+    requests::{IntoRequest, NextEventRequest},
+    types::{invoke_request_id, IntoFunctionResponse, LambdaEvent},
+    Config, Context, Diagnostic,
+};
 use http_body_util::BodyExt;
-use lambda_runtime_api_client::BoxError;
-use lambda_runtime_api_client::Client as ApiClient;
+use lambda_runtime_api_client::{BoxError, Client as ApiClient};
 use serde::{Deserialize, Serialize};
-use std::env;
-use std::fmt::Debug;
-use std::future::Future;
-use std::sync::Arc;
+use std::{env, fmt::Debug, future::Future, sync::Arc};
 use tokio_stream::{Stream, StreamExt};
-use tower::Layer;
-use tower::{Service, ServiceExt};
+use tower::{Layer, Service, ServiceExt};
 use tracing::trace;
 
 /* ----------------------------------------- INVOCATION ---------------------------------------- */


### PR DESCRIPTION

✍️ *Description of changes:*

I've had these defaults in other projects for a long time, and I find them more clear and easier to keep imports organized.

- Group imports by crate.
- Add instructions to the PR template about clippy and fmt.
- Remove PR comments because they don't work on forks.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
