### PR TITLE
fix(integ tests): enable graceful-shutdown feature flag; chore(ci/cd): build integration test crate as part of PR validation

### DIFF
--- a/.github/workflows/build-integration-test.yml
+++ b/.github/workflows/build-integration-test.yml
@@ -1,0 +1,37 @@
+name: Build integration tests
+
+on:
+  push:
+    paths:
+      - 'lambda-runtime-api-client/**'
+      - 'lambda-runtime/**'
+      - 'lambda-http/**'
+      - 'lambda-extension/**'
+      - 'Cargo.toml'
+
+  pull_request:
+    paths:
+      - 'lambda-runtime-api-client/**'
+      - 'lambda-runtime/**'
+      - 'lambda-http/**'
+      - 'lambda-extension/**'
+      - 'Cargo.toml'
+
+jobs:
+  build-runtime:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - "1.81.0" # Current MSRV
+          - stable
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Integration tests
+        uses: ./.github/actions/rust-build
+        with:
+          package: lambda_integration_tests
+          toolchain: ${{ matrix.toolchain}}

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["AWS", "Lambda", "API"]
 readme = "../README.md"
 
 [dependencies]
-lambda_runtime = { path = "../lambda-runtime" }
+lambda_runtime = { path = "../lambda-runtime", features = ["tracing", "graceful-shutdown"] }
 aws_lambda_events = { path = "../lambda-events" }
 serde_json = "1.0.121"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
📬 *Issue #, if available:*
n/a

✍️ *Description of changes:*
#982 broke our integration test since it did not enable the new `graceful-shutdown` feature flag but used the new `spawn_graceful_shutdown_handler()`. Sorry about that, I missed fixing it when i removed `graceful-shutdown` from default features partway through the PR.

Sample failure: https://github.com/awslabs/aws-lambda-rust-runtime/actions/runs/14901777878/job/41855115960

I also included a github CI update to build the integ test crate on new PRs. That way we can catch this kind of regression prior to merge.


🔏 *By submitting this pull request*

- [x ] I confirm that I've ran `cargo +nightly fmt`.
- [ x] I confirm that I've ran `cargo clippy --fix`.
- [x ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
