### PR TITLE
fix: bedrock tests

### DIFF
--- a/lambda-events/src/event/bedrock_agent_runtime/mod.rs
+++ b/lambda-events/src/event/bedrock_agent_runtime/mod.rs
@@ -91,7 +91,7 @@ mod tests {
         let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event.json");
         let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();
+        let reparsed: AgentEvent = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
@@ -100,7 +100,7 @@ mod tests {
         let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event-without-parameters.json");
         let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();
+        let reparsed: AgentEvent = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
@@ -109,7 +109,7 @@ mod tests {
         let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event-without-request-body.json");
         let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();
+        let reparsed: AgentEvent = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/bedrock_agent_runtime/mod.rs
+++ b/lambda-events/src/event/bedrock_agent_runtime/mod.rs
@@ -82,29 +82,32 @@ pub struct Agent {
 
 #[cfg(test)]
 mod tests {
+
+    use crate::event::bedrock_agent_runtime::AgentEvent;
+
     #[test]
-    #[cfg(feature = "bedrock-agent-runtime")]
-    fn example_bedrock_agent__runtime_event() {
-        let data = include!("../../fixtures/example-bedrock-agent-runtime-event.json");
-        let parsed: AgentEvent = serde_json::from_str(&data).unwrap();
+    #[cfg(feature = "bedrock_agent_runtime")]
+    fn example_bedrock_agent_runtime_event() {
+        let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event.json");
+        let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
-    #[cfg(feature = "bedrock-agent-runtime")]
+    #[cfg(feature = "bedrock_agent_runtime")]
     fn example_bedrock_agent_runtime_event_without_parameters() {
-        let data = include!("../../fixtures/example-bedrock-agent-runtime-event-without-parameters.json");
-        let parsed: AgentEvent = serde_json::from_str(&data).unwrap();
+        let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event-without-parameters.json");
+        let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
-    #[cfg(feature = "bedrock-agent-runtime")]
+    #[cfg(feature = "bedrock_agent_runtime")]
     fn example_bedrock_agent_runtime_event_without_request_body() {
-        let data = include!("../../fixtures/example-bedrock-agent-runtime-event-without-request-body.json");
-        let parsed: AgentEvent = serde_json::from_str(&data).unwrap();
+        let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event-without-request-body.json");
+        let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: AgentEvent = serde_json::from_slice(&output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);


### PR DESCRIPTION
✍️ *Description of changes:*

Clippy emits warning around `bedrock_agent_runtime`. 
This PR is
- Fixing incorrect casing for the feature `bedrock_agent_runtime`. The correct case is using underscore: https://github.com/awslabs/aws-lambda-rust-runtime/blob/150c5f0bee9fa81077a20faf402b1289189a22f5/lambda-events/src/event/mod.rs#L21
- Fixing the texts (which were not run before)

Note: https://github.com/awslabs/aws-lambda-rust-runtime/pull/914 will need to be merged first

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
