### PR TITLE
Only add URL query if it's not empty

### DIFF
--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -129,8 +129,10 @@ fn into_api_gateway_v2_request(ag: ApiGatewayV2httpRequest) -> http::Request<Bod
 
     let mut uri = build_request_uri(&path, &ag.headers, host, None);
     if let Some(query) = ag.raw_query_string {
-        uri.push('?');
-        uri.push_str(&query);
+        if !query.is_empty() {
+            uri.push('?');
+            uri.push_str(&query);
+        }
     }
 
     let builder = http::Request::builder()


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*
In the current state, the runtime adds a `?` to every request URL even if the query was not set. This change fixes that behavior for AWS API Gateway V2 requests.

🔏 *By submitting this pull request*

- [ ] I confirm that I've ran `cargo +nightly fmt`.
- [ ] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
