### PR TITLE
fix(docs): examples/extension-internal-flush: don't refer to a standalone layer arn for internal extension

### DIFF
--- a/examples/extension-internal-flush/README.md
+++ b/examples/extension-internal-flush/README.md
@@ -18,9 +18,10 @@ the Lambda service returns the response to the caller immediately. Extensions ma
 without introducing an observable delay.
 
 ## Build & Deploy
+Two deploy options for internal extensions: 
 
 1. Install [cargo-lambda](https://github.com/cargo-lambda/cargo-lambda#installation)
-2. Build the extension with `cargo lambda build --release`
+2. Build a function with the internal extension embedded with `cargo lambda build --release`
 3. Deploy the function to AWS Lambda with `cargo lambda deploy --iam-role YOUR_ROLE`
 
 The last command will give you an ARN for the extension layer that you can use in your functions.
@@ -28,3 +29,18 @@ The last command will give you an ARN for the extension layer that you can use i
 ## Build for ARM 64
 
 Build the extension with `cargo lambda build --release --arm64`
+
+
+## Test your Function
+
+From your local:
+```
+cargo lambda watch
+# in new terminal window
+cargo lambda invoke --data-ascii '{"Records":[{"messageId":"MessageID_1","receiptHandle":"MessageReceiptHandle","body":"{\"a\":\"Test\",\"b\":123}"}]}'
+```
+
+If you have deployed to AWS using the commands in the 'Build & Deploy' section, you can also invoke your function remotely:
+```
+cargo lambda invoke extension-internal-flush --remote --data-ascii '{"Records":[{"messageId":"MessageID_1","receiptHandle":"MessageReceiptHandle","body":"{\"a\":\"Test\",\"b\":123}"}]}'
+```

--- a/examples/extension-internal-flush/src/main.rs
+++ b/examples/extension-internal-flush/src/main.rs
@@ -101,6 +101,8 @@ async fn main() -> Result<(), Error> {
 
     let handler = Arc::new(EventHandler::new(request_done_sender));
 
+    // TODO: add biased! to always poll the handler future first, once supported:
+    // https://github.com/tokio-rs/tokio/issues/7304
     tokio::try_join!(
         lambda_runtime::run(service_fn(|event| {
             let handler = handler.clone();


### PR DESCRIPTION
📬 *Issue #, if available:*
n/a

✍️ *Description of changes:*

Small tweak to the docs for our example on internal extensions. We currently refer to retrieving a layer arn from `cargo lambda deploy`. This was probably copy-pasted from other examples where we actually are calling `cargo lambda deploy` with the `--extension` target.

In this case, we are deploying the function directly, and there is no standalone extension - it is all inside our primary binary.

Tweaking the language to remove a reference to a deployed layer ARN.

If we want to add a guide to invoking the remote function deployment, we could. The other examples don't have that though.

🔏 *By submitting this pull request*

- [x ] I confirm that I've ran `cargo +nightly fmt`.
- [ x] I confirm that I've ran `cargo clippy --fix`.
- [x ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
