### PR TITLE
Feature/otel span kind support

### DIFF
--- a/examples/opentelemetry-tracing/src/main.rs
+++ b/examples/opentelemetry-tracing/src/main.rs
@@ -1,6 +1,7 @@
 use lambda_runtime::{
     layers::{OpenTelemetryFaasTrigger, OpenTelemetryLayer as OtelLayer},
-    LambdaEvent, Runtime, tracing::Span
+    tracing::Span,
+    LambdaEvent, Runtime,
 };
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::{runtime, trace};

--- a/examples/opentelemetry-tracing/src/main.rs
+++ b/examples/opentelemetry-tracing/src/main.rs
@@ -1,6 +1,6 @@
 use lambda_runtime::{
     layers::{OpenTelemetryFaasTrigger, OpenTelemetryLayer as OtelLayer},
-    LambdaEvent, Runtime,
+    LambdaEvent, Runtime, tracing::Span
 };
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::{runtime, trace};
@@ -8,6 +8,8 @@ use tower::{service_fn, BoxError};
 use tracing_subscriber::prelude::*;
 
 async fn echo(event: LambdaEvent<serde_json::Value>) -> Result<serde_json::Value, &'static str> {
+    let span = Span::current();
+    span.record("otel.kind", "SERVER");
     Ok(event.payload)
 }
 

--- a/lambda-runtime/src/layers/otel.rs
+++ b/lambda-runtime/src/layers/otel.rs
@@ -4,7 +4,7 @@ use crate::LambdaInvocation;
 use opentelemetry_semantic_conventions::trace as traceconv;
 use pin_project::pin_project;
 use tower::{Layer, Service};
-use tracing::{instrument::Instrumented, Instrument};
+use tracing::{instrument::Instrumented, Instrument, field};
 
 /// Tower layer to add OpenTelemetry tracing to a Lambda function invocation. The layer accepts
 /// a function to flush OpenTelemetry after the end of the invocation.
@@ -75,6 +75,7 @@ where
         let span = tracing::info_span!(
             "Lambda function invocation",
             "otel.name" = req.context.env_config.function_name,
+            "otel.kind" = field::Empty,
             { traceconv::FAAS_TRIGGER } = &self.otel_attribute_trigger,
             { traceconv::FAAS_INVOCATION_ID } = req.context.request_id,
             { traceconv::FAAS_COLDSTART } = self.coldstart

--- a/lambda-runtime/src/layers/otel.rs
+++ b/lambda-runtime/src/layers/otel.rs
@@ -4,7 +4,7 @@ use crate::LambdaInvocation;
 use opentelemetry_semantic_conventions::trace as traceconv;
 use pin_project::pin_project;
 use tower::{Layer, Service};
-use tracing::{instrument::Instrumented, Instrument, field};
+use tracing::{field, instrument::Instrumented, Instrument};
 
 /// Tower layer to add OpenTelemetry tracing to a Lambda function invocation. The layer accepts
 /// a function to flush OpenTelemetry after the end of the invocation.


### PR DESCRIPTION
📬 *Issue #945

✍️ *Add OpenTelemetry span kind support to Lambda invocation tracing. This enhancement allows users to specify the span kind (e.g., SERVER, CLIENT) in their Lambda handlers, improving how functions are represented in distributed traces.
In this way:
- Users can set the span kind in their handlers using `span.record("otel.kind", "SERVER")` or `span.record("otel.kind", "CONSUMER") etc.
- Allows to follow [OpenTelemetry semantic conventions for span kind](https://opentelemetry.io/docs/specs/otel/trace/api/#spankind) while maintaining backward compatibility (the field can be left empty)

**Changes:**
- Added `otel.kind` field to the Lambda invocation span, initialized as `field::Empty` as per the [tracing_opentelemetry docs](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/#special-fields)
- Updated the example in `examples/opentelemetry-tracing/main.rs`to demonstrate setting the span kind

Please note that since tracing_opentelemetry 0.28.0, [they have provided a method to set the status on a span](https://github.com/tokio-rs/tracing-opentelemetry/pull/176), therefore setting `otel.status_code` and `otel.status_message` in advance on the span is not required anymore.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
