### PR TITLE
fix: serialize `AlbTargetGroupRequest::query_string_parameters` value to string

### DIFF
--- a/lambda-events/src/custom_serde/mod.rs
+++ b/lambda-events/src/custom_serde/mod.rs
@@ -33,6 +33,11 @@ pub(crate) mod float_unix_epoch;
 #[cfg(any(feature = "alb", feature = "apigw"))]
 pub(crate) mod http_method;
 
+#[cfg(feature = "alb")]
+mod query_string_parameters;
+#[cfg(feature = "alb")]
+pub(crate) use self::query_string_parameters::*;
+
 pub(crate) fn deserialize_base64<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
 where
     D: Deserializer<'de>,

--- a/lambda-events/src/custom_serde/query_string_parameters.rs
+++ b/lambda-events/src/custom_serde/query_string_parameters.rs
@@ -1,0 +1,63 @@
+use query_map::QueryMap;
+use serde::{ser::SerializeMap, Serializer};
+use std::collections::HashMap;
+
+/// Serializes `QueryMap`, converting value from `Vec<String>` to `String` using the last value.
+pub fn serialize_query_string_parameters<S>(value: &QueryMap, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut query_string_parameters = HashMap::new();
+
+    if let Some((mut last_key, mut last_value)) = value.iter().next() {
+        // insert the last value for each key
+        value.iter().for_each(|(k, v)| {
+            if k != last_key {
+                query_string_parameters.insert(last_key, last_value);
+                last_key = k;
+            }
+            last_value = v;
+        });
+        // insert the last pair
+        query_string_parameters.insert(last_key, last_value);
+    }
+
+    let mut map = serializer.serialize_map(Some(query_string_parameters.len()))?;
+    for (k, v) in &query_string_parameters {
+        map.serialize_entry(k, v)?;
+    }
+    map.end()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+    use serde_json::Value;
+
+    #[test]
+    fn test_serialize_query_string_parameters() {
+        #[derive(Serialize)]
+        struct Test {
+            #[serde(serialize_with = "serialize_query_string_parameters")]
+            pub v: QueryMap,
+        }
+
+        fn s(value: &str) -> String {
+            value.to_string()
+        }
+
+        let query = QueryMap::from(HashMap::from([
+            (s("key1"), vec![s("value1"), s("value2"), s("value3")]),
+            (s("key2"), vec![s("value4")]),
+            (s("key3"), vec![s("value5"), s("value6")]),
+        ]));
+
+        let serialized = serde_json::to_string(&Test { v: query }).unwrap();
+        let parsed: Value = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(parsed["v"]["key1"], Value::String("value3".to_string()));
+        assert_eq!(parsed["v"]["key2"], Value::String("value4".to_string()));
+        assert_eq!(parsed["v"]["key3"], Value::String("value6".to_string()));
+    }
+}

--- a/lambda-events/src/event/alb/mod.rs
+++ b/lambda-events/src/event/alb/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     custom_serde::{
-        deserialize_headers, deserialize_nullish_boolean, http_method, serialize_headers, serialize_multi_value_headers,
+        deserialize_headers, deserialize_nullish_boolean, http_method, serialize_headers,
+        serialize_multi_value_headers, serialize_query_string_parameters,
     },
     encodings::Body,
 };
@@ -17,7 +18,7 @@ pub struct AlbTargetGroupRequest {
     #[serde(default)]
     pub path: Option<String>,
     #[serde(default)]
-    #[serde(serialize_with = "query_map::serde::aws_api_gateway_v1::serialize_query_string_parameters")]
+    #[serde(serialize_with = "serialize_query_string_parameters")]
     pub query_string_parameters: QueryMap,
     #[serde(default)]
     pub multi_value_query_string_parameters: QueryMap,

--- a/lambda-events/src/event/alb/mod.rs
+++ b/lambda-events/src/event/alb/mod.rs
@@ -17,6 +17,7 @@ pub struct AlbTargetGroupRequest {
     #[serde(default)]
     pub path: Option<String>,
     #[serde(default)]
+    #[serde(serialize_with = "query_map::serde::aws_api_gateway_v1::serialize_query_string_parameters")]
     pub query_string_parameters: QueryMap,
     #[serde(default)]
     pub multi_value_query_string_parameters: QueryMap,
@@ -70,6 +71,7 @@ pub struct AlbTargetGroupResponse {
 #[cfg(test)]
 mod test {
     use super::*;
+    use serde_json::Value;
 
     #[test]
     #[cfg(feature = "alb")]
@@ -89,6 +91,19 @@ mod test {
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: AlbTargetGroupRequest = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "alb")]
+    fn ensure_alb_lambda_target_request_query_string_parameter_value_is_string() {
+        let data = include_bytes!("../../fixtures/example-alb-lambda-target-request-headers-only.json");
+        let parsed: AlbTargetGroupRequest = serde_json::from_slice(data).unwrap();
+        let output: String = serde_json::to_string(&parsed).unwrap();
+        let reparsed: Value = serde_json::from_slice(output.as_bytes()).unwrap();
+        assert_eq!(
+            reparsed["queryStringParameters"]["key"],
+            Value::String("hello".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
📬 *Issue #, if available:* 

#954

✍️ *Description of changes:* 

Provide a custom serializer `serialize_query_string_parameters` to serialize `AlbTargetGroupRequest::query_string_parameters`.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
