### PR TITLE
chore: add msrv in Cargo manifests

### DIFF
--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "aws_lambda_events"
 version = "0.16.0"
+rust-version = "1.81.0"
 description = "AWS Lambda event definitions"
 authors = [
   "Christian Legnitto <christian@legnitto.com>",

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lambda-extension"
 version = "0.11.0"
 edition = "2021"
+rust-version = "1.81.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
     "Harold Sun <sunhua@amazon.com>",
 ]
 edition = "2021"
+rust-version = "1.81.0"
 description = "Application Load Balancer and API Gateway event types for AWS Lambda"
 keywords = ["AWS", "Lambda", "APIGateway", "ALB", "API"]
 license = "Apache-2.0"

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -3,6 +3,7 @@ name = "aws_lambda_rust_integration_tests"
 version = "0.1.0"
 authors = ["Maxime David"]
 edition = "2021"
+rust-version = "1.81.0"
 description = "AWS Lambda Runtime integration tests"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/aws-lambda-rust-runtime"

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lambda_runtime_api_client"
 version = "0.11.1"
 edition = "2021"
+rust-version = "1.81.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 description = "AWS Lambda Runtime"
 edition = "2021"
+rust-version = "1.81.0"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/aws-lambda-rust-runtime"
 categories = ["web-programming::http-server"]


### PR DESCRIPTION
📬 *Issue #, if available:*

Relates to #986  but does not close it

✍️ *Description of changes:*

Adding the `Cargo.toml` declaration of our MSRV. Currently it is stated in our README that we support `1.81.0` or later, but not somewhere programmatically accessible. Ref: https://github.com/awslabs/aws-lambda-rust-runtime/blob/main/README.md#supported-rust-versions-msrv

Adding the `rust-version` field to all our crate manifests. This is nice for error messages, MSRV-aware crates resolution, etc. Ref: https://doc.rust-lang.org/cargo/reference/rust-version.html

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
