### PR TITLE
feat(tracing, lambda-runtime): add support for custom writer with default tracing subscriber, add turnkey graceful shutdown helper behind 'graceful-shutdown' feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,52 @@ async fn handler(_event: LambdaEvent<Request>) -> Result<(), Diagnostic> {
 
 You can see more examples on how to use these error crates in our [example repository](https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/examples/basic-error-error-crates-integration). 
 
+### Graceful shutdown
+
+`lambda_runtime` offers a helper to simplify configuring graceful shutdown signal handling, `spawn_graceful_shutdown_handler()`. This requires the `graceful-shutdown` feature flag and only supports Unix systems.
+
+You can use it by passing a `FnOnce` closure that returns an async block. That async block will be executed
+when the function receives a `SIGTERM` or `SIGKILL`.
+
+Note that this helper is opinionated in a number of ways. Most notably:
+1. It spawns a task to drive your signal handlers
+2. It registers a 'no-op' extension in order to enable graceful shutdown signals
+3. It panics on unrecoverable errors
+
+If you prefer to fine-tune the behavior, refer to the implementation of `spawn_graceful_shutdown_handler()` as a starting point for your own.
+
+For more information on graceful shutdown handling in AWS Lambda, see: [aws-samples/graceful-shutdown-with-aws-lambda](https://github.com/aws-samples/graceful-shutdown-with-aws-lambda).
+
+Complete example (cleaning up a non-blocking tracing writer):
+
+```rust,no_run
+use lambda_runtime::{service_fn, LambdaEvent, Error};
+use serde_json::{json, Value};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let func = service_fn(func);
+
+    let (writer, log_guard) = tracing_appender::non_blocking(std::io::stdout());
+    lambda_runtime::tracing::init_default_subscriber_with_writer(writer);
+
+    let shutdown_hook = || async move {
+      std::mem::drop(log_guard);
+    };
+    lambda_runtime::spawn_graceful_shutdown_handler(shutdown_hook);
+
+    lambda_runtime::run(func).await?;
+    Ok(())
+}
+
+async fn func(event: LambdaEvent<Value>) -> Result<Value, Error> {
+    let (event, _context) = event.into_parts();
+    let first_name = event["firstName"].as_str().unwrap_or("world");
+
+    Ok(json!({ "message": format!("Hello, {}!", first_name) }))
+}
+```
+
 ## Building and deploying your Lambda functions
 
 If you already have Cargo Lambda installed in your machine, run the next command to build your function:

--- a/lambda-integration-tests/src/helloworld.rs
+++ b/lambda-integration-tests/src/helloworld.rs
@@ -8,6 +8,7 @@ use lambda_runtime::{service_fn, tracing, Error, LambdaEvent};
 async fn main() -> Result<(), Error> {
     tracing::init_default_subscriber();
     let func = service_fn(func);
+    lambda_runtime::spawn_graceful_shutdown_handler(|| async move {});
     lambda_runtime::run(func).await?;
     Ok(())
 }

--- a/lambda-runtime-api-client/src/lib.rs
+++ b/lambda-runtime-api-client/src/lib.rs
@@ -22,6 +22,7 @@ pub use error::*;
 pub mod body;
 
 #[cfg(feature = "tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
 pub mod tracing;
 
 /// API client to interact with the AWS Lambda Runtime API.

--- a/lambda-runtime-api-client/src/tracing.rs
+++ b/lambda-runtime-api-client/src/tracing.rs
@@ -14,12 +14,16 @@ pub use tracing::*;
 
 /// Re-export the `tracing-subscriber` crate to build your own subscribers.
 pub use tracing_subscriber as subscriber;
+use tracing_subscriber::fmt::MakeWriter;
 
 const DEFAULT_LOG_LEVEL: &str = "INFO";
 
 /// Initialize `tracing-subscriber` with default logging options.
 ///
-/// This function uses environment variables set with [Lambda's advance logging controls](https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/)
+/// The default subscriber writes logs to STDOUT in the current context.
+/// If you want to customize the writer, see [`init_default_subscriber_with_writer()`].
+///
+/// This function uses environment variables set with [Lambda's advanced logging controls](https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/)
 /// if they're configured for your function.
 ///
 /// This subscriber sets the logging level based on environment variables:
@@ -31,6 +35,32 @@ const DEFAULT_LOG_LEVEL: &str = "INFO";
 /// If the `AWS_LAMBDA_LOG_FORMAT` environment variable is set to `JSON`, the log lines will be formatted as json objects,
 /// otherwise they will be formatted with the default tracing format.
 pub fn init_default_subscriber() {
+    init_default_subscriber_with_writer(std::io::stdout);
+}
+
+/// Initialize `tracing-subscriber` with default logging options, and a custom writer.
+///
+/// You might want to avoid writing to STDOUT in the local context via [`init_default_subscriber()`], if you have a high-throughput Lambdas that involve
+/// a lot of async concurrency. Since, writing to STDOUT can briefly block your tokio runtime - ref [tracing #2653](https://github.com/tokio-rs/tracing/issues/2653).
+/// In that case, you might prefer to use [tracing_appender::NonBlocking] instead - particularly if your Lambda is fairly long-running and stays warm.
+/// Though, note that you are then responsible
+/// for ensuring gracefuls shutdown. See [`examples/graceful-shutdown`] for a complete example.
+///
+/// This function uses environment variables set with [Lambda's advanced logging controls](https://aws.amazon.com/blogs/compute/introducing-advanced-logging-controls-for-aws-lambda-functions/)
+/// if they're configured for your function.
+///
+/// This subscriber sets the logging level based on environment variables:
+///     - if `AWS_LAMBDA_LOG_LEVEL` is set, it takes precedence over any other environment variables.
+///     - if `AWS_LAMBDA_LOG_LEVEL` is not set, check if `RUST_LOG` is set.
+///     - if none of those two variables are set, use `INFO` as the logging level.
+///
+/// The logging format can also be changed based on Lambda's advanced logging controls.
+/// If the `AWS_LAMBDA_LOG_FORMAT` environment variable is set to `JSON`, the log lines will be formatted as json objects,
+/// otherwise they will be formatted with the default tracing format.
+pub fn init_default_subscriber_with_writer<Writer>(writer: Writer)
+where
+    Writer: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
+{
     let log_format = env::var("AWS_LAMBDA_LOG_FORMAT").unwrap_or_default();
     let log_level_str = env::var("AWS_LAMBDA_LOG_LEVEL").or_else(|_| env::var("RUST_LOG"));
     let log_level =
@@ -43,7 +73,8 @@ pub fn init_default_subscriber() {
             EnvFilter::builder()
                 .with_default_directive(log_level.into())
                 .from_env_lossy(),
-        );
+        )
+        .with_writer(writer);
 
     if log_format.eq_ignore_ascii_case("json") {
         collector.json().init()

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -20,6 +20,10 @@ opentelemetry = ["opentelemetry-semantic-conventions"] # enables access to the O
 anyhow = ["dep:anyhow"] # enables From<T> for Diagnostic for anyhow error types, see README.md for more info
 eyre = ["dep:eyre"] # enables From<T> for Diagnostic for eyre error types, see README.md for more info
 miette = ["dep:miette"] # enables From<T> for Diagnostic for miette error types, see README.md for more info
+# TODO: remove tokio/rt and rt-multi-thread from non-feature-flagged dependencies in new breaking version, since they are unused:
+# as well as default features
+# https://github.com/awslabs/aws-lambda-rust-runtime/issues/984
+graceful-shutdown = ["tokio/rt", "tokio/signal", "dep:lambda-extension"]
 
 [dependencies]
 anyhow = { version = "1.0.86", optional = true }
@@ -39,6 +43,7 @@ hyper-util = { workspace = true, features = [
     "http1",
     "tokio",
 ] }
+lambda-extension = { version = "0.11.0", path = "../lambda-extension", default-features = false, optional = true }
 lambda_runtime_api_client = { version = "0.11.1", path = "../lambda-runtime-api-client", default-features = false }
 miette = { version = "7.2.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.29", optional = true, features = ["semconv_experimental"] }
@@ -67,4 +72,7 @@ hyper-util = { workspace = true, features = [
     "server-auto",
     "tokio",
 ] }
+# Self dependency to enable the graceful-shutdown feature for tests
+lambda_runtime = { path = ".", features = ["tracing", "graceful-shutdown"] }
 pin-project-lite = { workspace = true }
+tracing-appender = "0.2"

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -32,6 +32,7 @@ pub mod streaming;
 
 /// Utilities to initialize and use `tracing` and `tracing-subscriber` in Lambda Functions.
 #[cfg(feature = "tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
 pub use lambda_runtime_api_client::tracing;
 
 /// Types available to a Lambda function.
@@ -122,4 +123,111 @@ where
 {
     let runtime = Runtime::new(handler).layer(layers::TracingLayer::new());
     runtime.run().await
+}
+
+/// Spawns a task that will be execute a provided async closure when the process
+/// receives unix graceful shutdown signals. If the closure takes longer than 500ms
+/// to execute, an unhandled `SIGKILL` signal might be received.
+///
+/// You can use this future to execute cleanup or flush related logic prior to runtime shutdown.
+///
+/// This function must be called prior to [lambda_runtime::run()].
+///
+/// Note that this implicitly also registers and drives a no-op internal extension that subscribes to no events.
+/// This extension will be named `_lambda-rust-runtime-no-op-graceful-shutdown-helper`. This extension name
+/// can not be reused by other registered extensions. This is necessary in order to receive graceful shutdown signals.
+///
+/// This extension is cheap to run because it receives no events, but is not zero cost. If you have another extension
+/// registered already, you might prefer to manually construct your own graceful shutdown handling without the dummy extension.
+///
+/// For more information on general AWS Lambda graceful shutdown handling, see:
+/// https://github.com/aws-samples/graceful-shutdown-with-aws-lambda
+///
+/// # Panics
+///
+/// This function panics if:
+/// - this function is called after [lambda_runtime::run()]
+/// - this function is called outside of a context that has access to the tokio i/o
+/// - the no-op extension cannot be registered
+/// - either signal listener panics [tokio::signal::unix](https://docs.rs/tokio/latest/tokio/signal/unix/fn.signal.html#errors)
+///
+/// # Example
+/// ```no_run
+/// use lambda_runtime::{Error, service_fn, LambdaEvent};
+/// use serde_json::Value;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
+///     let func = service_fn(func);
+///
+///     let (writer, log_guard) = tracing_appender::non_blocking(std::io::stdout());
+///     lambda_runtime::tracing::init_default_subscriber_with_writer(writer);
+///
+///     let shutdown_hook = || async move {
+///         std::mem::drop(log_guard);
+///     };
+///     lambda_runtime::spawn_graceful_shutdown_handler(shutdown_hook);
+///
+///     lambda_runtime::run(func).await?;
+///     Ok(())
+/// }
+///
+/// async fn func(event: LambdaEvent<Value>) -> Result<Value, Error> {
+///     Ok(event.payload)
+/// }
+/// ```
+#[cfg(all(unix, feature = "graceful-shutdown"))]
+#[cfg_attr(docsrs, doc(cfg(all(unix, feature = "tokio-rt"))))]
+pub fn spawn_graceful_shutdown_handler<Fut>(shutdown_hook: impl FnOnce() -> Fut + Send + 'static)
+where
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    tokio::task::spawn(async move {
+        // You need an extension registered with the Lambda orchestrator in order for your process
+        // to receive a SIGTERM for graceful shutdown.
+        //
+        // We accomplish this here by registering a no-op internal extension, which does not subscribe to any events.
+        //
+        // This extension is cheap to run since after it connects to the lambda orchestration, the connection
+        // will just wait forever for data to come, which never comes, so it won't cause wakes.
+        let extension = lambda_extension::Extension::new()
+            // Don't subscribe to any event types
+            .with_events(&[])
+            // Internal extension names MUST be unique within a given Lambda function.
+            .with_extension_name("_lambda-rust-runtime-no-op-graceful-shutdown-helper")
+            // Extensions MUST be registered before calling lambda_runtime::run(), which ends the Init
+            // phase and begins the Invoke phase.
+            .register()
+            .await
+            .expect("could not register no-op extension for graceful shutdown");
+
+        let graceful_shutdown_future = async move {
+            let mut sigint = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()).unwrap();
+            let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
+            tokio::select! {
+                _sigint = sigint.recv() => {
+                    eprintln!("[runtime] SIGINT received");
+                    eprintln!("[runtime] Graceful shutdown in progress ...");
+                    shutdown_hook().await;
+                    eprintln!("[runtime] Graceful shutdown completed");
+                    std::process::exit(0);
+                },
+                _sigterm = sigterm.recv()=> {
+                    eprintln!("[runtime] SIGTERM received");
+                    eprintln!("[runtime] Graceful shutdown in progress ...");
+                    shutdown_hook().await;
+                    eprintln!("[runtime] Graceful shutdown completed");
+                    std::process::exit(0);
+                },
+            }
+        };
+
+        // TODO: add biased! to always poll the signal handling future first, once supported:
+        // https://github.com/tokio-rs/tokio/issues/7304
+        let _: (_, ()) = tokio::join!(graceful_shutdown_future, async {
+            // we suppress extension errors because we don't actually mind if it crashes,
+            // all we need to do is kick off the run so that lambda exits the init phase
+            let _ = extension.run().await;
+        });
+    });
 }


### PR DESCRIPTION
📬 *Issue #, if available:*
Closes #983 
✍️ *Description of changes:*
## Custom writer support for default tracing subscriber 
The current tracing subscriber uses the default stdout writer. This mostly is the right choice, but it does run the risk of occasionally blocking the tokio runtime - ref: https://github.com/tokio-rs/tracing/issues/2653

For high throughput, performance sensitive lambdas that have async concurrency in their handlers, they might instead prefer to use a non-blocking writer on a dedicated logging thread.

You can do that today by initializing a totally custom tracing subscriber, but the default one has convenient integrations with some native Lambda ENVs, that I'd like to keep using. 

Ideally we would have an API to return the configured `fmt::SubscriberBuilder` rather than implicitly initializing it in our helper. But, the tracing types are [very unpleasant to work with](https://github.com/tokio-rs/tracing/issues/575) due to the JSON vs full formatting choice. We would need to introduce a layer of dynamic dispatch, custom traits, or something else like that, if we wanted to bake in the handling for the `AWS_LAMBDA_LOG_FORMAT` ENV. We could also have a default subscriber builder that adds the JSON format at the end, but that felt very heavyweight for a simple 'default subscriber' helper API.

I felt that adding a custom writer is an important enough knob that a new `init_default_subscriber_with_writer()` API was warranted. It is much simpler code.

I don't think the semantic version of risk of surfacing the [fmt::MakeWriter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/trait.MakeWriter.html) trait bound is significant - first of all, we already re-export all the tracing types, so presumably we would treat a major version tracing-subscriber bump as our own major version bump. Second, the `MakeWriter` trait is very simple and seems unlikely to change; it just expects a function that returns something that implements `std::io::Writer`.

Note that we also now explicitly initialize `init_default_subscriber()` using STDOUT writer. This is the current default behavior of tracing subscriber, but it could presumably change across a major version bump. Probably better to pin it and make it a conscious choice on our own end to change it, if we later desire.

### Documentation decisions
I didn't explicitly document this in the README, since I think it would add confusion as it is not the right choice for most users. I do reference the API in the new `Graceful shutdown` README section, which I think is a useful breadcrumb for the sort of user that might need it.

The function docs do give a pretty good overview of what scenarios it might be appropriate for.

## Turnkey 'graceful shutdown hook'
Previously I had a more extended graceful shutdown example that added manual non-op extension registry, signal handling, etc. @bnusunny pointed out that this could be very cheaply abstracted away by the library, and he was right!

I went with a route that was pretty opinionated and on-rails, to reduce cognitive load of the API. Specifically:
- I implicitly register a dummy non-op extension that is subscribed to no events
- I implicitly construct the signal handling loop for SIGTERM and SIGINT, wrapping the user-provided hook
- I implicitly spawn a task to drive the signal handling + extension future, rather than returning to to the caller to interact with
- I panic on unrecoverable errors rather than returning a fallible `JoinHandle` or since the caller generally will be thinking of this as a background task

Note that the dummy extension is very low cost, since the extension.nextEvent API will keep a connection but then hang indefinitely if no events come. So it won't frequently wake the task that contains it and the signal handling future. Generally waking will be from the signal handling. The cost is essentially the memory to keep the connection open (and also in my testing, the extension future was exiting on run() when no events were registered, though I wouldn't count on that behavior).

Nothing is stopping the caller from manually constructing a more sophisticated set of signal handling, avoiding registering a dummy extension if they already have another one, etc. 

I did reference these choices in the function docs. I also shared the panic conditions as well as a realistic usage example. I also added a small section in the README to help with discoverability.

Anyway, I think that this is the API that is proper for 95%+ of callers, and anyway we can expand on it if we need to. I assume at that point it probably is worth baking into the `Runtime` type since anyway that is where we add more granularity of behavior.

### Dependency changes

I added a new feature flag for this, `graceful-shutdown`, since it adds new dependencies:
- `tokio`'s `signal` feature
- `lambda-extension`

Also worth noting is that this is the first time we actually need the `tokio` `rt` feature (`tokio::signal::signal()` requires it, as does `task::spawn()`). That matters more for #984 , but I made this feature a default feature to make it easier to rip that out without breaking people if we ever remove the vestigial dependency on `rt/rt-multi-threaded` without feature flags (across a semver boundary).

I didn't add a `lib.rs` passage documenting this new feature flag, but I did mention it in a new README section. I also added some `docs.rs` metatags to give us the nice `feature` indicator for both this as well as the tracing module re-export.

### Testing
I didn't see any great existing unit tests or integration tests that can be run locally, to extend to cover this case. My doctest validates that it will compile, but not that it runs, since it would hang indefinitely waiting for events. It would be cool to set up some sort of build-time integ testing that uses `cargo lambda`, but that wasn't scope I had time for.

I did throw in the graceful shutdown helper in our integration test that presumably runs against github actions - that at least will capture a fatal regression in our logic implicitly spinning up the non-op extension, etc, that would prevent the function from starting properly. Open to cutting a new integration test to run in CI that more specifically probes this, if folks feel it is necessary. Itust will be a bit awkward, since we'll need to have it sleep for a while to let the function spin down. Also either we will need sort of callback from the function to call against our github CI runner from inside the shutdown hook (aka expose a server in Github CI), or else poll eg CloudWatch Metrics or CloudWatch Logs to validate that the graceful shutdown logic fired.

**Manual e2e testing**

I did test a complete example manually both:
- locally (with my `cargo-lambda watch` signal handling fix in place - [ref](https://github.com/cargo-lambda/cargo-lambda/pull/853) 
- after deploying to an AWS account

Both showed the expected behavior:
- function runs and responds properly to handlers
- graceful shutdown shows up in logs on runtime shutdown:

Full AWS logs are at the end of this section.

I previously had my test code checked in as a complete `examples/` folder code. But, it felt kind of ridiculous when literally the doc comment was sufficient to demonstrate the behavior. I'm glad to add it back in if we think it is useful. Another option would be to use that example to show a more 'custom' signal handling use case that doesn't use our helper, but I was concerned that that would confuse readers.

AWS logs:
```
INIT_START Runtime Version: provided:al2023.v90	Runtime Version ARN: arn:aws:lambda:us-east-1::runtime:e49c711d78a410691cb8ac89b78502f273c233e01eed3d50c5ae2d6acc83b037
EXTENSION	Name: _lambda-rust-runtime-no-op-graceful-shutdown-helper	State: Ready	Events: []
START RequestId: adfa53cb-4372-4559-9879-be77c28359d6 Version: $LATEST
INFO Lambda runtime invoke{requestId="adfa53cb-4372-4559-9879-be77c28359d6" xrayTraceId="Root=1-681a76f5-2af5130749044a1110e28326;Parent=359483ddc68179b2;Sampled=0;Lineage=1:99116690:0"}: executing hello
END RequestId: adfa53cb-4372-4559-9879-be77c28359d6
REPORT RequestId: adfa53cb-4372-4559-9879-be77c28359d6	Duration: 2.18 ms	Billed Duration: 41 ms	Memory Size: 128 MB	Max Memory Used: 21 MB	Init Duration: 38.10 ms	
START RequestId: 5c971ea0-e406-474f-b952-24f9b76f876b Version: $LATEST
INFO Lambda runtime invoke{requestId="5c971ea0-e406-474f-b952-24f9b76f876b" xrayTraceId="Root=1-681a76f9-39ac3cb87f1fa86462caaa8c;Parent=76252a84c5d7fe51;Sampled=0;Lineage=1:99116690:0"}: executing hello
END RequestId: 5c971ea0-e406-474f-b952-24f9b76f876b
REPORT RequestId: 5c971ea0-e406-474f-b952-24f9b76f876b	Duration: 1.25 ms	Billed Duration: 2 ms	Memory Size: 128 MB	Max Memory Used: 21 MB	
[runtime] SIGTERM received
[runtime] Graceful shutdown in progress ...
[runtime] Graceful shutdown completed
``` 


🔏 *By submitting this pull request*

- [x ] I confirm that I've ran `cargo +nightly fmt`.
- [x ] I confirm that I've ran `cargo clippy --fix`.
- [x ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
