### PR TITLE
fix: expose CloudWatchMetricAlarm and CloudWatchCompositeAlarm

### DIFF
--- a/lambda-events/src/event/cloudwatch_alarms/mod.rs
+++ b/lambda-events/src/event/cloudwatch_alarms/mod.rs
@@ -36,12 +36,10 @@ where
 }
 
 /// `CloudWatchMetricAlarm` is the structure of an event triggered by CloudWatch metric alarms.
-#[allow(unused)]
-type CloudWatchMetricAlarm<R = CloudWatchAlarmStateReasonData> = CloudWatchAlarm<CloudWatchMetricAlarmConfiguration, R>;
+pub type CloudWatchMetricAlarm<R = CloudWatchAlarmStateReasonData> = CloudWatchAlarm<CloudWatchMetricAlarmConfiguration, R>;
 
 /// `CloudWatchCompositeAlarm` is the structure of an event triggered by CloudWatch composite alarms.
-#[allow(unused)]
-type CloudWatchCompositeAlarm<R = CloudWatchAlarmStateReasonData> =
+pub type CloudWatchCompositeAlarm<R = CloudWatchAlarmStateReasonData> =
     CloudWatchAlarm<CloudWatchCompositeAlarmConfiguration, R>;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/lambda-events/src/event/cloudwatch_alarms/mod.rs
+++ b/lambda-events/src/event/cloudwatch_alarms/mod.rs
@@ -36,7 +36,8 @@ where
 }
 
 /// `CloudWatchMetricAlarm` is the structure of an event triggered by CloudWatch metric alarms.
-pub type CloudWatchMetricAlarm<R = CloudWatchAlarmStateReasonData> = CloudWatchAlarm<CloudWatchMetricAlarmConfiguration, R>;
+pub type CloudWatchMetricAlarm<R = CloudWatchAlarmStateReasonData> =
+    CloudWatchAlarm<CloudWatchMetricAlarmConfiguration, R>;
 
 /// `CloudWatchCompositeAlarm` is the structure of an event triggered by CloudWatch composite alarms.
 pub type CloudWatchCompositeAlarm<R = CloudWatchAlarmStateReasonData> =


### PR DESCRIPTION
📬 *Issue #, if available:*
N/A

✍️ *Description of changes:*
These types are referred to in the rust documentation for the CloudWatchAlarm type, but they were previously not exported by the crate, and instead left unused.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
