### PR TITLE
Release runtime 0.14.0 with graceful shutdown hook

### DIFF
--- a/.github/workflows/build-integration-test.yml
+++ b/.github/workflows/build-integration-test.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Build Integration tests
         uses: ./.github/actions/rust-build
         with:
-          package: lambda_integration_tests
+          package: lambda-integration-tests
           toolchain: ${{ matrix.toolchain}}

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-extension"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.81.0"
 authors = [
@@ -26,7 +26,7 @@ http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client", "server"] }
 hyper-util = { workspace = true }
-lambda_runtime_api_client = { version = "0.11", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "0.12", path = "../lambda-runtime-api-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "^1"
 tokio = { version = "1.0", features = [

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -39,7 +39,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "0.13.0", path = "../lambda-runtime" }
+lambda_runtime = { version = "0.14.0", path = "../lambda-runtime" }
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }
@@ -58,7 +58,7 @@ features = ["alb", "apigw"]
 [dev-dependencies]
 axum-core = "0.4.3"
 axum-extra = { version = "0.9.2", features = ["query"] }
-lambda_runtime_api_client = { version = "0.11.1", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "0.12.0", path = "../lambda-runtime-api-client" }
 log = "^0.4"
 maplit = "1.0"
 tokio = { version = "1.0", features = ["macros"] }

--- a/lambda-integration-tests/Cargo.toml
+++ b/lambda-integration-tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "aws_lambda_rust_integration_tests"
+name = "lambda-integration-tests"
 version = "0.1.0"
 authors = ["Maxime David"]
 edition = "2021"

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime_api_client"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.81.0"
 authors = [

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -44,7 +44,7 @@ hyper-util = { workspace = true, features = [
     "http1",
     "tokio",
 ] }
-lambda-extension = { version = "0.11.0", path = "../lambda-extension", default-features = false, optional = true }
+lambda-extension = { version = "0.12.0", path = "../lambda-extension", default-features = false, optional = true }
 lambda_runtime_api_client = { version = "0.12.0", path = "../lambda-runtime-api-client", default-features = false }
 miette = { version = "7.2.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.29", optional = true, features = ["semconv_experimental"] }

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -45,7 +45,7 @@ hyper-util = { workspace = true, features = [
     "tokio",
 ] }
 lambda-extension = { version = "0.11.0", path = "../lambda-extension", default-features = false, optional = true }
-lambda_runtime_api_client = { version = "0.11.1", path = "../lambda-runtime-api-client", default-features = false }
+lambda_runtime_api_client = { version = "0.12.0", path = "../lambda-runtime-api-client", default-features = false }
 miette = { version = "7.2.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.29", optional = true, features = ["semconv_experimental"] }
 pin-project = "1"


### PR DESCRIPTION
lambda-runtime-api-clietn 0.12.0
lambda-runtime 0.14.0
lambda-http 0.15.0
lambda-extesnion 0.12.0

📬 *Issue #, if available:*

✍️ *Description of changes:*

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
