### PR TITLE
Add alternative to pip3 install of cargo lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Or PiP on any system with Python 3 installed:
 ```bash
 pip3 install cargo-lambda
 ```
+Alternative, install the pip package as an executable using [uv](https://docs.astral.sh/uv/)
+
+```bash
+uv tool install cargo-lambda
+```
 
 See other installation options in [the Cargo Lambda documentation](https://www.cargo-lambda.info/guide/installation.html).
 


### PR DESCRIPTION


Another way to manage executable pip packages is with uv which has been very popular and helpful in the python community.

```

📬 *Issue #, if available:*

Small issue, When running `pip3 install .....` it shows this error about system vs user installation:

```
rror: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

```

✍️ *Description of changes:*

Experienced python users might already know that they can use `uv` to install and load python packages from pip as executable. But for those that don't know, adding this line can be a helpful alternative that doesn't show installation errors, reducing any friction to rust or python developers.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
