### PR TITLE
fix: Add type annotation to LambdaRequest's Deserialize impl to avoid compiler recursive loop

### DIFF
--- a/lambda-http/src/deserializer.rs
+++ b/lambda-http/src/deserializer.rs
@@ -20,7 +20,7 @@ impl<'de> Deserialize<'de> for LambdaRequest {
     where
         D: serde::Deserializer<'de>,
     {
-        let raw_value: Box<RawValue> = Box::deserialize(deserializer)?;
+        let raw_value: Box<RawValue> = Box::<RawValue>::deserialize(deserializer)?;
         let data = raw_value.get();
 
         #[cfg(feature = "apigw_rest")]


### PR DESCRIPTION
I ran into an issue where the compiler would get into an infinite loop evaluating `lambda_http/src/deserializer.rs:23`. I haven't seen anyone else complaining, so this might just be an issue from my own code.

```
error[E0275]: overflow evaluating the requirement `Box<_>: Deserialize<'_>`
  --> /home/redacted/.cargo/registry/src/index.crates.io-6f17d22bba15001f/lambda_http-0.13.0/src/deserializer.rs:23:45
   |
23 |         let raw_value: Box<RawValue> = Box::deserialize(deserializer)?;
   |                                             ^^^^^^^^^^^
   |
   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`lambda_http`)
   = note: required for `Box<zerovec::varzerovec::slice::VarZeroSlice<_, _>>` to implement `Deserialize<'_>`
   = note: 126 redundant requirements hidden
   = note: required for `Box<VarZeroSlice<VarZeroSlice<VarZeroSlice<VarZeroSlice<..., ...>, ...>, ...>, ...>>` to implement `Deserialize<'_>`
   = note: the full name for the type has been written to '/home/redacted/Documents/bernardino-reports/target/debug/deps/lambda_http-09107d4e09e782b6.long-type-5185401784481107607.txt'
   = note: consider using `--verbose` to print the full type name to the console

For more information about this error, try `rustc --explain E0275`.
error: could not compile `lambda_http` (lib) due to 1 previous error
```
I am not experienced in rust, or oss contributions in general, so apologies in advance if I am not following proper oss ettiquet and any advice/help would be appreciated.


📬 *Issue #, if available:*
n/a. 

✍️ *Description of changes:*
added a type hint to deserialize implementation of LambdaRequest. This avoids an infinite loop when evaluating a Box::deserialize()

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
