### PR TITLE
Use event filter

### DIFF
--- a/lambda-runtime-api-client/src/tracing.rs
+++ b/lambda-runtime-api-client/src/tracing.rs
@@ -33,7 +33,8 @@ const DEFAULT_LOG_LEVEL: &str = "INFO";
 pub fn init_default_subscriber() {
     let log_format = env::var("AWS_LAMBDA_LOG_FORMAT").unwrap_or_default();
     let log_level_str = env::var("AWS_LAMBDA_LOG_LEVEL").or_else(|_| env::var("RUST_LOG"));
-    let log_level = LevelFilter::from_str(log_level_str.as_deref().unwrap_or(DEFAULT_LOG_LEVEL)).unwrap_or(LevelFilter::INFO);
+    let log_level =
+        LevelFilter::from_str(log_level_str.as_deref().unwrap_or(DEFAULT_LOG_LEVEL)).unwrap_or(LevelFilter::INFO);
 
     let collector = tracing_subscriber::fmt()
         .with_target(false)

--- a/lambda-runtime-api-client/src/tracing.rs
+++ b/lambda-runtime-api-client/src/tracing.rs
@@ -33,14 +33,14 @@ const DEFAULT_LOG_LEVEL: &str = "INFO";
 pub fn init_default_subscriber() {
     let log_format = env::var("AWS_LAMBDA_LOG_FORMAT").unwrap_or_default();
     let log_level_str = env::var("AWS_LAMBDA_LOG_LEVEL").or_else(|_| env::var("RUST_LOG"));
-    let log_level = Level::from_str(log_level_str.as_deref().unwrap_or(DEFAULT_LOG_LEVEL)).unwrap_or(Level::INFO);
+    let log_level = LevelFilter::from_str(log_level_str.as_deref().unwrap_or(DEFAULT_LOG_LEVEL)).unwrap_or(LevelFilter::INFO);
 
     let collector = tracing_subscriber::fmt()
         .with_target(false)
         .without_time()
         .with_env_filter(
             EnvFilter::builder()
-                .with_default_directive(LevelFilter::from_level(log_level).into())
+                .with_default_directive(log_level.into())
                 .from_env_lossy(),
         );
 


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*
Originally a `Level` was parsed from one of two environment variables (or defaulted) and then converted into a `LevelFilter` before initializing the subscriber.

However, this precludes using `RUST_LOG=off` since `Level` does not recognize that as valid, resulting in `Level::INFO` (the default) being used.

`LevelFilter` (to which the above is converted anyway) _does_ allow the value to be `off` - so it seems a little more flexible (and very very minutely faster) to parse the env var, or default value, directly into a `LevelFilter`.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
