### PR TITLE
Support simd_json as an optional alternative to serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "json-impl",
     "lambda-http",
     "lambda-integration-tests",
     "lambda-runtime-api-client",

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you'd like to manually create your first function, the code below shows you a
 
 ```rust,no_run
 use lambda_runtime::{service_fn, LambdaEvent, Error};
-use serde_json::{json, Value};
+use aws_lambda_json_impl::{json, Value};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -375,7 +375,7 @@ To serialize and deserialize events and responses, we suggest using the [`serde`
 
 ```rust,no_run
 use serde::{Serialize, Deserialize};
-use serde_json::json;
+use aws_lambda_json_impl::json;
 use std::error::Error;
 
 #[derive(Serialize, Deserialize)]

--- a/examples/advanced-sqs-multiple-functions-shared-data/producer/src/main.rs
+++ b/examples/advanced-sqs-multiple-functions-shared-data/producer/src/main.rs
@@ -1,6 +1,6 @@
 use lambda_runtime::{service_fn, tracing, Error, LambdaEvent};
 use pizza_lib::Pizza;
-use serde_json::{json, Value};
+use aws_lambda_json_impl::{json, Value};
 
 struct SQSManager {
     client: aws_sdk_sqs::Client,

--- a/examples/basic-error-handling/src/main.rs
+++ b/examples/basic-error-handling/src/main.rs
@@ -1,7 +1,7 @@
 /// See https://github.com/awslabs/aws-lambda-rust-runtime for more info on Rust runtime for AWS Lambda
 use lambda_runtime::{service_fn, tracing, Error, LambdaEvent};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use aws_lambda_json_impl::json;
 use std::fs::File;
 
 /// A simple Lambda request structure with just one field

--- a/examples/basic-streaming-response/src/main.rs
+++ b/examples/basic-streaming-response/src/main.rs
@@ -3,7 +3,7 @@ use lambda_runtime::{
     streaming::{channel, Body, Response},
     tracing, Error, LambdaEvent,
 };
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 use std::{thread, time::Duration};
 
 async fn func(_event: LambdaEvent<Value>) -> Result<Response<Body>, Error> {

--- a/examples/http-axum-apigw-authorizer/src/main.rs
+++ b/examples/http-axum-apigw-authorizer/src/main.rs
@@ -7,7 +7,7 @@ use axum::{
     Router,
 };
 use lambda_http::{run, tracing, Error, RequestExt};
-use serde_json::{json, Value};
+use aws_lambda_json_impl::{json, Value};
 use std::{collections::HashMap, env::set_var};
 
 struct AuthorizerField(String);

--- a/examples/http-axum-middleware/src/main.rs
+++ b/examples/http-axum-middleware/src/main.rs
@@ -12,7 +12,7 @@
 use axum::{response::Json, routing::post, Router};
 use lambda_http::request::RequestContext::ApiGatewayV1;
 use lambda_http::{run, tracing, Error};
-use serde_json::{json, Value};
+use aws_lambda_json_impl::{json, Value};
 
 // Sample middleware that logs the request id
 async fn mw_sample(req: axum::extract::Request, next: axum::middleware::Next) -> impl axum::response::IntoResponse {

--- a/examples/http-axum/src/main.rs
+++ b/examples/http-axum/src/main.rs
@@ -16,7 +16,7 @@ use axum::{
 };
 use lambda_http::{run, tracing, Error};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use aws_lambda_json_impl::{json, Value};
 use std::env::set_var;
 
 #[derive(Deserialize, Serialize)]

--- a/examples/lambda-rds-iam-auth/src/main.rs
+++ b/examples/lambda-rds-iam-auth/src/main.rs
@@ -5,7 +5,7 @@ use aws_sigv4::{
     sign::v4,
 };
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
-use serde_json::{json, Value};
+use aws_lambda_json_impl::{json, Value};
 use sqlx::postgres::PgConnectOptions;
 use std::env;
 use std::time::{Duration, SystemTime};

--- a/json-impl/Cargo.toml
+++ b/json-impl/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "aws_lambda_json_impl"
+version = "0.15.1"
+description = "AWS Lambda JSON adapter switch between serde_json and simd_json"
+authors = [
+  "Martin Bartmett <martin.j.bartmett@gmail.com>",
+]
+license = "MIT"
+homepage = "https://github.com/awslabs/aws-lambda-rust-runtime"
+repository = "https://github.com/awslabs/aws-lambda-rust-runtime"
+readme = "README.md"
+keywords = ["lambda", "aws", "amazon", "events", "S3", "json"]
+categories = ["api-bindings", "encoding", "web-programming"]
+edition = "2021"
+
+[features]
+default = [ "serde" ]
+serde = [ "serde_json" ]
+simd = [ "simd-json" ]
+
+[dependencies]
+serde_json = { version = "^1", features = ["raw_value"], optional = true }
+simd-json = { version = "^0", optional = true }

--- a/json-impl/src/lib.rs
+++ b/json-impl/src/lib.rs
@@ -1,0 +1,48 @@
+// Using serde_json as the JSON handler
+#[cfg(feature = "serde")]
+pub use serde::*;
+// Using simd_json as the JSON handler
+#[cfg(feature = "simd")]
+pub use simd::*;
+
+// Implementations
+
+#[cfg(feature = "serde")]
+mod serde {
+	pub use serde_json::{
+		from_reader, 
+		from_slice, 
+		from_str,
+		from_value, 
+		json, 
+		to_string_pretty,
+		to_string, 
+		to_value, 
+		to_writer, 
+		Deserializer as JsonDeserializer,
+		Value, 
+		error::Error as JsonError, 
+		value::RawValue as RawValue,
+	};
+}
+
+#[cfg(feature = "simd")]
+mod simd {
+	pub use simd_json::{
+		serde::{
+			from_reader, 
+			from_slice,                  //THIS is mutable!
+			from_str,                    //THIS is mutable and is unsafe!
+			from_owned_value as from_value, 
+			json, 
+			to_string_pretty,
+			to_string, 
+			to_owned_value as to_value, 
+			to_writer,
+		}, 
+		Deserializer as JsonDeserializer,
+		owned::Value, 
+		Error as JsonError, 
+		tape::Value as RawValue, //THIS is gonna be the fun one!
+	};
+}

--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -29,7 +29,7 @@ query_map = { version = "^0.7", features = [
 ], optional = true }
 serde = { version = "^1", features = ["derive"] }
 serde_with = { version = "^3", features = ["json"], optional = true }
-serde_json = "^1"
+aws_lambda_json_impl = { version = "0", features = ["serde"], path = "../json-impl" }
 serde_dynamo = { version = "^4.1", optional = true }
 
 [features]

--- a/lambda-events/src/custom_serde/codebuild_time.rs
+++ b/lambda-events/src/custom_serde/codebuild_time.rs
@@ -78,14 +78,14 @@ mod tests {
             #[serde(with = "str_time")]
             pub date: TestTime,
         }
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "date": "Sep 1, 2017 4:12:29 PM"
         });
 
         let expected = NaiveDateTime::parse_from_str("Sep 1, 2017 4:12:29 PM", CODEBUILD_TIME_FORMAT)
             .unwrap()
             .and_utc();
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(expected, decoded.date);
     }
 
@@ -96,14 +96,14 @@ mod tests {
             #[serde(with = "optional_time")]
             pub date: Option<TestTime>,
         }
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "date": "Sep 1, 2017 4:12:29 PM"
         });
 
         let expected = NaiveDateTime::parse_from_str("Sep 1, 2017 4:12:29 PM", CODEBUILD_TIME_FORMAT)
             .unwrap()
             .and_utc();
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(Some(expected), decoded.date);
     }
 }

--- a/lambda-events/src/custom_serde/headers.rs
+++ b/lambda-events/src/custom_serde/headers.rs
@@ -145,13 +145,13 @@ mod tests {
             #[serde(deserialize_with = "deserialize_headers", default)]
             pub headers: HeaderMap,
         }
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "not_headers": {}
         });
 
         let expected = HeaderMap::new();
 
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(expected, decoded.headers);
     }
 
@@ -163,16 +163,16 @@ mod tests {
             #[serde(serialize_with = "serialize_multi_value_headers")]
             headers: HeaderMap,
         }
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "headers": {
                 "Accept": ["*/*"]
             }
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(&"*/*", decoded.headers.get("Accept").unwrap());
 
-        let recoded = serde_json::to_value(decoded).unwrap();
-        let decoded: Test = serde_json::from_value(recoded).unwrap();
+        let recoded = aws_lambda_json_impl::to_value(decoded).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(recoded).unwrap();
         assert_eq!(&"*/*", decoded.headers.get("Accept").unwrap());
     }
 
@@ -183,9 +183,9 @@ mod tests {
             #[serde(deserialize_with = "deserialize_headers")]
             headers: HeaderMap,
         }
-        let data = serde_json::json!({ "headers": null });
+        let data = aws_lambda_json_impl::json!({ "headers": null });
 
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert!(decoded.headers.is_empty());
     }
 
@@ -203,7 +203,7 @@ mod tests {
 
         let content_disposition =
             "inline; filename=\"Schillers schönste Szenenanweisungen -Kabale und Liebe.mp4.avif\"";
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "headers": {
                 "Content-Disposition": content_disposition
             },
@@ -211,15 +211,15 @@ mod tests {
                 "Content-Disposition": content_disposition
             }
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(content_disposition, decoded.headers.get("Content-Disposition").unwrap());
         assert_eq!(
             content_disposition,
             decoded.multi_value_headers.get("Content-Disposition").unwrap()
         );
 
-        let recoded = serde_json::to_value(decoded).unwrap();
-        let decoded: Test = serde_json::from_value(recoded).unwrap();
+        let recoded = aws_lambda_json_impl::to_value(decoded).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(recoded).unwrap();
         assert_eq!(content_disposition, decoded.headers.get("Content-Disposition").unwrap());
         assert_eq!(
             content_disposition,

--- a/lambda-events/src/custom_serde/http_method.rs
+++ b/lambda-events/src/custom_serde/http_method.rs
@@ -67,13 +67,13 @@ mod tests {
             #[serde(with = "crate::custom_serde::http_method")]
             pub method: http::Method,
         }
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "method": "DELETE"
         });
-        let decoded: Test = serde_json::from_value(data.clone()).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data.clone()).unwrap();
         assert_eq!(http::Method::DELETE, decoded.method);
 
-        let recoded = serde_json::to_value(decoded).unwrap();
+        let recoded = aws_lambda_json_impl::to_value(decoded).unwrap();
         assert_eq!(data, recoded);
     }
 
@@ -86,21 +86,21 @@ mod tests {
             #[serde(default)]
             pub method: Option<http::Method>,
         }
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "method": "DELETE"
         });
-        let decoded: Test = serde_json::from_value(data.clone()).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data.clone()).unwrap();
         assert_eq!(Some(http::Method::DELETE), decoded.method);
 
-        let recoded = serde_json::to_value(decoded).unwrap();
+        let recoded = aws_lambda_json_impl::to_value(decoded).unwrap();
         assert_eq!(data, recoded);
 
-        let data = serde_json::json!({ "method": null });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let data = aws_lambda_json_impl::json!({ "method": null });
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(None, decoded.method);
 
-        let data = serde_json::json!({});
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let data = aws_lambda_json_impl::json!({});
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(None, decoded.method);
     }
 }

--- a/lambda-events/src/custom_serde/mod.rs
+++ b/lambda-events/src/custom_serde/mod.rs
@@ -107,10 +107,10 @@ mod test {
             #[serde(deserialize_with = "deserialize_base64")]
             v: Vec<u8>,
         }
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "v": "SGVsbG8gV29ybGQ=",
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(String::from_utf8(decoded.v).unwrap(), "Hello World".to_string());
     }
 
@@ -124,7 +124,7 @@ mod test {
         let instance = Test {
             v: "Hello World".as_bytes().to_vec(),
         };
-        let encoded = serde_json::to_string(&instance).unwrap();
+        let encoded = aws_lambda_json_impl::to_string(&instance).unwrap();
         assert_eq!(encoded, r#"{"v":"SGVsbG8gV29ybGQ="}"#.to_string());
     }
 
@@ -135,16 +135,16 @@ mod test {
             #[serde(deserialize_with = "deserialize_lambda_map")]
             v: HashMap<String, String>,
         }
-        let input = serde_json::json!({
+        let input = aws_lambda_json_impl::json!({
           "v": {},
         });
-        let decoded: Test = serde_json::from_value(input).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(input).unwrap();
         assert_eq!(HashMap::new(), decoded.v);
 
-        let input = serde_json::json!({
+        let input = aws_lambda_json_impl::json!({
           "v": null,
         });
-        let decoded: Test = serde_json::from_value(input).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(input).unwrap();
         assert_eq!(HashMap::new(), decoded.v);
     }
 
@@ -156,16 +156,16 @@ mod test {
             #[serde(deserialize_with = "deserialize_lambda_dynamodb_item")]
             v: serde_dynamo::Item,
         }
-        let input = serde_json::json!({
+        let input = aws_lambda_json_impl::json!({
           "v": {},
         });
-        let decoded: Test = serde_json::from_value(input).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(input).unwrap();
         assert_eq!(serde_dynamo::Item::from(HashMap::new()), decoded.v);
 
-        let input = serde_json::json!({
+        let input = aws_lambda_json_impl::json!({
           "v": null,
         });
-        let decoded: Test = serde_json::from_value(input).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(input).unwrap();
         assert_eq!(serde_dynamo::Item::from(HashMap::new()), decoded.v);
     }
 
@@ -178,19 +178,19 @@ mod test {
         }
 
         let test = r#"{"v": null}"#;
-        let decoded: Test = serde_json::from_str(test).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_str(test).unwrap();
         assert!(!decoded.v);
 
         let test = r#"{}"#;
-        let decoded: Test = serde_json::from_str(test).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_str(test).unwrap();
         assert!(!decoded.v);
 
         let test = r#"{"v": true}"#;
-        let decoded: Test = serde_json::from_str(test).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_str(test).unwrap();
         assert!(decoded.v);
 
         let test = r#"{"v": false}"#;
-        let decoded: Test = serde_json::from_str(test).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_str(test).unwrap();
         assert!(!decoded.v);
     }
 }

--- a/lambda-events/src/encodings/http.rs
+++ b/lambda-events/src/encodings/http.rs
@@ -304,21 +304,21 @@ mod tests {
     fn serialize_text() {
         let mut map = HashMap::new();
         map.insert("foo", Body::from("bar"));
-        assert_eq!(serde_json::to_string(&map).unwrap(), r#"{"foo":"bar"}"#);
+        assert_eq!(aws_lambda_json_impl::to_string(&map).unwrap(), r#"{"foo":"bar"}"#);
     }
 
     #[test]
     fn serialize_binary() {
         let mut map = HashMap::new();
         map.insert("foo", Body::from("bar".as_bytes()));
-        assert_eq!(serde_json::to_string(&map).unwrap(), r#"{"foo":"YmFy"}"#);
+        assert_eq!(aws_lambda_json_impl::to_string(&map).unwrap(), r#"{"foo":"YmFy"}"#);
     }
 
     #[test]
     fn serialize_empty() {
         let mut map = HashMap::new();
         map.insert("foo", Body::Empty);
-        assert_eq!(serde_json::to_string(&map).unwrap(), r#"{"foo":null}"#);
+        assert_eq!(aws_lambda_json_impl::to_string(&map).unwrap(), r#"{"foo":null}"#);
     }
 
     #[test]

--- a/lambda-events/src/encodings/time.rs
+++ b/lambda-events/src/encodings/time.rs
@@ -228,19 +228,19 @@ mod test {
         let expected = Utc.ymd(2017, 10, 5).and_hms_nano(15, 33, 44, 302_000_000);
 
         // Test parsing strings.
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "v": "1507217624302",
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(expected, decoded.v,);
         // Test parsing ints.
-        let decoded: Test = serde_json::from_slice(r#"{"v":1507217624302}"#.as_bytes()).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_slice(r#"{"v":1507217624302}"#.as_bytes()).unwrap();
         assert_eq!(expected, decoded.v,);
         // Test parsing floats.
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "v": 1507217624302.0,
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(expected, decoded.v,);
     }
 
@@ -254,7 +254,7 @@ mod test {
         let instance = Test {
             v: Utc.ymd(1983, 7, 22).and_hms_nano(1, 0, 0, 99_888_777),
         };
-        let encoded = serde_json::to_string(&instance).unwrap();
+        let encoded = aws_lambda_json_impl::to_string(&instance).unwrap();
         assert_eq!(encoded, String::from(r#"{"v":"427683600099"}"#));
     }
 
@@ -270,21 +270,21 @@ mod test {
         let instance = Test {
             v: Utc.ymd(1983, 7, 22).and_hms_nano(1, 0, 0, 99),
         };
-        let encoded = serde_json::to_string(&instance).unwrap();
+        let encoded = aws_lambda_json_impl::to_string(&instance).unwrap();
         assert_eq!(encoded, String::from(r#"{"v":"427683600"}"#));
 
         // Make sure milliseconds are included.
         let instance = Test {
             v: Utc.ymd(1983, 7, 22).and_hms_nano(1, 0, 0, 2_000_000),
         };
-        let encoded = serde_json::to_string(&instance).unwrap();
+        let encoded = aws_lambda_json_impl::to_string(&instance).unwrap();
         assert_eq!(encoded, String::from(r#"{"v":"427683600.002"}"#));
 
         // Make sure leap seconds are included.
         let instance = Test {
             v: Utc.ymd(1983, 7, 22).and_hms_nano(23, 59, 59, 1_999_999_999),
         };
-        let encoded = serde_json::to_string(&instance).unwrap();
+        let encoded = aws_lambda_json_impl::to_string(&instance).unwrap();
         assert_eq!(encoded, String::from(r#"{"v":"427766400.999"}"#));
     }
 
@@ -298,16 +298,16 @@ mod test {
 
         let expected = TimeDelta::try_seconds(36).unwrap();
 
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "v": 36,
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(expected, decoded.v,);
 
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "v": 36.1,
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(expected, decoded.v,);
     }
 
@@ -321,7 +321,7 @@ mod test {
         let instance = Test {
             v: TimeDelta::try_seconds(36).unwrap(),
         };
-        let encoded = serde_json::to_string(&instance).unwrap();
+        let encoded = aws_lambda_json_impl::to_string(&instance).unwrap();
         assert_eq!(encoded, String::from(r#"{"v":36}"#));
     }
 
@@ -335,16 +335,16 @@ mod test {
 
         let expected = TimeDelta::try_minutes(36).unwrap();
 
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "v": 36,
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(expected, decoded.v,);
 
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "v": 36.1,
         });
-        let decoded: Test = serde_json::from_value(data).unwrap();
+        let decoded: Test = aws_lambda_json_impl::from_value(data).unwrap();
         assert_eq!(expected, decoded.v,);
     }
 
@@ -358,7 +358,7 @@ mod test {
         let instance = Test {
             v: TimeDelta::try_minutes(36).unwrap(),
         };
-        let encoded = serde_json::to_string(&instance).unwrap();
+        let encoded = aws_lambda_json_impl::to_string(&instance).unwrap();
         assert_eq!(encoded, String::from(r#"{"v":36}"#));
     }
 }

--- a/lambda-events/src/event/activemq/mod.rs
+++ b/lambda-events/src/event/activemq/mod.rs
@@ -58,9 +58,9 @@ mod test {
     #[cfg(feature = "activemq")]
     fn example_activemq_event() {
         let data = include_bytes!("../../fixtures/example-activemq-event.json");
-        let parsed: ActiveMqEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ActiveMqEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ActiveMqEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ActiveMqEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/alb/mod.rs
+++ b/lambda-events/src/event/alb/mod.rs
@@ -75,9 +75,9 @@ mod test {
     #[cfg(feature = "alb")]
     fn example_alb_lambda_target_request_headers_only() {
         let data = include_bytes!("../../fixtures/example-alb-lambda-target-request-headers-only.json");
-        let parsed: AlbTargetGroupRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AlbTargetGroupRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AlbTargetGroupRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AlbTargetGroupRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -85,9 +85,9 @@ mod test {
     #[cfg(feature = "alb")]
     fn example_alb_lambda_target_request_multivalue_headers() {
         let data = include_bytes!("../../fixtures/example-alb-lambda-target-request-multivalue-headers.json");
-        let parsed: AlbTargetGroupRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AlbTargetGroupRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AlbTargetGroupRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AlbTargetGroupRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -95,9 +95,9 @@ mod test {
     #[cfg(feature = "alb")]
     fn example_alb_lambda_target_response() {
         let data = include_bytes!("../../fixtures/example-alb-lambda-target-response.json");
-        let parsed: AlbTargetGroupResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AlbTargetGroupResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AlbTargetGroupResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AlbTargetGroupResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/apigw/mod.rs
+++ b/lambda-events/src/event/apigw/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use http::{HeaderMap, Method};
 use query_map::QueryMap;
 use serde::{de::DeserializeOwned, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 use std::collections::HashMap;
 
 /// `ApiGatewayProxyRequest` contains data coming from the API Gateway proxy
@@ -785,9 +785,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_custom_auth_request_type_request() {
         let data = include_bytes!("../../fixtures/example-apigw-custom-auth-request-type-request.json");
-        let parsed: ApiGatewayCustomAuthorizerRequestTypeRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayCustomAuthorizerRequestTypeRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayCustomAuthorizerRequestTypeRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayCustomAuthorizerRequestTypeRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -795,9 +795,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_custom_auth_request_type_request_websocket() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-custom-authorizer-websocket-request.json");
-        let parsed: ApiGatewayCustomAuthorizerRequestTypeRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayCustomAuthorizerRequestTypeRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayCustomAuthorizerRequestTypeRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayCustomAuthorizerRequestTypeRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -805,9 +805,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_custom_auth_request() {
         let data = include_bytes!("../../fixtures/example-apigw-custom-auth-request.json");
-        let parsed: ApiGatewayCustomAuthorizerRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayCustomAuthorizerRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayCustomAuthorizerRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayCustomAuthorizerRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -815,9 +815,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_custom_auth_response() {
         let data = include_bytes!("../../fixtures/example-apigw-custom-auth-response.json");
-        let parsed: ApiGatewayCustomAuthorizerResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayCustomAuthorizerResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -825,9 +825,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_custom_auth_response_with_single_value_action() {
         let data = include_bytes!("../../fixtures/example-apigw-custom-auth-response-with-single-value-action.json");
-        let parsed: ApiGatewayCustomAuthorizerResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayCustomAuthorizerResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -835,9 +835,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_custom_auth_response_with_single_value_resource() {
         let data = include_bytes!("../../fixtures/example-apigw-custom-auth-response-with-single-value-resource.json");
-        let parsed: ApiGatewayCustomAuthorizerResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayCustomAuthorizerResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -845,9 +845,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_request() {
         let data = include_bytes!("../../fixtures/example-apigw-request.json");
-        let parsed: ApiGatewayProxyRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -855,9 +855,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_response() {
         let data = include_bytes!("../../fixtures/example-apigw-response.json");
-        let parsed: ApiGatewayProxyResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayProxyResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayProxyResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayProxyResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -865,9 +865,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_request_multi_value_parameters() {
         let data = include_bytes!("../../fixtures/example-apigw-request-multi-value-parameters.json");
-        let parsed: ApiGatewayProxyRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
 
         assert!(output.contains(r#""multiValueQueryStringParameters":{"name":["me","me2"]}"#));
@@ -880,9 +880,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_restapi_openapi_request() {
         let data = include_bytes!("../../fixtures/example-apigw-restapi-openapi-request.json");
-        let parsed: ApiGatewayProxyRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -890,9 +890,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_request_iam() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-request-iam.json");
-        let parsed: ApiGatewayV2httpRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2httpRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -900,9 +900,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_request_jwt_authorizer() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-request-jwt-authorizer.json");
-        let parsed: ApiGatewayV2httpRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2httpRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -910,9 +910,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_request_lambda_authorizer() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-request-lambda-authorizer.json");
-        let parsed: ApiGatewayV2httpRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2httpRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -920,9 +920,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_request_multi_value_parameters() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-request-multi-value-parameters.json");
-        let parsed: ApiGatewayV2httpRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2httpRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
 
         assert!(output.contains(r#""header2":"value1,value2""#));
@@ -933,9 +933,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_request_no_authorizer() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-request-no-authorizer.json");
-        let parsed: ApiGatewayV2httpRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2httpRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -943,9 +943,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_websocket_request() {
         let data = include_bytes!("../../fixtures/example-apigw-websocket-request.json");
-        let parsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayWebsocketProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayWebsocketProxyRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -953,9 +953,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_console_test_request() {
         let data = include_bytes!("../../fixtures/example-apigw-console-test-request.json");
-        let parsed: ApiGatewayProxyRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -963,9 +963,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_websocket_request_without_method() {
         let data = include_bytes!("../../fixtures/example-apigw-websocket-request-without-method.json");
-        let parsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayWebsocketProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayWebsocketProxyRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -973,9 +973,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_websocket_request_disconnect_route() {
         let data = include_bytes!("../../fixtures/example-apigw-websocket-request-disconnect-route.json");
-        let parsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayWebsocketProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayWebsocketProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayWebsocketProxyRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -983,9 +983,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_custom_authorizer_v1_request() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-custom-authorizer-v1-request.json");
-        let parsed: ApiGatewayV2httpRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2httpRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2httpRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
         assert_eq!("REQUEST", parsed.kind.unwrap());
         assert_eq!(Method::GET, parsed.http_method);
@@ -995,9 +995,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_custom_authorizer_v2_request() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-custom-authorizer-v2-request.json");
-        let parsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2CustomAuthorizerV2Request = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2CustomAuthorizerV2Request = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -1005,9 +1005,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_v2_custom_authorizer_v2_request_without_cookies() {
         let data = include_bytes!("../../fixtures/example-apigw-v2-custom-authorizer-v2-request-without-cookies.json");
-        let parsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2CustomAuthorizerV2Request = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2CustomAuthorizerV2Request = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -1016,9 +1016,9 @@ mod test {
     fn example_apigw_v2_custom_authorizer_v2_request_without_identity_source() {
         let data =
             include_bytes!("../../fixtures/example-apigw-v2-custom-authorizer-v2-request-without-identity-source.json");
-        let parsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayV2CustomAuthorizerV2Request = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayV2CustomAuthorizerV2Request = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayV2CustomAuthorizerV2Request = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -1026,9 +1026,9 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_console_request() {
         let data = include_bytes!("../../fixtures/example-apigw-console-request.json");
-        let parsed: ApiGatewayProxyRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayProxyRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -1036,7 +1036,7 @@ mod test {
     #[cfg(feature = "apigw")]
     fn example_apigw_request_authorizer_fields() {
         let data = include_bytes!("../../fixtures/example-apigw-request.json");
-        let parsed: ApiGatewayProxyRequest = serde_json::from_slice(data).unwrap();
+        let parsed: ApiGatewayProxyRequest = aws_lambda_json_impl::from_slice(data).unwrap();
 
         let fields = parsed.request_context.authorizer.fields;
         assert_eq!(Some("admin"), fields.get("principalId").unwrap().as_str());
@@ -1050,9 +1050,9 @@ mod test {
         use crate::iam::IamPolicyEffect;
 
         let data = include_bytes!("../../fixtures/example-apigw-custom-auth-response-with-condition.json");
-        let parsed: ApiGatewayCustomAuthorizerResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ApiGatewayCustomAuthorizerResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ApiGatewayCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ApiGatewayCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
 
         let statement = parsed.policy_document.statement.first().unwrap();

--- a/lambda-events/src/event/appsync/mod.rs
+++ b/lambda-events/src/event/appsync/mod.rs
@@ -1,5 +1,5 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 use std::collections::HashMap;
 
 use crate::custom_serde::deserialize_lambda_map;
@@ -125,9 +125,9 @@ mod test {
     #[cfg(feature = "appsync")]
     fn example_appsync_identity_cognito() {
         let data = include_bytes!("../../fixtures/example-appsync-identity-cognito.json");
-        let parsed: AppSyncCognitoIdentity = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AppSyncCognitoIdentity = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AppSyncCognitoIdentity = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AppSyncCognitoIdentity = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -135,9 +135,9 @@ mod test {
     #[cfg(feature = "appsync")]
     fn example_appsync_identity_iam() {
         let data = include_bytes!("../../fixtures/example-appsync-identity-iam.json");
-        let parsed: AppSyncIamIdentity = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AppSyncIamIdentity = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AppSyncIamIdentity = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AppSyncIamIdentity = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -145,9 +145,9 @@ mod test {
     #[cfg(feature = "appsync")]
     fn example_appsync_lambda_auth_request() {
         let data = include_bytes!("../../fixtures/example-appsync-lambda-auth-request.json");
-        let parsed: AppSyncLambdaAuthorizerRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AppSyncLambdaAuthorizerRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AppSyncLambdaAuthorizerRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AppSyncLambdaAuthorizerRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -155,9 +155,9 @@ mod test {
     #[cfg(feature = "appsync")]
     fn example_appsync_lambda_auth_response() {
         let data = include_bytes!("../../fixtures/example-appsync-lambda-auth-response.json");
-        let parsed: AppSyncLambdaAuthorizerResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AppSyncLambdaAuthorizerResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AppSyncLambdaAuthorizerResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AppSyncLambdaAuthorizerResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/autoscaling/mod.rs
+++ b/lambda-events/src/event/autoscaling/mod.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 use std::collections::HashMap;
 
 use crate::custom_serde::deserialize_lambda_map;
@@ -51,9 +51,9 @@ mod test {
     #[cfg(feature = "autoscaling")]
     fn example_autoscaling_event_launch_successful() {
         let data = include_bytes!("../../fixtures/example-autoscaling-event-launch-successful.json");
-        let parsed: AutoScalingEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AutoScalingEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -61,9 +61,9 @@ mod test {
     #[cfg(feature = "autoscaling")]
     fn example_autoscaling_event_launch_unsuccessful() {
         let data = include_bytes!("../../fixtures/example-autoscaling-event-launch-unsuccessful.json");
-        let parsed: AutoScalingEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AutoScalingEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -71,9 +71,9 @@ mod test {
     #[cfg(feature = "autoscaling")]
     fn example_autoscaling_event_lifecycle_action() {
         let data = include_bytes!("../../fixtures/example-autoscaling-event-lifecycle-action.json");
-        let parsed: AutoScalingEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AutoScalingEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -81,9 +81,9 @@ mod test {
     #[cfg(feature = "autoscaling")]
     fn example_autoscaling_event_terminate_action() {
         let data = include_bytes!("../../fixtures/example-autoscaling-event-terminate-action.json");
-        let parsed: AutoScalingEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AutoScalingEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -91,9 +91,9 @@ mod test {
     #[cfg(feature = "autoscaling")]
     fn example_autoscaling_event_terminate_successful() {
         let data = include_bytes!("../../fixtures/example-autoscaling-event-terminate-successful.json");
-        let parsed: AutoScalingEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AutoScalingEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -101,9 +101,9 @@ mod test {
     #[cfg(feature = "autoscaling")]
     fn example_autoscaling_event_terminate_unsuccessful() {
         let data = include_bytes!("../../fixtures/example-autoscaling-event-terminate-unsuccessful.json");
-        let parsed: AutoScalingEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AutoScalingEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AutoScalingEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/bedrock_agent_runtime/mod.rs
+++ b/lambda-events/src/event/bedrock_agent_runtime/mod.rs
@@ -89,27 +89,27 @@ mod tests {
     #[cfg(feature = "bedrock_agent_runtime")]
     fn example_bedrock_agent_runtime_event() {
         let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event.json");
-        let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AgentEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AgentEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AgentEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
     #[cfg(feature = "bedrock_agent_runtime")]
     fn example_bedrock_agent_runtime_event_without_parameters() {
         let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event-without-parameters.json");
-        let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AgentEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AgentEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AgentEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
     #[cfg(feature = "bedrock_agent_runtime")]
     fn example_bedrock_agent_runtime_event_without_request_body() {
         let data = include_bytes!("../../fixtures/example-bedrock-agent-runtime-event-without-request-body.json");
-        let parsed: AgentEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AgentEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AgentEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AgentEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/clientvpn/mod.rs
+++ b/lambda-events/src/event/clientvpn/mod.rs
@@ -53,9 +53,9 @@ mod test {
     #[cfg(feature = "clientvpn")]
     fn example_clientvpn_connectionhandler_request() {
         let data = include_bytes!("../../fixtures/example-clientvpn-connectionhandler-request.json");
-        let parsed: ClientVpnConnectionHandlerRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ClientVpnConnectionHandlerRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ClientVpnConnectionHandlerRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ClientVpnConnectionHandlerRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/cloudformation/mod.rs
+++ b/lambda-events/src/event/cloudformation/mod.rs
@@ -1,5 +1,5 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 use std::collections::HashMap;
 
 pub mod provider;
@@ -117,54 +117,54 @@ mod test {
     #[test]
     fn example_cloudformation_custom_resource_create_request() {
         let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-create-request.json");
-        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+        let parsed: TestRequest = aws_lambda_json_impl::from_slice(data).unwrap();
 
         match parsed {
             Create(_) => (),
             _ => panic!("expected Create request"),
         }
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
     #[test]
     fn example_cloudformation_custom_resource_update_request() {
         let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-update-request.json");
-        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+        let parsed: TestRequest = aws_lambda_json_impl::from_slice(data).unwrap();
 
         match parsed {
             Update(_) => (),
             _ => panic!("expected Update request"),
         }
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
     #[test]
     fn example_cloudformation_custom_resource_delete_request() {
         let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-delete-request.json");
-        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+        let parsed: TestRequest = aws_lambda_json_impl::from_slice(data).unwrap();
 
         match parsed {
             Delete(_) => (),
             _ => panic!("expected Delete request"),
         }
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
     #[test]
     fn example_cloudformation_custom_resource_response() {
         let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-response.json");
-        let parsed: CloudFormationCustomResourceResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CloudFormationCustomResourceResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CloudFormationCustomResourceResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CloudFormationCustomResourceResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/cloudformation/provider.rs
+++ b/lambda-events/src/event/cloudformation/provider.rs
@@ -5,7 +5,7 @@
 //! See https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.custom_resources-readme.html for details.
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "RequestType")]
@@ -105,54 +105,54 @@ mod test {
     #[test]
     fn example_create_request() {
         let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-provider-create-request.json");
-        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+        let parsed: TestRequest = aws_lambda_json_impl::from_slice(data).unwrap();
 
         match parsed {
             Create(_) => (),
             _ => panic!("expected Create request"),
         }
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
     #[test]
     fn example_update_request() {
         let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-provider-update-request.json");
-        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+        let parsed: TestRequest = aws_lambda_json_impl::from_slice(data).unwrap();
 
         match parsed {
             Update(_) => (),
             _ => panic!("expected Update request"),
         }
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
     #[test]
     fn example_delete_request() {
         let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-provider-delete-request.json");
-        let parsed: TestRequest = serde_json::from_slice(data).unwrap();
+        let parsed: TestRequest = aws_lambda_json_impl::from_slice(data).unwrap();
 
         match parsed {
             Delete(_) => (),
             _ => panic!("expected Delete request"),
         }
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: TestRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: TestRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
     #[test]
     fn example_response() {
         let data = include_bytes!("../../fixtures/example-cloudformation-custom-resource-provider-response.json");
-        let parsed: CloudFormationCustomResourceResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CloudFormationCustomResourceResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CloudFormationCustomResourceResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CloudFormationCustomResourceResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/cloudwatch_alarms/mod.rs
+++ b/lambda-events/src/event/cloudwatch_alarms/mod.rs
@@ -6,7 +6,7 @@ use serde::{
     ser::Error as SerError,
     Deserialize, Serialize,
 };
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 
 /// `CloudWatchAlarm` is the generic outer structure of an event triggered by a CloudWatch Alarm.
 /// You probably want to use `CloudWatchMetricAlarm` or `CloudWatchCompositeAlarm` if you know which kind of alarm your function is receiving.
@@ -220,9 +220,9 @@ impl Serialize for CloudWatchAlarmStateReasonData {
         S: serde::Serializer,
     {
         let r = match self {
-            Self::Metric(m) => serde_json::to_string(m),
-            Self::Composite(m) => serde_json::to_string(m),
-            Self::Generic(m) => serde_json::to_string(m),
+            Self::Metric(m) => aws_lambda_json_impl::to_string(m),
+            Self::Composite(m) => aws_lambda_json_impl::to_string(m),
+            Self::Generic(m) => aws_lambda_json_impl::to_string(m),
         };
         let s = r.map_err(|e| SerError::custom(format!("failed to serialize struct as string {}", e)))?;
 
@@ -243,10 +243,10 @@ impl<'de> Visitor<'de> for ReasonDataVisitor {
     where
         E: serde::de::Error,
     {
-        if let Ok(metric) = serde_json::from_str::<CloudWatchAlarmStateReasonDataMetric>(v) {
+        if let Ok(metric) = aws_lambda_json_impl::from_str::<CloudWatchAlarmStateReasonDataMetric>(v) {
             return Ok(CloudWatchAlarmStateReasonData::Metric(metric));
         }
-        if let Ok(aggregate) = serde_json::from_str::<ClodWatchAlarmStateReasonDataComposite>(v) {
+        if let Ok(aggregate) = aws_lambda_json_impl::from_str::<ClodWatchAlarmStateReasonDataComposite>(v) {
             return Ok(CloudWatchAlarmStateReasonData::Composite(aggregate));
         }
         Ok(CloudWatchAlarmStateReasonData::Generic(Value::String(v.to_owned())))
@@ -261,7 +261,7 @@ mod test {
     #[cfg(feature = "cloudwatch_alarms")]
     fn example_cloudwatch_alarm_metric() {
         let data = include_bytes!("../../fixtures/example-cloudwatch-alarm-metric.json");
-        let parsed: CloudWatchMetricAlarm = serde_json::from_slice(data).unwrap();
+        let parsed: CloudWatchMetricAlarm = aws_lambda_json_impl::from_slice(data).unwrap();
         let state = parsed.alarm_data.previous_state.clone().unwrap();
         let data = state.reason_data.unwrap();
         match &data {
@@ -272,8 +272,8 @@ mod test {
             _ => panic!("unexpected reason data {data:?}"),
         }
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CloudWatchMetricAlarm = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CloudWatchMetricAlarm = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -281,7 +281,7 @@ mod test {
     #[cfg(feature = "cloudwatch_alarms")]
     fn example_cloudwatch_alarm_composite() {
         let data = include_bytes!("../../fixtures/example-cloudwatch-alarm-composite.json");
-        let parsed: CloudWatchCompositeAlarm = serde_json::from_slice(data).unwrap();
+        let parsed: CloudWatchCompositeAlarm = aws_lambda_json_impl::from_slice(data).unwrap();
 
         let state = parsed.alarm_data.state.clone().unwrap();
         let data = state.reason_data.unwrap();
@@ -296,8 +296,8 @@ mod test {
             _ => panic!("unexpected reason data {data:?}"),
         }
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CloudWatchCompositeAlarm = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CloudWatchCompositeAlarm = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -305,7 +305,7 @@ mod test {
     #[cfg(feature = "cloudwatch_alarms")]
     fn example_cloudwatch_alarm_composite_with_suppressor_alarm() {
         let data = include_bytes!("../../fixtures/example-cloudwatch-alarm-composite-with-suppressor-alarm.json");
-        let parsed: CloudWatchCompositeAlarm = serde_json::from_slice(data).unwrap();
+        let parsed: CloudWatchCompositeAlarm = aws_lambda_json_impl::from_slice(data).unwrap();
         let state = parsed.alarm_data.state.clone().unwrap();
         assert_eq!("WaitPeriod", state.actions_suppressed_by.unwrap());
         assert_eq!(
@@ -313,8 +313,8 @@ mod test {
             state.actions_suppressed_reason.unwrap()
         );
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CloudWatchCompositeAlarm = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CloudWatchCompositeAlarm = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/cloudwatch_events/cloudtrail.rs
+++ b/lambda-events/src/event/cloudwatch_events/cloudtrail.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -89,27 +89,27 @@ mod tests {
     #[cfg(feature = "cloudwatch_events")]
     fn example_cloudwatch_cloudtrail_unknown_assumed_role() {
         let data = include_bytes!("../../fixtures/example-cloudwatch-cloudtrail-assumed-role.json");
-        let parsed: AWSAPICall = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AWSAPICall = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AWSAPICall = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AWSAPICall = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
     #[cfg(feature = "cloudwatch_events")]
     fn example_cloudwatch_cloudtrail_unknown_federate() {
         let data = include_bytes!("../../fixtures/example-cloudwatch-cloudtrail-unknown-federate.json");
-        let parsed: AWSAPICall = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AWSAPICall = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AWSAPICall = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AWSAPICall = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
     #[test]
     #[cfg(feature = "cloudwatch_events")]
     fn example_cloudwatch_cloudtrail_assumed_role() {
         let data = include_bytes!("../../fixtures/example-cloudwatch-cloudtrail-unknown-user-auth.json");
-        let parsed: AWSAPICall = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: AWSAPICall = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: AWSAPICall = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: AWSAPICall = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/cloudwatch_events/mod.rs
+++ b/lambda-events/src/event/cloudwatch_events/mod.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 
 pub mod cloudtrail;
 pub mod codedeploy;

--- a/lambda-events/src/event/cloudwatch_events/signin.rs
+++ b/lambda-events/src/event/cloudwatch_events/signin.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/lambda-events/src/event/cloudwatch_logs/mod.rs
+++ b/lambda-events/src/event/cloudwatch_logs/mod.rs
@@ -80,7 +80,7 @@ impl<'de> Deserialize<'de> for AwsLogs {
                             })?;
 
                             let bytes = flate2::read::GzDecoder::new(&bytes[..]);
-                            let mut de = serde_json::Deserializer::from_reader(BufReader::new(bytes));
+                            let mut de = aws_lambda_json_impl::JsonDeserializer::from_reader(BufReader::new(bytes));
                             data = Some(LogData::deserialize(&mut de).map_err(Error::custom)?);
                         }
                         _ => return Err(Error::unknown_field(key, FIELDS)),
@@ -105,7 +105,7 @@ impl Serialize for AwsLogs {
         let base = base64::write::EncoderWriter::new(Vec::new(), &base64::engine::general_purpose::STANDARD_NO_PAD);
         let mut gzip = flate2::write::GzEncoder::new(base, flate2::Compression::default());
 
-        serde_json::to_writer(&mut gzip, &self.data).map_err(SeError::custom)?;
+        aws_lambda_json_impl::to_writer(&mut gzip, &self.data).map_err(SeError::custom)?;
         let mut base = gzip.finish().map_err(SeError::custom)?;
         let data = base.finish().map_err(SeError::custom)?;
         let string = std::str::from_utf8(data.as_slice()).map_err(SeError::custom)?;
@@ -128,7 +128,7 @@ mod test {
         "data": "H4sIAFETomIAA12Ry27bMBBF9/4KQuiyqsQ36Z2DqEGBGC0sdRUHAS0NExV6uCJVNw3y76Fkx03CFTH3cubwztMChRO14Jy5h+JxD9ESRZerYnW3zvJ8dZVFn4+W/tDBMImYUMaFVDrF5FVs+vuroR/3k56Yg0sa0+4qk0D50MddX8Ev98aa+wFMO3lJinWS0gTT5ObT9arI8uJWM2uUkMCpZIxiorGRtsQMiOXCgHxt5MadK4d67+u++1o3HgYXWt7M4my4nhmOw+7Kph+rg/HlQwBwM1M0W2//c2V/oPPvmzydb7OpriZqygQhFItUa6GlUkymgrNUS5EKpQhRfMpGCEzC/xgWjCpNOBMn8nM3X4fcvWmn2DDnhGNFWXiffvCdtjON3mQ/vm8KtIHfY3j6rVoiEdaxsxZizLSJd4KRWGFrYwIKqBSVMtZu/eU4mCmoJWLii2KodVt/UTcNVOiNJEMdbf0a2n54RHn9DwKYJmh9EYrmLzoJPx2EwfJY33bRmfb5mOjiefECiB5LsVgCAAA="
     }
 }"#;
-        let event: LogsEvent = serde_json::from_str(json).expect("failed to deserialize");
+        let event: LogsEvent = aws_lambda_json_impl::from_str(json).expect("failed to deserialize");
 
         let data = event.clone().aws_logs.data;
         assert_eq!("DATA_MESSAGE", data.message_type);
@@ -145,8 +145,8 @@ mod test {
         assert_eq!(1552518348220, data.log_events[0].timestamp);
         assert_eq!("REPORT RequestId: 6234bffe-149a-b642-81ff-2e8e376d8aff\tDuration: 46.84 ms\tBilled Duration: 47 ms \tMemory Size: 192 MB\tMax Memory Used: 72 MB\t\n", data.log_events[0].message);
 
-        let new_json: String = serde_json::to_string_pretty(&event).unwrap();
-        let new_event: LogsEvent = serde_json::from_str(&new_json).expect("failed to deserialize");
+        let new_json: String = aws_lambda_json_impl::to_string_pretty(&event).unwrap();
+        let new_event: LogsEvent = aws_lambda_json_impl::from_str(&new_json).expect("failed to deserialize");
         assert_eq!(new_event, event);
     }
 
@@ -154,9 +154,9 @@ mod test {
     #[cfg(feature = "cloudwatch_logs")]
     fn example_cloudwatch_logs_event() {
         let data = include_bytes!("../../fixtures/example-cloudwatch_logs-event.json");
-        let parsed: LogsEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: LogsEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: LogsEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: LogsEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/code_commit/mod.rs
+++ b/lambda-events/src/event/code_commit/mod.rs
@@ -73,9 +73,9 @@ mod test {
     #[cfg(feature = "code_commit")]
     fn example_code_commit_event() {
         let data = include_bytes!("../../fixtures/example-code_commit-event.json");
-        let parsed: CodeCommitEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodeCommitEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodeCommitEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodeCommitEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/codebuild/mod.rs
+++ b/lambda-events/src/event/codebuild/mod.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 
 pub type CodeBuildPhaseStatus = String;
 
@@ -218,9 +218,9 @@ mod test {
     #[cfg(feature = "codebuild")]
     fn example_codebuild_phase_change() {
         let data = include_bytes!("../../fixtures/example-codebuild-phase-change.json");
-        let parsed: CodeBuildEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodeBuildEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodeBuildEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodeBuildEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -228,9 +228,9 @@ mod test {
     #[cfg(feature = "codebuild")]
     fn example_codebuild_state_change() {
         let data = include_bytes!("../../fixtures/example-codebuild-state-change.json");
-        let parsed: CodeBuildEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodeBuildEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodeBuildEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodeBuildEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/codedeploy/mod.rs
+++ b/lambda-events/src/event/codedeploy/mod.rs
@@ -80,13 +80,13 @@ mod test {
     #[cfg(feature = "codedeploy")]
     fn example_codedeploy_lifecycle_event() {
         let data = include_bytes!("../../fixtures/example-codedeploy-lifecycle-event.json");
-        let parsed: CodeDeployLifecycleEvent = serde_json::from_slice(data).unwrap();
+        let parsed: CodeDeployLifecycleEvent = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert_eq!(parsed.deployment_id, "d-deploymentId".to_string());
         assert_eq!(parsed.lifecycle_event_hook_execution_id, "eyJlbmNyeXB0ZWREYXRhIjoiY3VHU2NjdkJXUTJQUENVd2dkYUNGRVg0dWlpME9UWVdHTVhZcDRXVW5LYUVKc21EaUFPMkNLNXMwMWFrNDlYVStlbXdRb29xS3NJTUNVQ3RYRGFZSXc1VTFwUllvMDhmMzdlbDZFeDVVdjZrNFc0eU5waGh6YTRvdkNWcmVveVR6OWdERlM2SmlIYW1TZz09IiwiaXZQYXJhbWV0ZXJTcGVjIjoiTm1ZNFR6RzZxQVhHamhhLyIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ==".to_string());
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodeDeployLifecycleEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodeDeployLifecycleEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -94,9 +94,9 @@ mod test {
     #[cfg(feature = "codedeploy")]
     fn example_codedeploy_deployment_event() {
         let data = include_bytes!("../../fixtures/example-codedeploy-deployment-event.json");
-        let parsed: CodeDeployEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodeDeployEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodeDeployEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodeDeployEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -104,9 +104,9 @@ mod test {
     #[cfg(feature = "codedeploy")]
     fn example_codedeploy_instance_event() {
         let data = include_bytes!("../../fixtures/example-codedeploy-instance-event.json");
-        let parsed: CodeDeployEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodeDeployEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodeDeployEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodeDeployEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/codepipeline_cloudwatch/mod.rs
+++ b/lambda-events/src/event/codepipeline_cloudwatch/mod.rs
@@ -85,9 +85,9 @@ mod test {
     #[cfg(feature = "codepipeline_cloudwatch")]
     fn example_codepipeline_action_execution_stage_change_event() {
         let data = include_bytes!("../../fixtures/example-codepipeline-action-execution-stage-change-event.json");
-        let parsed: CodePipelineCloudWatchEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodePipelineCloudWatchEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodePipelineCloudWatchEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodePipelineCloudWatchEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -95,9 +95,9 @@ mod test {
     #[cfg(feature = "codepipeline_cloudwatch")]
     fn example_codepipeline_execution_stage_change_event() {
         let data = include_bytes!("../../fixtures/example-codepipeline-execution-stage-change-event.json");
-        let parsed: CodePipelineCloudWatchEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodePipelineCloudWatchEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodePipelineCloudWatchEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodePipelineCloudWatchEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -105,9 +105,9 @@ mod test {
     #[cfg(feature = "codepipeline_cloudwatch")]
     fn example_codepipeline_execution_state_change_event() {
         let data = include_bytes!("../../fixtures/example-codepipeline-execution-state-change-event.json");
-        let parsed: CodePipelineCloudWatchEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodePipelineCloudWatchEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodePipelineCloudWatchEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodePipelineCloudWatchEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/codepipeline_job/mod.rs
+++ b/lambda-events/src/event/codepipeline_job/mod.rs
@@ -121,9 +121,9 @@ mod test {
     #[cfg(feature = "codepipeline_job")]
     fn example_codepipeline_job_event() {
         let data = include_bytes!("../../fixtures/example-codepipeline_job-event.json");
-        let parsed: CodePipelineJobEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CodePipelineJobEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CodePipelineJobEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CodePipelineJobEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/cognito/mod.rs
+++ b/lambda-events/src/event/cognito/mod.rs
@@ -1,5 +1,5 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 use std::collections::HashMap;
 
 use crate::custom_serde::{deserialize_lambda_map, deserialize_nullish_boolean};
@@ -636,9 +636,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event() {
         let data = include_bytes!("../../fixtures/example-cognito-event.json");
-        let parsed: CognitoEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -646,9 +646,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_create_auth_challenge() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-create-auth-challenge.json");
-        let parsed: CognitoEventUserPoolsCreateAuthChallenge = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsCreateAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsCreateAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsCreateAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -657,12 +657,12 @@ mod test {
     fn example_cognito_event_userpools_create_auth_challenge_user_not_found() {
         let data =
             include_bytes!("../../fixtures/example-cognito-event-userpools-create-auth-challenge-user-not-found.json");
-        let parsed: CognitoEventUserPoolsCreateAuthChallenge = serde_json::from_slice(data).unwrap();
+        let parsed: CognitoEventUserPoolsCreateAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert!(parsed.request.user_not_found);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsCreateAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsCreateAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -670,9 +670,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_custommessage() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-custommessage.json");
-        let parsed: CognitoEventUserPoolsCustomMessage = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsCustomMessage = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsCustomMessage = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsCustomMessage = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -680,9 +680,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_define_auth_challenge() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-define-auth-challenge.json");
-        let parsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsDefineAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsDefineAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -692,13 +692,13 @@ mod test {
         let data = include_bytes!(
             "../../fixtures/example-cognito-event-userpools-define-auth-challenge-optional-response-fields.json"
         );
-        let parsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(data).unwrap();
+        let parsed: CognitoEventUserPoolsDefineAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert!(!parsed.response.fail_authentication);
         assert!(!parsed.response.issue_tokens);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsDefineAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -707,12 +707,12 @@ mod test {
     fn example_cognito_event_userpools_define_auth_challenge_user_not_found() {
         let data =
             include_bytes!("../../fixtures/example-cognito-event-userpools-define-auth-challenge-user-not-found.json");
-        let parsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(data).unwrap();
+        let parsed: CognitoEventUserPoolsDefineAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert!(parsed.request.user_not_found);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsDefineAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsDefineAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -720,9 +720,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_migrateuser() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-migrateuser.json");
-        let parsed: CognitoEventUserPoolsMigrateUser = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsMigrateUser = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsMigrateUser = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsMigrateUser = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -730,9 +730,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_postauthentication() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-postauthentication.json");
-        let parsed: CognitoEventUserPoolsPostAuthentication = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsPostAuthentication = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsPostAuthentication = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPostAuthentication = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -740,9 +740,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_postconfirmation() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-postconfirmation.json");
-        let parsed: CognitoEventUserPoolsPostConfirmation = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsPostConfirmation = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsPostConfirmation = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPostConfirmation = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -750,9 +750,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_preauthentication() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-preauthentication.json");
-        let parsed: CognitoEventUserPoolsPreAuthentication = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsPreAuthentication = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsPreAuthentication = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreAuthentication = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -760,9 +760,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_presignup() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-presignup.json");
-        let parsed: CognitoEventUserPoolsPreSignup = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsPreSignup = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsPreSignup = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreSignup = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -770,9 +770,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_pretokengen_incoming() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-pretokengen-incoming.json");
-        let parsed: CognitoEventUserPoolsPreTokenGen = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsPreTokenGen = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsPreTokenGen = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreTokenGen = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -780,9 +780,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_pretokengen_v2_incoming() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-pretokengen-v2-incoming.json");
-        let parsed: CognitoEventUserPoolsPreTokenGenV2 = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsPreTokenGenV2 = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsPreTokenGenV2 = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreTokenGenV2 = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -790,9 +790,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_pretokengen() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-pretokengen.json");
-        let parsed: CognitoEventUserPoolsPreTokenGen = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsPreTokenGen = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsPreTokenGen = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreTokenGen = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -800,9 +800,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_v2_pretokengen() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-pretokengen-v2.json");
-        let parsed: CognitoEventUserPoolsPreTokenGenV2 = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsPreTokenGenV2 = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsPreTokenGenV2 = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsPreTokenGenV2 = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -810,9 +810,9 @@ mod test {
     #[cfg(feature = "cognito")]
     fn example_cognito_event_userpools_verify_auth_challenge() {
         let data = include_bytes!("../../fixtures/example-cognito-event-userpools-verify-auth-challenge.json");
-        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -822,12 +822,12 @@ mod test {
         let data = include_bytes!(
             "../../fixtures/example-cognito-event-userpools-verify-auth-challenge-optional-answer-correct.json"
         );
-        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(data).unwrap();
+        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert!(!parsed.response.answer_correct);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -837,12 +837,12 @@ mod test {
         let data = include_bytes!(
             "../../fixtures/example-cognito-event-userpools-verify-auth-challenge-null-answer-correct.json"
         );
-        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(data).unwrap();
+        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert!(!parsed.response.answer_correct);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -851,12 +851,12 @@ mod test {
     fn example_cognito_event_userpools_verify_auth_challenge_user_not_found() {
         let data =
             include_bytes!("../../fixtures/example-cognito-event-userpools-verify-auth-challenge-user-not-found.json");
-        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(data).unwrap();
+        let parsed: CognitoEventUserPoolsVerifyAuthChallenge = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert!(parsed.request.user_not_found);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: CognitoEventUserPoolsVerifyAuthChallenge = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }
@@ -893,9 +893,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsPreSignupTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -906,9 +906,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsPreAuthenticationTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -922,9 +922,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsPostConfirmationTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -935,9 +935,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsPostAuthenticationTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -948,9 +948,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsDefineAuthChallengeTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -962,9 +962,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsCreateAuthChallengeTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -975,9 +975,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsVerifyAuthChallengeTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -994,9 +994,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsPreTokenGenTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -1007,9 +1007,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsMigrateUserTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }
@@ -1028,9 +1028,9 @@ mod trigger_source_tests {
         possible_triggers.into_iter().for_each(|trigger| {
             let header = gen_header(trigger);
             let parsed: CognitoEventUserPoolsHeader<CognitoEventUserPoolsCustomMessageTriggerSource> =
-                serde_json::from_str(&header).unwrap();
-            let output: String = serde_json::to_string(&parsed).unwrap();
-            let reparsed: CognitoEventUserPoolsHeader<_> = serde_json::from_slice(output.as_bytes()).unwrap();
+                aws_lambda_json_impl::from_str(&header).unwrap();
+            let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+            let reparsed: CognitoEventUserPoolsHeader<_> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
             assert_eq!(parsed, reparsed);
         });
     }

--- a/lambda-events/src/event/config/mod.rs
+++ b/lambda-events/src/event/config/mod.rs
@@ -44,9 +44,9 @@ mod test {
     #[cfg(feature = "config")]
     fn example_config_event() {
         let data = include_bytes!("../../fixtures/example-config-event.json");
-        let parsed: ConfigEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ConfigEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ConfigEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ConfigEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/connect/mod.rs
+++ b/lambda-events/src/event/connect/mod.rs
@@ -98,9 +98,9 @@ mod test {
     #[cfg(feature = "connect")]
     fn example_connect_event() {
         let data = include_bytes!("../../fixtures/example-connect-event.json");
-        let parsed: ConnectEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ConnectEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ConnectEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ConnectEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -108,9 +108,9 @@ mod test {
     #[cfg(feature = "connect")]
     fn example_connect_event_without_queue() {
         let data = include_bytes!("../../fixtures/example-connect-event-without-queue.json");
-        let parsed: ConnectEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: ConnectEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: ConnectEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: ConnectEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/documentdb/events/commom_types.rs
+++ b/lambda-events/src/event/documentdb/events/commom_types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 
 pub type AnyDocument = HashMap<String, Value>;
 

--- a/lambda-events/src/event/documentdb/mod.rs
+++ b/lambda-events/src/event/documentdb/mod.rs
@@ -43,9 +43,9 @@ mod test {
     pub type Event = DocumentDbEvent;
 
     fn test_example(data: &[u8]) {
-        let parsed: Event = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: Event = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: Event = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: Event = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
 
         assert_eq!(parsed, reparsed);
     }

--- a/lambda-events/src/event/dynamodb/attributes.rs
+++ b/lambda-events/src/event/dynamodb/attributes.rs
@@ -8,59 +8,59 @@ mod test {
 
     #[test]
     fn test_null_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "NULL": true
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::Null(true) => {}
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_string_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "S": "value"
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::S(ref s) => assert_eq!("value", s.as_str()),
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_number_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "N": "123.45"
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::N(ref n) => assert_eq!("123.45", n.as_str()),
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_binary_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::B(ref b) => {
                 let expected = base64::engine::general_purpose::STANDARD
@@ -71,33 +71,33 @@ mod test {
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_boolean_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "BOOL": true
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::Bool(b) => assert!(b),
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_string_set_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "SS": ["Giraffe", "Hippo" ,"Zebra"]
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::Ss(ref s) => {
                 let expected = vec!["Giraffe", "Hippo", "Zebra"];
@@ -106,17 +106,17 @@ mod test {
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_number_set_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "NS": ["42.2", "-19", "7.5", "3.14"]
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::Ns(ref s) => {
                 let expected = vec!["42.2", "-19", "7.5", "3.14"];
@@ -125,17 +125,17 @@ mod test {
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_binary_set_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::Bs(ref s) => {
                 let expected = vec!["U3Vubnk=", "UmFpbnk=", "U25vd3k="]
@@ -147,17 +147,17 @@ mod test {
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_attribute_list_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "L": [ {"S": "Cookies"} , {"S": "Coffee"}, {"N": "3.14159"}]
         });
 
-        let attr: AttributeValue = serde_json::from_value(value.clone()).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value.clone()).unwrap();
         match attr {
             AttributeValue::L(ref s) => {
                 let expected = vec![
@@ -170,17 +170,17 @@ mod test {
             other => panic!("unexpected value {:?}", other),
         }
 
-        let reparsed = serde_json::to_value(attr).unwrap();
+        let reparsed = aws_lambda_json_impl::to_value(attr).unwrap();
         assert_eq!(value, reparsed);
     }
 
     #[test]
     fn test_attribute_map_attribute() {
-        let value = serde_json::json!({
+        let value = aws_lambda_json_impl::json!({
             "M": {"Name": {"S": "Joe"}, "Age": {"N": "35"}}
         });
 
-        let attr: AttributeValue = serde_json::from_value(value).unwrap();
+        let attr: AttributeValue = aws_lambda_json_impl::from_value(value).unwrap();
         match attr {
             AttributeValue::M(s) => {
                 let mut expected = HashMap::new();

--- a/lambda-events/src/event/dynamodb/mod.rs
+++ b/lambda-events/src/event/dynamodb/mod.rs
@@ -260,9 +260,9 @@ mod test {
     #[cfg(feature = "dynamodb")]
     fn example_dynamodb_event() {
         let data = include_bytes!("../../fixtures/example-dynamodb-event.json");
-        let mut parsed: Event = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: Event = serde_json::from_slice(output.as_bytes()).unwrap();
+        let mut parsed: Event = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: Event = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
 
         let event = parsed.records.pop().unwrap();
@@ -274,9 +274,9 @@ mod test {
     #[cfg(feature = "dynamodb")]
     fn example_dynamodb_event_with_optional_fields() {
         let data = include_bytes!("../../fixtures/example-dynamodb-event-record-with-optional-fields.json");
-        let parsed: EventRecord = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: EventRecord = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: EventRecord = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: EventRecord = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
         let date = Utc.timestamp_micros(0).unwrap(); // 1970-01-01T00:00:00Z
         assert_eq!(date, reparsed.change.approximate_creation_date_time);

--- a/lambda-events/src/event/ecr_scan/mod.rs
+++ b/lambda-events/src/event/ecr_scan/mod.rs
@@ -71,9 +71,9 @@ mod test {
     #[cfg(feature = "ecr_scan")]
     fn example_ecr_image_scan_event() {
         let data = include_bytes!("../../fixtures/example-ecr-image-scan-event.json");
-        let parsed: EcrScanEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: EcrScanEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: EcrScanEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: EcrScanEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -81,9 +81,9 @@ mod test {
     #[cfg(feature = "ecr_scan")]
     fn example_ecr_image_scan_event_with_missing_severities() {
         let data = include_bytes!("../../fixtures/example-ecr-image-scan-event-with-missing-severities.json");
-        let parsed: EcrScanEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: EcrScanEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: EcrScanEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: EcrScanEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/eventbridge/mod.rs
+++ b/lambda-events/src/event/eventbridge/mod.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 
 /// Parse EventBridge events.
 /// Deserialize the event detail into a structure that's `DeserializeOwned`.
@@ -48,26 +48,26 @@ mod test {
 
         // Example from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-instance-state-changes.html
         let data = include_bytes!("../../fixtures/example-eventbridge-event-obj.json");
-        let parsed: EventBridgeEvent<Ec2StateChange> = serde_json::from_slice(data).unwrap();
+        let parsed: EventBridgeEvent<Ec2StateChange> = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert_eq!("i-abcd1111", parsed.detail.instance_id);
         assert_eq!("pending", parsed.detail.state);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: EventBridgeEvent<Ec2StateChange> = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: EventBridgeEvent<Ec2StateChange> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
     #[test]
     fn example_eventbridge_schedule_event() {
         let data = include_bytes!("../../fixtures/example-eventbridge-schedule.json");
-        let parsed: EventBridgeEvent = serde_json::from_slice(data).unwrap();
+        let parsed: EventBridgeEvent = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert_eq!("aws.events", parsed.source);
         assert_eq!("Scheduled Event", parsed.detail_type);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: EventBridgeEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: EventBridgeEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/firehose/mod.rs
+++ b/lambda-events/src/event/firehose/mod.rs
@@ -80,9 +80,9 @@ mod test {
     #[cfg(feature = "firehose")]
     fn example_firehose_event() {
         let data = include_bytes!("../../fixtures/example-firehose-event.json");
-        let parsed: KinesisFirehoseEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: KinesisFirehoseEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: KinesisFirehoseEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: KinesisFirehoseEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/iam/mod.rs
+++ b/lambda-events/src/event/iam/mod.rs
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_string_condition() {
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "condition": {
                 "StringEquals": {
                     "iam:RegisterSecurityKey": "Activate",
@@ -144,7 +144,7 @@ mod tests {
             condition: Option<IamPolicyCondition>,
         }
 
-        let test: Test = serde_json::from_value(data).unwrap();
+        let test: Test = aws_lambda_json_impl::from_value(data).unwrap();
         let condition = test.condition.unwrap();
         assert_eq!(1, condition.len());
 
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_slide_condition() {
-        let data = serde_json::json!({
+        let data = aws_lambda_json_impl::json!({
             "condition": {"StringLike": {"s3:prefix": ["janedoe/*"]}}
         });
 
@@ -164,7 +164,7 @@ mod tests {
             condition: Option<IamPolicyCondition>,
         }
 
-        let test: Test = serde_json::from_value(data).unwrap();
+        let test: Test = aws_lambda_json_impl::from_value(data).unwrap();
         let condition = test.condition.unwrap();
         assert_eq!(1, condition.len());
 
@@ -179,11 +179,11 @@ mod tests {
             resource: vec!["some:resource".into()],
             condition: None,
         };
-        let policy_ser = serde_json::to_value(policy).unwrap();
+        let policy_ser = aws_lambda_json_impl::to_value(policy).unwrap();
 
         assert_eq!(
             policy_ser,
-            serde_json::json!({
+            aws_lambda_json_impl::json!({
                 "Action": ["some:action"],
                 "Effect": "Allow",
                 "Resource": ["some:resource"]

--- a/lambda-events/src/event/iot/mod.rs
+++ b/lambda-events/src/event/iot/mod.rs
@@ -78,9 +78,9 @@ mod test {
     #[cfg(feature = "iot")]
     fn example_iot_custom_auth_request() {
         let data = include_bytes!("../../fixtures/example-iot-custom-auth-request.json");
-        let parsed: IoTCoreCustomAuthorizerRequest = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: IoTCoreCustomAuthorizerRequest = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: IoTCoreCustomAuthorizerRequest = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: IoTCoreCustomAuthorizerRequest = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -88,9 +88,9 @@ mod test {
     #[cfg(feature = "iot")]
     fn example_iot_custom_auth_response() {
         let data = include_bytes!("../../fixtures/example-iot-custom-auth-response.json");
-        let parsed: IoTCoreCustomAuthorizerResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: IoTCoreCustomAuthorizerResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: IoTCoreCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: IoTCoreCustomAuthorizerResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/iot_1_click/mod.rs
+++ b/lambda-events/src/event/iot_1_click/mod.rs
@@ -64,9 +64,9 @@ mod test {
     #[cfg(feature = "iot_1_click")]
     fn example_iot_1_click_event() {
         let data = include_bytes!("../../fixtures/example-iot_1_click-event.json");
-        let parsed: IoTOneClickEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: IoTOneClickEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: IoTOneClickEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: IoTOneClickEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/iot_button/mod.rs
+++ b/lambda-events/src/event/iot_button/mod.rs
@@ -19,9 +19,9 @@ mod test {
     #[cfg(feature = "iot_button")]
     fn example_iot_button_event() {
         let data = include_bytes!("../../fixtures/example-iot_button-event.json");
-        let parsed: IoTButtonEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: IoTButtonEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: IoTButtonEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: IoTButtonEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/kafka/mod.rs
+++ b/lambda-events/src/event/kafka/mod.rs
@@ -39,9 +39,9 @@ mod test {
     #[cfg(feature = "kafka")]
     fn example_kafka_event() {
         let data = include_bytes!("../../fixtures/example-kafka-event.json");
-        let parsed: KafkaEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: KafkaEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: KafkaEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: KafkaEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/kinesis/event.rs
+++ b/lambda-events/src/event/kinesis/event.rs
@@ -90,11 +90,11 @@ mod test {
     #[cfg(feature = "kinesis")]
     fn example_kinesis_event() {
         let data = include_bytes!("../../fixtures/example-kinesis-event.json");
-        let parsed: KinesisEvent = serde_json::from_slice(data).unwrap();
+        let parsed: KinesisEvent = aws_lambda_json_impl::from_slice(data).unwrap();
         assert_eq!(KinesisEncryptionType::None, parsed.records[0].kinesis.encryption_type);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: KinesisEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: KinesisEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -102,11 +102,11 @@ mod test {
     #[cfg(feature = "kinesis")]
     fn example_kinesis_event_encrypted() {
         let data = include_bytes!("../../fixtures/example-kinesis-event-encrypted.json");
-        let parsed: KinesisEvent = serde_json::from_slice(data).unwrap();
+        let parsed: KinesisEvent = aws_lambda_json_impl::from_slice(data).unwrap();
         assert_eq!(KinesisEncryptionType::Kms, parsed.records[0].kinesis.encryption_type);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: KinesisEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: KinesisEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/lex/mod.rs
+++ b/lambda-events/src/event/lex/mod.rs
@@ -112,9 +112,9 @@ mod test {
     #[cfg(feature = "lex")]
     fn example_lex_event() {
         let data = include_bytes!("../../fixtures/example-lex-event.json");
-        let parsed: LexEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: LexEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: LexEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: LexEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -122,9 +122,9 @@ mod test {
     #[cfg(feature = "lex")]
     fn example_lex_response() {
         let data = include_bytes!("../../fixtures/example-lex-response.json");
-        let parsed: LexEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: LexEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: LexEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: LexEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/rabbitmq/mod.rs
+++ b/lambda-events/src/event/rabbitmq/mod.rs
@@ -1,5 +1,5 @@
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 use std::collections::HashMap;
 
 use crate::custom_serde::deserialize_lambda_map;
@@ -66,9 +66,9 @@ mod test {
     #[cfg(feature = "rabbitmq")]
     fn example_rabbitmq_event() {
         let data = include_bytes!("../../fixtures/example-rabbitmq-event.json");
-        let parsed: RabbitMqEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: RabbitMqEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: RabbitMqEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: RabbitMqEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/s3/event.rs
+++ b/lambda-events/src/event/s3/event.rs
@@ -96,9 +96,9 @@ mod test {
     #[cfg(feature = "s3")]
     fn example_s3_event() {
         let data = include_bytes!("../../fixtures/example-s3-event.json");
-        let parsed: S3Event = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: S3Event = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: S3Event = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: S3Event = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -106,9 +106,9 @@ mod test {
     #[cfg(feature = "s3")]
     fn example_s3_event_with_decoded() {
         let data = include_bytes!("../../fixtures/example-s3-event-with-decoded.json");
-        let parsed: S3Event = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: S3Event = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: S3Event = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: S3Event = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/s3/object_lambda.rs
+++ b/lambda-events/src/event/s3/object_lambda.rs
@@ -1,6 +1,6 @@
 use http::HeaderMap;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_json::Value;
+use aws_lambda_json_impl::Value;
 use std::collections::HashMap;
 
 use crate::custom_serde::{deserialize_headers, serialize_headers};
@@ -123,9 +123,9 @@ mod test {
     #[cfg(feature = "s3")]
     fn example_object_lambda_event_get_object_assumed_role() {
         let data = include_bytes!("../../fixtures/example-s3-object-lambda-event-get-object-assumed-role.json");
-        let parsed: S3ObjectLambdaEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: S3ObjectLambdaEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -133,9 +133,9 @@ mod test {
     #[cfg(feature = "s3")]
     fn example_object_lambda_event_get_object_iam() {
         let data = include_bytes!("../../fixtures/example-s3-object-lambda-event-get-object-iam.json");
-        let parsed: S3ObjectLambdaEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: S3ObjectLambdaEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -143,9 +143,9 @@ mod test {
     #[cfg(feature = "s3")]
     fn example_object_lambda_event_head_object_iam() {
         let data = include_bytes!("../../fixtures/example-s3-object-lambda-event-head-object-iam.json");
-        let parsed: S3ObjectLambdaEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: S3ObjectLambdaEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -153,9 +153,9 @@ mod test {
     #[cfg(feature = "s3")]
     fn example_object_lambda_event_list_objects_iam() {
         let data = include_bytes!("../../fixtures/example-s3-object-lambda-event-list-objects-iam.json");
-        let parsed: S3ObjectLambdaEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: S3ObjectLambdaEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -163,9 +163,9 @@ mod test {
     #[cfg(feature = "s3")]
     fn example_object_lambda_event_list_objects_v2_iam() {
         let data = include_bytes!("../../fixtures/example-s3-object-lambda-event-list-objects-v2-iam.json");
-        let parsed: S3ObjectLambdaEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: S3ObjectLambdaEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: S3ObjectLambdaEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/secretsmanager/mod.rs
+++ b/lambda-events/src/event/secretsmanager/mod.rs
@@ -16,9 +16,9 @@ mod test {
     #[cfg(feature = "secretsmanager")]
     fn example_secretsmanager_secret_rotation_event() {
         let data = include_bytes!("../../fixtures/example-secretsmanager-secret-rotation-event.json");
-        let parsed: SecretsManagerSecretRotationEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SecretsManagerSecretRotationEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: SecretsManagerSecretRotationEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SecretsManagerSecretRotationEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/ses/mod.rs
+++ b/lambda-events/src/event/ses/mod.rs
@@ -126,9 +126,9 @@ mod test {
     #[cfg(feature = "ses")]
     fn example_ses_lambda_event() {
         let data = include_bytes!("../../fixtures/example-ses-lambda-event.json");
-        let parsed: SimpleEmailEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SimpleEmailEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: SimpleEmailEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SimpleEmailEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -136,9 +136,9 @@ mod test {
     #[cfg(feature = "ses")]
     fn example_ses_s3_event() {
         let data = include_bytes!("../../fixtures/example-ses-s3-event.json");
-        let parsed: SimpleEmailEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SimpleEmailEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: SimpleEmailEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SimpleEmailEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -146,9 +146,9 @@ mod test {
     #[cfg(feature = "ses")]
     fn example_ses_sns_event() {
         let data = include_bytes!("../../fixtures/example-ses-sns-event.json");
-        let parsed: SimpleEmailEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SimpleEmailEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: SimpleEmailEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SimpleEmailEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/sns/mod.rs
+++ b/lambda-events/src/event/sns/mod.rs
@@ -254,9 +254,9 @@ mod test {
     #[cfg(feature = "sns")]
     fn my_example_sns_event() {
         let data = include_bytes!("../../fixtures/example-sns-event.json");
-        let parsed: SnsEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SnsEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: SnsEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SnsEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -264,9 +264,9 @@ mod test {
     #[cfg(feature = "sns")]
     fn my_example_sns_event_pascal_case() {
         let data = include_bytes!("../../fixtures/example-sns-event-pascal-case.json");
-        let parsed: SnsEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SnsEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: SnsEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SnsEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -274,15 +274,15 @@ mod test {
     #[cfg(feature = "sns")]
     fn my_example_sns_event_cloudwatch_single_metric() {
         let data = include_bytes!("../../fixtures/example-cloudwatch-alarm-sns-payload-single-metric.json");
-        let parsed: SnsEvent = serde_json::from_slice(data).unwrap();
+        let parsed: SnsEvent = aws_lambda_json_impl::from_slice(data).unwrap();
         assert_eq!(1, parsed.records.len());
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SnsEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SnsEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
 
         let parsed: SnsEventObj<CloudWatchAlarmPayload> =
-            serde_json::from_slice(data).expect("failed to parse CloudWatch Alarm payload");
+            aws_lambda_json_impl::from_slice(data).expect("failed to parse CloudWatch Alarm payload");
 
         let record = parsed.records.first().unwrap();
         assert_eq!("EXAMPLE", record.sns.message.alarm_name);
@@ -292,11 +292,11 @@ mod test {
     #[cfg(feature = "sns")]
     fn my_example_sns_event_cloudwatch_multiple_metrics() {
         let data = include_bytes!("../../fixtures/example-cloudwatch-alarm-sns-payload-multiple-metrics.json");
-        let parsed: SnsEvent = serde_json::from_slice(data).unwrap();
+        let parsed: SnsEvent = aws_lambda_json_impl::from_slice(data).unwrap();
         assert_eq!(2, parsed.records.len());
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SnsEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SnsEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -311,14 +311,14 @@ mod test {
             bar: i32,
         }
 
-        let parsed: SnsEventObj<CustStruct> = serde_json::from_slice(data).unwrap();
+        let parsed: SnsEventObj<CustStruct> = aws_lambda_json_impl::from_slice(data).unwrap();
         println!("{:?}", parsed);
 
         assert_eq!(parsed.records[0].sns.message.foo, "Hello world!");
         assert_eq!(parsed.records[0].sns.message.bar, 123);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SnsEventObj<CustStruct> = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SnsEventObj<CustStruct> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/event/sqs/mod.rs
+++ b/lambda-events/src/event/sqs/mod.rs
@@ -186,9 +186,9 @@ mod test {
     #[cfg(feature = "sqs")]
     fn example_sqs_event() {
         let data = include_bytes!("../../fixtures/example-sqs-event.json");
-        let parsed: SqsEvent = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SqsEvent = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: SqsEvent = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SqsEvent = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -202,13 +202,13 @@ mod test {
         }
 
         let data = include_bytes!("../../fixtures/example-sqs-event-obj.json");
-        let parsed: SqsEventObj<CustStruct> = serde_json::from_slice(data).unwrap();
+        let parsed: SqsEventObj<CustStruct> = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert_eq!(parsed.records[0].body.a, "Test");
         assert_eq!(parsed.records[0].body.b, 123);
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SqsEventObj<CustStruct> = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SqsEventObj<CustStruct> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -218,9 +218,9 @@ mod test {
         // Example sqs batch response fetched 2022-05-13, from:
         // https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
         let data = include_bytes!("../../fixtures/example-sqs-batch-response.json");
-        let parsed: SqsBatchResponse = serde_json::from_slice(data).unwrap();
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SqsBatchResponse = serde_json::from_slice(output.as_bytes()).unwrap();
+        let parsed: SqsBatchResponse = aws_lambda_json_impl::from_slice(data).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SqsBatchResponse = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 
@@ -236,13 +236,13 @@ mod test {
         }
 
         let data = include_bytes!("../../fixtures/example-sqs-api-event-obj.json");
-        let parsed: SqsApiEventObj<CustStruct> = serde_json::from_slice(data).unwrap();
+        let parsed: SqsApiEventObj<CustStruct> = aws_lambda_json_impl::from_slice(data).unwrap();
 
         assert_eq!(parsed.messages[0].body.city, "provincetown");
         assert_eq!(parsed.messages[0].body.country, "usa");
 
-        let output: String = serde_json::to_string(&parsed).unwrap();
-        let reparsed: SqsApiEventObj<CustStruct> = serde_json::from_slice(output.as_bytes()).unwrap();
+        let output: String = aws_lambda_json_impl::to_string(&parsed).unwrap();
+        let reparsed: SqsApiEventObj<CustStruct> = aws_lambda_json_impl::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
     }
 }

--- a/lambda-events/src/time_window.rs
+++ b/lambda-events/src/time_window.rs
@@ -68,12 +68,12 @@ mod test {
 
     #[test]
     fn test_window_deserializer() {
-        let v = serde_json::json!({
+        let v = aws_lambda_json_impl::json!({
             "start": "2020-12-09T07:04:00Z",
             "end": "2020-12-09T07:06:00Z",
         });
 
-        let parsed: Window = serde_json::from_value(v).unwrap();
+        let parsed: Window = aws_lambda_json_impl::from_value(v).unwrap();
         assert_eq!("2020-12-09T07:04:00+00:00", &parsed.start.to_rfc3339());
         assert_eq!("2020-12-09T07:06:00+00:00", &parsed.end.to_rfc3339());
     }

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -43,7 +43,7 @@ mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
+aws_lambda_json_impl = { version = "0", features = ["serde"], path = "../json-impl" }
 serde_urlencoded = "0.7"
 tokio-stream = "0.1.2"
 url = "2.2"

--- a/lambda-http/README.md
+++ b/lambda-http/README.md
@@ -45,7 +45,7 @@ The code below creates a simple API Gateway proxy (HTTP, REST) that accepts in i
 ```rust
 use lambda_http::{run, http::{StatusCode, Response}, service_fn, Error, IntoResponse, Request, RequestPayloadExt};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use aws_lambda_json_impl::json;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -83,7 +83,7 @@ pub struct MyPayload {
 
 ```rust
 use lambda_http::{run, http::{StatusCode, Response}, service_fn, Error, RequestExt, IntoResponse, Request};
-use serde_json::json;
+use aws_lambda_json_impl::json;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -124,7 +124,7 @@ use aws_lambda_events::apigw::{
     ApiGatewayCustomAuthorizerRequestTypeRequest, ApiGatewayCustomAuthorizerResponse, ApiGatewayCustomAuthorizerPolicy, IamPolicyStatement,
 };
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
-use serde_json::json;
+use aws_lambda_json_impl::json;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -183,7 +183,7 @@ One of the [best practices](https://docs.aws.amazon.com/lambda/latest/dg/best-pr
 use aws_sdk_dynamodb::model::AttributeValue;
 use chrono::Utc;
 use lambda_http::{run, http::{StatusCode, Response}, service_fn, Error, RequestExt, IntoResponse, Request};
-use serde_json::json;
+use aws_lambda_json_impl::json;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {

--- a/lambda-http/src/ext/request.rs
+++ b/lambda-http/src/ext/request.rs
@@ -15,7 +15,7 @@ use crate::Body;
 #[derive(Debug)]
 pub enum PayloadError {
     /// Returned when `application/json` bodies fail to deserialize a payload
-    Json(serde_json::Error),
+    Json(aws_lambda_json_impl::JsonError),
     /// Returned when `application/x-www-form-urlencoded` bodies fail to deserialize a payload
     WwwFormUrlEncoded(SerdeError),
 }
@@ -24,7 +24,7 @@ pub enum PayloadError {
 #[derive(Debug)]
 pub enum JsonPayloadError {
     /// Problem deserializing a JSON payload.
-    Parsing(serde_json::Error),
+    Parsing(aws_lambda_json_impl::JsonError),
 }
 
 /// Indicates a problem processing an x-www-form-urlencoded payload.
@@ -251,7 +251,7 @@ impl RequestPayloadExt for http::Request<Body> {
         if self.body().is_empty() {
             return Ok(None);
         }
-        serde_json::from_slice::<D>(self.body().as_ref())
+        aws_lambda_json_impl::from_slice::<D>(self.body().as_ref())
             .map(Some)
             .map_err(JsonPayloadError::Parsing)
     }

--- a/lambda-http/src/request.rs
+++ b/lambda-http/src/request.rs
@@ -29,7 +29,7 @@ use aws_lambda_events::{encodings::Body, query_map::QueryMap};
 use http::{header::HeaderName, HeaderMap, HeaderValue};
 
 use serde::{Deserialize, Serialize};
-use serde_json::error::Error as JsonError;
+use aws_lambda_json_impl::JsonError;
 
 use std::{env, future::Future, io::Read, pin::Pin};
 use url::Url;
@@ -463,7 +463,7 @@ pub fn from_reader<R>(rdr: R) -> Result<crate::Request, JsonError>
 where
     R: Read,
 {
-    serde_json::from_reader(rdr).map(LambdaRequest::into)
+    aws_lambda_json_impl::from_reader(rdr).map(LambdaRequest::into)
 }
 
 /// Deserializes a `Request` from a string of JSON text.
@@ -483,7 +483,7 @@ where
 /// }
 /// ```
 pub fn from_str(s: &str) -> Result<crate::Request, JsonError> {
-    serde_json::from_str(s).map(LambdaRequest::into)
+    aws_lambda_json_impl::from_str(s).map(LambdaRequest::into)
 }
 
 fn x_forwarded_proto() -> HeaderName {

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 [dependencies]
 lambda_runtime = { path = "../lambda-runtime" }
 aws_lambda_events = { path = "../lambda-events" }
-serde_json = "1.0.121"
+aws_lambda_json_impl = { version = "0", features = ["serde"], path = "../json-impl" }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0.204", features = ["derive"] }
 

--- a/lambda-integration-tests/src/authorizer.rs
+++ b/lambda-integration-tests/src/authorizer.rs
@@ -6,7 +6,7 @@ use aws_lambda_events::{
 };
 use lambda_runtime::{service_fn, tracing, Error, LambdaEvent};
 use serde::Deserialize;
-use serde_json::json;
+use aws_lambda_json_impl::json;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
The approach is to abstract _all_  original serde_json references to a new lib crate in the workspace - json-impl.

That crate as a feature swicth between serde_json and simd_json. In

The initial phase, is to to get all the other crates to depend on json-impl with the serde feature, instead of serde_json directly, so in the end nothing should change.

The next phase is to activate the simd feature and see what fails, then start mitigating the failures.

📬 *Issue #, if available:*

✍️ *Description of changes:*

🔏 *By submitting this pull request*

- [ ] I confirm that I've ran `cargo +nightly fmt`.
- [ ] I confirm that I've ran `cargo clippy --fix`.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
