### PR TITLE
Make root level tracing span (TracingLayer) optional

### DIFF
--- a/lambda-runtime-api-client/src/tracing.rs
+++ b/lambda-runtime-api-client/src/tracing.rs
@@ -23,7 +23,7 @@ const DEFAULT_LOG_LEVEL: &str = "INFO";
 /// if they're configured for your function.
 ///
 /// This subscriber sets the logging level based on environment variables:
-///     - if `AWS_LAMBDA_LOG_LEVEL` is set, it takes predecence over any other environment variables.
+///     - if `AWS_LAMBDA_LOG_LEVEL` is set, it takes precedence over any other environment variables.
 ///     - if `AWS_LAMBDA_LOG_LEVEL` is not set, check if `RUST_LOG` is set.
 ///     - if none of those two variables are set, use `INFO` as the logging level.
 ///
@@ -44,7 +44,7 @@ pub fn init_default_subscriber() {
                 .from_env_lossy(),
         );
 
-    if log_format.eq_ignore_ascii_case("json") {
+    if log_format.to_lowercase().contains("json") {
         collector.json().init()
     } else {
         collector.init()

--- a/lambda-runtime/src/layers/trace.rs
+++ b/lambda-runtime/src/layers/trace.rs
@@ -16,7 +16,7 @@ impl TracingLayer {
     }
 
     /// Returns true if the tracing span provided by this service should be included in the log output.
-    /// The span is enabled by default, 
+    /// The span is enabled by default,
     /// but can be disabled by adding `no-span` to the `AWS_LAMBDA_LOG_FORMAT` environment variable.
     /// E.g. AWS_LAMBDA_LOG_FORMAT=no-span or =json,no-span.
     pub fn is_enabled() -> bool {

--- a/lambda-runtime/src/layers/trace.rs
+++ b/lambda-runtime/src/layers/trace.rs
@@ -14,6 +14,14 @@ impl TracingLayer {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Returns true if the tracing span provided by this service should be included in the log output.
+    /// The span is enabled by default, 
+    /// but can be disabled by adding `no-span` to the `AWS_LAMBDA_LOG_FORMAT` environment variable.
+    /// E.g. AWS_LAMBDA_LOG_FORMAT=no-span or =json,no-span.
+    pub fn is_enabled() -> bool {
+        !matches! (std::env::var("AWS_LAMBDA_LOG_FORMAT") , Ok(v) if v.to_lowercase().contains("no-span"))
+    }
 }
 
 impl<S> Layer<S> for TracingLayer {

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -120,6 +120,11 @@ where
     D: Into<bytes::Bytes> + Send,
     E: Into<Error> + Send + Debug,
 {
-    let runtime = Runtime::new(handler).layer(layers::TracingLayer::new());
-    runtime.run().await
+    if layers::TracingLayer::is_enabled() {
+        let runtime = Runtime::new(handler).layer(layers::TracingLayer::new());
+        runtime.run().await
+    } else {
+        let runtime = Runtime::new(handler);
+        runtime.run().await
+    }
 }


### PR DESCRIPTION
📬 A demo implementation for the log clutter issue discussed in #672.
It needs more work (docs, tests, better env var parsing)

✍️ *Description of changes:*

Reuse `AWS_LAMBDA_LOG_FORMAT` to specify if the root span should not be created.
E.g. `AWS_LAMBDA_LOG_FORMAT=no-span` or `AWS_LAMBDA_LOG_FORMAT=json,no-span`

The `TracingLayer` is added by default and not added if `AWS_LAMBDA_LOG_FORMAT` contains `no-span`.

## Impact

1. the change is backward compatible
2. nothing changes for existing implementations
3. minimal performance penalty for reading an env var
4. no code changes are needed to change the log format

This last point allows using different log formats in different environments without code changes.

### Examples 

#### Including the root span
```
 INFO Lambda runtime invoke{requestId="local-request-id" xrayTraceId="Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0"}: With global default provider
 INFO Lambda runtime invoke{requestId="local-request-id" xrayTraceId="Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0"}: Command received: echo
ERROR Lambda runtime invoke{requestId="local-request-id" xrayTraceId="Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0"}: "Error"
```

#### No root span (the main goal of this PR)
```
 INFO With global default provider
 INFO Command received: echo
ERROR "Error"
```

#### Root span + JSON
```json
{"level":"INFO","fields":{"message":"With global default provider"},"span":{"requestId":"local-request-id","xrayTraceId":"Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0","name":"Lambda runtime invoke"},"spans":[{"requestId":"local-request-id","xrayTraceId":"Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0","name":"Lambda runtime invoke"}]}
{"level":"INFO","fields":{"message":"Command received: echo"},"span":{"requestId":"local-request-id","xrayTraceId":"Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0","name":"Lambda runtime invoke"},"spans":[{"requestId":"local-request-id","xrayTraceId":"Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0","name":"Lambda runtime invoke"}]}
{"level":"ERROR","fields":{"message":"\"Error\""},"span":{"requestId":"local-request-id","xrayTraceId":"Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0","name":"Lambda runtime invoke"},"spans":[{"requestId":"local-request-id","xrayTraceId":"Root=0-00000000-000000000000000000000000;Parent=0000000000000000;Sampled=0;Lineage=00000000:0","name":"Lambda runtime invoke"}]}
```

#### No root span + JSON
```json
{"level":"INFO","fields":{"message":"With global default provider"}}
{"level":"INFO","fields":{"message":"Command received: echo"}}
{"level":"ERROR","fields":{"message":"\"Error\""}}
```


🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
