### PR TITLE
Improved error messages about payload deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ async fn main() -> Result<(), Error> {
 }
 ```
 
-The subscriber uses `RUST_LOG` as the environment variable to determine the log level for your function. It also uses [Lambda's advance logging controls](https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/) if they're configured for your function. By default, the log level to emit events is `INFO`.
+The subscriber uses `RUST_LOG` environment variable to determine the log level for your function. It also uses [Lambda's advanced logging controls](https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/), if configured.
+
+By default, the log level to emit events is `INFO`. Log at `TRACE` level for more detail, including a dump of the raw payload.
 
 ## AWS event objects
 

--- a/lambda-runtime/src/layers/api_response.rs
+++ b/lambda-runtime/src/layers/api_response.rs
@@ -98,7 +98,7 @@ where
             Ok(())
         };
         if let Err(err) = trace_fn() {
-            error!(error = ?err, "failed to parse raw JSON event received from Lambda");
+            error!(error = ?err, "Failed to parse raw JSON event received from Lambda. The handler will not be called. Log at TRACE level to see the payload.");
             return RuntimeApiResponseFuture::Ready(Some(Err(err)));
         };
 
@@ -124,7 +124,7 @@ fn build_event_error_request<'a, T>(request_id: &'a str, err: T) -> Result<http:
 where
     T: Into<Diagnostic<'a>> + Debug,
 {
-    error!(error = ?err, "building error response for Lambda Runtime API");
+    error!(error = ?err, "Request payload deserialization into LambdaEvent<T> failed. The handler will not be called. Log at TRACE level to see the payload.");
     EventErrorRequest::new(request_id, err).into_req()
 }
 


### PR DESCRIPTION
This PR makes errors about payload deserialization into a concrete event type more informative.

For example, my lambda had `LambdaEvent<ApiGatewayProxyRequest>` and was failing with the following error message:
```
ERROR lambda_runtime::layers::api_response: building error response for Lambda Runtime API error=DeserializeError { inner: Error { path: Path { segments: [] }, original: Error("missing field `httpMethod`", line: 1, column: 49) } }
```
That error message makes perfect sense to the developer of the runtime, but the user is likely to be stumped because the problem is a mismatch between the payload and the target type, but the error says `building error response for Lambda Runtime API`. What does that mean?

I was and had to look up the runtime source to understand what's going. 

The proposed message is not ideal, but makes it clearer that the error happened before the handler was called, relates to the deserialization and suggests where to find more info (TRACE):
```
ERROR lambda_runtime::layers::api_response: Request payload deserialization into LambdaEvent<T> failed. The handler will not be called. Log at TRACE level to see the payload. error=DeserializeError { inner: Error { path: Path { segments: [] }, original: Error("missing field `httpMethod`", line: 1, column: 49) } }
```

I also added a note about logging with TRACE to see the raw payload. It is a very useful feature that is worth mentioning. I accidentally stumbled across it while working on this PR.

Looks like the runtime uses TRACE and not DEBUG.


## Changes made

* made error messages more informative
* added a suggestion to log at TRACE level to README

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
