### PR TITLE
fix(ci/cd): pin cargo-lambda back to 1.8.1 temporarily

### DIFF
--- a/.github/workflows/run-integration-test.yml
+++ b/.github/workflows/run-integration-test.yml
@@ -18,6 +18,8 @@ jobs:
             repo: cargo-lambda/cargo-lambda
             platform: linux
             arch: x86_64
+            # TODO: unpin once https://github.com/cargo-lambda/cargo-lambda/issues/856 is fixed
+            tag: v1.8.1
         - name: install Zig toolchain
           uses: korandoru/setup-zig@v1
           with:


### PR DESCRIPTION
📬 *Issue #, if available:*
n/a 
✍️ *Description of changes:*

Fix for:
https://github.com/awslabs/aws-lambda-rust-runtime/actions/runs/14909766508/job/41880956336#step:7:36

>Error: RustCargoLambdaBuilder:CargoLambdaBuild - Cargo Lambda failed: Error:   × Failed to collect `zig cc` options

This is a known regression in `cargo-lambda`: https://github.com/cargo-lambda/cargo-lambda/issues/856

Pinning back until it is fixed upstream.

🔏 *By submitting this pull request*

- [x ] I confirm that I've ran `cargo +nightly fmt`.
- [ x] I confirm that I've ran `cargo clippy --fix`.
- [ x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [ x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
