### PR TITLE
fix(lambda-runtime,lambda-integration-tests): make spawn_graceful_shutdown_handler() async, await the extension being registered before spawning background extension handler task

### DIFF
--- a/lambda-integration-tests/src/helloworld.rs
+++ b/lambda-integration-tests/src/helloworld.rs
@@ -8,7 +8,7 @@ use lambda_runtime::{service_fn, tracing, Error, LambdaEvent};
 async fn main() -> Result<(), Error> {
     tracing::init_default_subscriber();
     let func = service_fn(func);
-    lambda_runtime::spawn_graceful_shutdown_handler(|| async move {});
+    lambda_runtime::spawn_graceful_shutdown_handler(|| async move {}).await;
     lambda_runtime::run(func).await?;
     Ok(())
 }

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -73,6 +73,9 @@ hyper-util = { workspace = true, features = [
     "server-auto",
     "tokio",
 ] }
+# pin back to pre-1.2.1 to avoid breaking rust MSRV of 1.81:
+# https://github.com/hsivonen/idna_adapter/commit/f948802e3a2ae936eec51886eefbd7d536a28791
+idna_adapter = "=1.2.0"
 # Self dependency to enable the graceful-shutdown feature for tests
 lambda_runtime = { path = ".", features = ["tracing", "graceful-shutdown"] }
 pin-project-lite = { workspace = true }


### PR DESCRIPTION
📬 *Issue #, if available:*
n/a

✍️ *Description of changes:*

Fix a race condition in `spawn_graceful_shutdown_handler()`. Previously function spawned a background task that handled both registration of the non-op extension and driving the extension/signal handling. This might take longer to finish registration than the primary function handler running, which would cause a crash.

Instead, we now model `spawn_graceful_shutdown_handler` as async and await the non-op registration completing. Updating the integration test as well.

This would normally be a semver breaking change, but we have not yet cut a release with this functionality, so it is safe.


🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
