### PR TITLE
Release runtime 0.12 and extension 0.11

### DIFF
--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-extension"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = [
     "David Calavera <dcalaver@amazon.com>",

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.11.4"
+version = "0.12.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -34,7 +34,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "0.11.3", path = "../lambda-runtime" }
+lambda_runtime = { version = "0.12.0", path = "../lambda-runtime" }
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "0.11.3"
+version = "0.12.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",


### PR DESCRIPTION
*Description of changes:*

*Runtime:*

- Relax Diagnostic trait implementation (this is a big change, so I rather have a minor release instead of a patch)
- Fix issues creating parent tracing spans

*Extension:*
- Add account id response extension

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
