### PR TITLE
Fixed clippy warnings in lambda-events

### DIFF
--- a/lambda-events/src/event/cloudwatch_events/cloudtrail.rs
+++ b/lambda-events/src/event/cloudwatch_events/cloudtrail.rs
@@ -91,7 +91,7 @@ mod tests {
         let data = include_bytes!("../../fixtures/example-cloudwatch-cloudtrail-assumed-role.json");
         let parsed: AWSAPICall = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AWSAPICall = serde_json::from_slice(&output.as_bytes()).unwrap();
+        let reparsed: AWSAPICall = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
@@ -100,7 +100,7 @@ mod tests {
         let data = include_bytes!("../../fixtures/example-cloudwatch-cloudtrail-unknown-federate.json");
         let parsed: AWSAPICall = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AWSAPICall = serde_json::from_slice(&output.as_bytes()).unwrap();
+        let reparsed: AWSAPICall = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
@@ -109,7 +109,7 @@ mod tests {
         let data = include_bytes!("../../fixtures/example-cloudwatch-cloudtrail-unknown-user-auth.json");
         let parsed: AWSAPICall = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AWSAPICall = serde_json::from_slice(&output.as_bytes()).unwrap();
+        let reparsed: AWSAPICall = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }


### PR DESCRIPTION
A minor fix to remove Clippy warnings in lambda-events:

```
this expression creates a reference which is immediately dereferenced by the compiler
for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
`#[warn(clippy::needless_borrow)]` on by defaultclippy[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20%5B0%5D?0#file%3A%2F%2F%2Fhome%2Fmx%2Fprojects%2Fgh-forks%2Faws-lambda-rust-runtime-fork%2Flambda-events%2Fsrc%2Fevent%2Fcloudwatch_events%2Fcloudtrail.rs)
cloudtrail.rs(103, 59): change this to: `output.as_bytes()`
```

Weirdly enough, the warnings came up in VSCode, but not in the CLI.
@martinjlowm, please take a look if you get a chance in case I'm breaking something with this fix. It was your code.


🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
