### PR TITLE
feat(ci): build and check rustdocs for warnings; fix(docs): add missing cfg flag to allow displaying features on doc.rs, fix various warnings

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,39 @@
+name: Check rustdocs
+# this is its own workflow since we to to use unstable
+# to have the docs.rs display of feature flags
+
+on:
+  push:
+    paths:
+      - 'lambda-runtime/**'
+      - 'lambda-runtime-api-client/**'
+      - 'lambda-http/**'
+      - 'lambda-events/**'
+      - 'lambda-extension/**'
+      - 'Cargo.toml'
+
+  pull_request:
+    paths:
+      - 'lambda-runtime/**'
+      - 'lambda-runtime-api-client/**'
+      - 'lambda-http/**'
+      - 'lambda-events/**'
+      - 'lambda-extension/**'
+      - 'Cargo.toml'
+
+jobs:
+  build-runtime:
+    runs-on: ubuntu-latest
+
+    env:
+      RUST_BACKTRACE: 1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - name: Check documentation
+        shell: bash
+        env:
+            RUSTFLAGS: --cfg docsrs 
+            RUSTDOCFLAGS: --cfg docsrs -Dwarnings
+        run: cargo doc --no-deps --document-private-items --all-features

--- a/examples/advanced-sqs-partial-batch-failures/src/main.rs
+++ b/examples/advanced-sqs-partial-batch-failures/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Error> {
 /// Important note: your lambda sqs trigger *needs* to be configured with partial batch response support
 /// with the ` ReportBatchItemFailures` flag set to true, otherwise failed message will be dropped,
 /// for more details see:
-/// https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
+/// <https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting>
 ///
 ///
 /// Note that if you are looking for parallel processing (multithread) instead of concurrent processing,

--- a/examples/basic-error-handling/src/main.rs
+++ b/examples/basic-error-handling/src/main.rs
@@ -1,4 +1,4 @@
-/// See https://github.com/awslabs/aws-lambda-rust-runtime for more info on Rust runtime for AWS Lambda
+/// See <https://github.com/awslabs/aws-lambda-rust-runtime> for more info on Rust runtime for AWS Lambda
 use lambda_runtime::{service_fn, tracing, Error, LambdaEvent};
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/examples/http-basic-lambda/src/main.rs
+++ b/examples/http-basic-lambda/src/main.rs
@@ -3,7 +3,7 @@ use lambda_http::{run, service_fn, tracing, Body, Error, Request, Response};
 /// This is the main body for the function.
 /// Write your code inside it.
 /// There are some code examples in the Runtime repository:
-/// - https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/examples
+/// - <https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/examples>
 async fn function_handler(_event: Request) -> Result<Response<Body>, Error> {
     // Extract some useful information from the request
 

--- a/examples/http-dynamodb/src/main.rs
+++ b/examples/http-dynamodb/src/main.rs
@@ -15,7 +15,7 @@ pub struct Item {
 /// This is the main body for the function.
 /// Write your code inside it.
 /// You can see more examples in Runtime's repository:
-/// - https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/examples
+/// - <https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/examples>
 async fn handle_request(db_client: &Client, event: Request) -> Result<Response<Body>, Error> {
     // Extract some useful information from the request
     let body = event.body();

--- a/examples/http-query-parameters/src/main.rs
+++ b/examples/http-query-parameters/src/main.rs
@@ -3,7 +3,7 @@ use lambda_http::{run, service_fn, tracing, Error, IntoResponse, Request, Reques
 /// This is the main body for the function.
 /// Write your code inside it.
 /// You can see more examples in Runtime's repository:
-/// - https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/examples
+/// - <https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/examples>
 async fn function_handler(event: Request) -> Result<impl IntoResponse, Error> {
     // Extract some useful information from the request
     Ok(

--- a/lambda-events/src/custom_serde/float_unix_epoch.rs
+++ b/lambda-events/src/custom_serde/float_unix_epoch.rs
@@ -57,7 +57,6 @@ where
 struct SecondsFloatTimestampVisitor;
 
 /// Serialize a UTC datetime into an float number of seconds since the epoch
-/// ```
 pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: ser::Serializer,

--- a/lambda-events/src/custom_serde/headers.rs
+++ b/lambda-events/src/custom_serde/headers.rs
@@ -5,7 +5,7 @@ use serde::{
 };
 use std::{borrow::Cow, fmt};
 
-/// Serialize a http::HeaderMap into a serde str => Vec<str> map
+/// Serialize a http::HeaderMap into a serde str => `Vec<str>` map
 pub(crate) fn serialize_multi_value_headers<S>(headers: &HeaderMap, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/lambda-events/src/event/appsync/mod.rs
+++ b/lambda-events/src/event/appsync/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::custom_serde::deserialize_lambda_map;
 
-/// Deprecated: `AppSyncResolverTemplate` does not represent resolver events sent by AppSync. Instead directly model your input schema, or use map[string]string, json.RawMessage, interface{}, etc..
+/// Deprecated: `AppSyncResolverTemplate` does not represent resolver events sent by AppSync. Instead directly model your input schema, or use `map[string]string`, `json.RawMessage`,` interface{}`, etc..
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppSyncResolverTemplate<T1 = Value>

--- a/lambda-events/src/event/cloudformation/provider.rs
+++ b/lambda-events/src/event/cloudformation/provider.rs
@@ -2,7 +2,7 @@
 //!
 //! Note that they are similar (but not the same) as the events in the `super` module.
 //!
-//! See https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.custom_resources-readme.html for details.
+//! See <https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.custom_resources-readme.html> for details.
 
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;

--- a/lambda-events/src/event/cloudwatch_alarms/mod.rs
+++ b/lambda-events/src/event/cloudwatch_alarms/mod.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 /// `CloudWatchAlarm` is the generic outer structure of an event triggered by a CloudWatch Alarm.
 /// You probably want to use `CloudWatchMetricAlarm` or `CloudWatchCompositeAlarm` if you know which kind of alarm your function is receiving.
 /// For examples of events that come via CloudWatch Alarms,
-/// see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#Lambda-action-payload
+/// see <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#Lambda-action-payload>
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudWatchAlarm<C = Value, R = CloudWatchAlarmStateReasonData>

--- a/lambda-events/src/event/cloudwatch_events/mod.rs
+++ b/lambda-events/src/event/cloudwatch_events/mod.rs
@@ -20,7 +20,7 @@ pub mod tag;
 pub mod trustedadvisor;
 
 /// `CloudWatchEvent` is the outer structure of an event sent via CloudWatch Events.
-/// For examples of events that come via CloudWatch Events, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html
+/// For examples of events that come via CloudWatch Events, see <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudWatchEvent<T1 = Value>

--- a/lambda-events/src/event/codebuild/mod.rs
+++ b/lambda-events/src/event/codebuild/mod.rs
@@ -11,7 +11,7 @@ pub type CodeBuildPhaseStatus = String;
 pub type CodeBuildPhaseType = String;
 
 /// `CodeBuildEvent` is documented at:
-/// https://docs.aws.amazon.com/codebuild/latest/userguide/sample-build-notifications.html#sample-build-notifications-ref
+/// <https://docs.aws.amazon.com/codebuild/latest/userguide/sample-build-notifications.html#sample-build-notifications-ref>
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeBuildEvent {

--- a/lambda-events/src/event/codedeploy/mod.rs
+++ b/lambda-events/src/event/codedeploy/mod.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub type CodeDeployDeploymentState = String;
 
 /// `CodeDeployEvent` is documented at:
-/// https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#acd_event_types
+/// <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#acd_event_types>
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeDeployEvent {

--- a/lambda-events/src/event/codepipeline_cloudwatch/mod.rs
+++ b/lambda-events/src/event/codepipeline_cloudwatch/mod.rs
@@ -8,7 +8,7 @@ pub type CodePipelineState = String;
 pub type CodePipelineActionState = String;
 
 /// CodePipelineEvent is documented at:
-/// https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#codepipeline_event_type
+/// <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#codepipeline_event_type>
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineCloudWatchEvent {

--- a/lambda-events/src/event/dynamodb/mod.rs
+++ b/lambda-events/src/event/dynamodb/mod.rs
@@ -110,7 +110,7 @@ impl fmt::Display for KeyType {
 }
 
 /// The `Event` stream event handled to Lambda
-/// http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-ddb-update
+/// <http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-ddb-update>
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Event {
     #[serde(rename = "Records")]
@@ -118,7 +118,7 @@ pub struct Event {
 }
 
 /// `TimeWindowEvent` represents an Amazon Dynamodb event when using time windows
-/// ref. https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-windows
+/// ref. <https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-windows>
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeWindowEvent {
@@ -215,8 +215,8 @@ pub struct UserIdentity {
 #[serde(rename_all = "camelCase")]
 pub struct StreamRecord {
     /// The approximate date and time when the stream record was created, in UNIX
-    /// epoch time (http://www.epochconverter.com/) format. Might not be present in
-    /// the record: https://github.com/awslabs/aws-lambda-rust-runtime/issues/889
+    /// epoch time (<http://www.epochconverter.com/>) format. Might not be present in
+    /// the record: <https://github.com/awslabs/aws-lambda-rust-runtime/issues/889>
     #[serde(rename = "ApproximateCreationDateTime")]
     #[serde(with = "float_unix_epoch")]
     #[serde(default)]

--- a/lambda-events/src/event/eventbridge/mod.rs
+++ b/lambda-events/src/event/eventbridge/mod.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 /// Parse EventBridge events.
 /// Deserialize the event detail into a structure that's `DeserializeOwned`.
 ///
-/// See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html for structure details.
+/// See <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html> for structure details.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(bound(deserialize = "T1: DeserializeOwned"))]
 #[serde(rename_all = "kebab-case")]

--- a/lambda-events/src/event/iot/mod.rs
+++ b/lambda-events/src/event/iot/mod.rs
@@ -3,7 +3,7 @@ use http::HeaderMap;
 use serde::{Deserialize, Serialize};
 
 /// `IoTCoreCustomAuthorizerRequest` represents the request to an IoT Core custom authorizer.
-/// See https://docs.aws.amazon.com/iot/latest/developerguide/config-custom-auth.html
+/// See <https://docs.aws.amazon.com/iot/latest/developerguide/config-custom-auth.html>
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IoTCoreCustomAuthorizerRequest {
@@ -58,7 +58,7 @@ pub struct IoTCoreConnectionMetadata {
 }
 
 /// `IoTCoreCustomAuthorizerResponse` represents the response from an IoT Core custom authorizer.
-/// See https://docs.aws.amazon.com/iot/latest/developerguide/config-custom-auth.html
+/// See <https://docs.aws.amazon.com/iot/latest/developerguide/config-custom-auth.html>
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IoTCoreCustomAuthorizerResponse {

--- a/lambda-events/src/event/kinesis/event.rs
+++ b/lambda-events/src/event/kinesis/event.rs
@@ -12,7 +12,7 @@ pub struct KinesisEvent {
 }
 
 /// `KinesisTimeWindowEvent` represents an Amazon Dynamodb event when using time windows
-/// ref. https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows
+/// ref. <https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KinesisTimeWindowEvent {

--- a/lambda-events/src/event/s3/object_lambda.rs
+++ b/lambda-events/src/event/s3/object_lambda.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use crate::custom_serde::{deserialize_headers, serialize_headers};
 
 /// `S3ObjectLambdaEvent` contains data coming from S3 object lambdas
-/// See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-writing-lambda.html
+/// See: <https://docs.aws.amazon.com/AmazonS3/latest/userguide/olap-writing-lambda.html>
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct S3ObjectLambdaEvent<P = Value>

--- a/lambda-events/src/event/sqs/mod.rs
+++ b/lambda-events/src/event/sqs/mod.rs
@@ -126,7 +126,7 @@ pub struct SqsApiEvent {
     pub messages: Vec<SqsApiMessage>,
 }
 
-/// Alternative to SqsApiEvent to be used alongside SqsApiMessageObj<T> when you need to
+/// Alternative to SqsApiEvent to be used alongside `SqsApiMessageObj<T>` when you need to
 /// deserialize a nested object into a struct of type T within the SQS Message rather
 /// than just using the raw SQS Message string
 #[serde_with::serde_as]

--- a/lambda-events/src/lib.rs
+++ b/lambda-events/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "http")]
 pub use http;
 #[cfg(feature = "query_map")]

--- a/lambda-events/src/time_window.rs
+++ b/lambda-events/src/time_window.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use crate::custom_serde::deserialize_lambda_map;
 
 /// `Window` is the object that captures the time window for the records in the event when using the tumbling windows feature
-/// Kinesis: https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows
-/// DDB: https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-windows
+/// Kinesis: <https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows>
+/// DDB: <https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-windows>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Window {
@@ -24,8 +24,8 @@ impl Default for Window {
 }
 
 /// `TimeWindowProperties` is the object that captures properties that relate to the tumbling windows feature
-/// Kinesis: https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows
-/// DDB: https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-windows
+/// Kinesis: <https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows>
+/// DDB: <https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-windows>
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeWindowProperties {
@@ -51,8 +51,8 @@ pub struct TimeWindowProperties {
 }
 
 /// `TimeWindowEventResponseProperties` is the object that captures response properties that relate to the tumbling windows feature
-/// Kinesis: https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows
-/// DDB: https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-windows
+/// Kinesis: <https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows>
+/// DDB: <https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-windows>
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeWindowEventResponseProperties {

--- a/lambda-extension/src/lib.rs
+++ b/lambda-extension/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all, clippy::cargo)]
 #![allow(clippy::multiple_crate_versions, clippy::type_complexity)]
 #![warn(missing_docs, nonstandard_style, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! This module includes utilities to create Lambda Runtime Extensions.
 //!

--- a/lambda-extension/src/logs.rs
+++ b/lambda-extension/src/logs.rs
@@ -12,7 +12,7 @@ use tracing::{error, trace};
 use crate::{Error, ExtensionError};
 
 /// Payload received from the Lambda Logs API
-/// See: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-logs-api.html#runtimes-logs-api-msg
+/// See: <https://docs.aws.amazon.com/lambda/latest/dg/runtimes-logs-api.html#runtimes-logs-api-msg>
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct LambdaLog {
     /// Time when the log was generated

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //#![deny(warnings)]
 //! Enriches the `lambda` crate with [`http`](https://github.com/hyperium/http)
 //! types targeting AWS [ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html), [API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html) REST and HTTP API lambda integrations.

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -189,7 +189,7 @@ where
 /// Runtime APIs](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html).
 ///
 /// This takes care of transforming the LambdaEvent into a [`Request`] and then
-/// converting the result into a [`LambdaResponse`].
+/// converting the result into a `LambdaResponse`.
 pub async fn run<'a, R, S, E>(handler: S) -> Result<(), Error>
 where
     S: Service<Request, Response = R, Error = E>,

--- a/lambda-http/src/response.rs
+++ b/lambda-http/src/response.rs
@@ -153,7 +153,7 @@ impl LambdaResponse {
 ///
 /// Types that implement this trait can be used as return types for handler functions.
 pub trait IntoResponse {
-    /// Transform into a Response<Body> Future
+    /// Transform into a `Response<Body>` Future
     fn into_response(self) -> ResponseFuture;
 }
 

--- a/lambda-runtime-api-client/src/body/channel.rs
+++ b/lambda-runtime-api-client/src/body/channel.rs
@@ -1,5 +1,5 @@
 //! Body::channel utilities. Extracted from Hyper under MIT license.
-//! https://github.com/hyperium/hyper/blob/master/LICENSE
+//! <https://github.com/hyperium/hyper/blob/master/LICENSE>
 
 use std::{
     pin::Pin,
@@ -31,7 +31,7 @@ impl DecodedLength {
         }
     }
 
-    /// Converts to an Option<u64> representing a Known or Unknown length.
+    /// Converts to an `Option<u64>` representing a Known or Unknown length.
     pub(crate) fn into_opt(self) -> Option<u64> {
         match self {
             DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => None,

--- a/lambda-runtime-api-client/src/body/mod.rs
+++ b/lambda-runtime-api-client/src/body/mod.rs
@@ -1,5 +1,5 @@
 //! HTTP body utilities. Extracted from Axum under MIT license.
-//! https://github.com/tokio-rs/axum/blob/main/axum/LICENSE
+//! <https://github.com/tokio-rs/axum/blob/main/axum/LICENSE>
 
 use crate::{BoxError, Error};
 use bytes::Bytes;

--- a/lambda-runtime-api-client/src/body/sender.rs
+++ b/lambda-runtime-api-client/src/body/sender.rs
@@ -1,5 +1,5 @@
 //! Body::channel utilities. Extracted from Hyper under MIT license.
-//! https://github.com/hyperium/hyper/blob/master/LICENSE
+//! <https://github.com/hyperium/hyper/blob/master/LICENSE>
 
 use crate::Error;
 use std::task::{Context, Poll};

--- a/lambda-runtime-api-client/src/body/watch.rs
+++ b/lambda-runtime-api-client/src/body/watch.rs
@@ -1,5 +1,5 @@
 //! Body::channel utilities. Extracted from Hyper under MIT license.
-//! https://github.com/hyperium/hyper/blob/master/LICENSE
+//! <https://github.com/hyperium/hyper/blob/master/LICENSE>
 
 //! An SPSC broadcast channel.
 //!

--- a/lambda-runtime-api-client/src/error.rs
+++ b/lambda-runtime-api-client/src/error.rs
@@ -1,5 +1,5 @@
 //! Extracted from Axum under MIT license.
-//! https://github.com/tokio-rs/axum/blob/main/axum/LICENSE
+//! <https://github.com/tokio-rs/axum/blob/main/axum/LICENSE>
 use std::{error::Error as StdError, fmt};
 pub use tower::BoxError;
 /// Errors that can happen when using axum.

--- a/lambda-runtime-api-client/src/lib.rs
+++ b/lambda-runtime-api-client/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all, clippy::cargo)]
 #![warn(missing_docs, nonstandard_style, rust_2018_idioms)]
 #![allow(clippy::multiple_crate_versions)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! This crate includes a base HTTP client to interact with
 //! the AWS Lambda Runtime API.

--- a/lambda-runtime-api-client/src/tracing.rs
+++ b/lambda-runtime-api-client/src/tracing.rs
@@ -42,7 +42,7 @@ pub fn init_default_subscriber() {
 ///
 /// You might want to avoid writing to STDOUT in the local context via [`init_default_subscriber()`], if you have a high-throughput Lambdas that involve
 /// a lot of async concurrency. Since, writing to STDOUT can briefly block your tokio runtime - ref [tracing #2653](https://github.com/tokio-rs/tracing/issues/2653).
-/// In that case, you might prefer to use [tracing_appender::NonBlocking] instead - particularly if your Lambda is fairly long-running and stays warm.
+/// In that case, you might prefer to use [tracing_appender::NonBlocking](https://docs.rs/tracing-appender/latest/tracing_appender/non_blocking/struct.NonBlocking.html) instead - particularly if your Lambda is fairly long-running and stays warm.
 /// Though, note that you are then responsible
 /// for ensuring gracefuls shutdown. See [`examples/graceful-shutdown`] for a complete example.
 ///

--- a/lambda-runtime/src/layers/otel.rs
+++ b/lambda-runtime/src/layers/otel.rs
@@ -131,7 +131,7 @@ where
 }
 
 /// Represent the possible values for the OpenTelemetry `faas.trigger` attribute.
-/// See https://opentelemetry.io/docs/specs/semconv/attributes-registry/faas/ for more details.
+/// See <https://opentelemetry.io/docs/specs/semconv/attributes-registry/faas/> for more details.
 #[derive(Default, Clone, Copy)]
 #[non_exhaustive]
 pub enum OpenTelemetryFaasTrigger {

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(clippy::all, clippy::cargo)]
 #![allow(clippy::multiple_crate_versions)]
 #![warn(missing_docs, nonstandard_style, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! The mechanism available for defining a Lambda function is as follows:
 //!

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -132,7 +132,7 @@ where
 ///
 /// You can use this future to execute cleanup or flush related logic prior to runtime shutdown.
 ///
-/// This function's returned future must be resolved prior to [lambda_runtime::run()].
+/// This function's returned future must be resolved prior to `lambda_runtime::run()`.
 ///
 /// Note that this implicitly also registers and drives a no-op internal extension that subscribes to no events.
 /// This extension will be named `_lambda-rust-runtime-no-op-graceful-shutdown-helper`. This extension name
@@ -142,12 +142,12 @@ where
 /// registered already, you might prefer to manually construct your own graceful shutdown handling without the dummy extension.
 ///
 /// For more information on general AWS Lambda graceful shutdown handling, see:
-/// https://github.com/aws-samples/graceful-shutdown-with-aws-lambda
+/// <https://github.com/aws-samples/graceful-shutdown-with-aws-lambda>
 ///
 /// # Panics
 ///
 /// This function panics if:
-/// - this function is called after [lambda_runtime::run()]
+/// - this function is called after `lambda_runtime::run()`
 /// - this function is called outside of a context that has access to the tokio i/o
 /// - the no-op extension cannot be registered
 /// - either signal listener panics [tokio::signal::unix](https://docs.rs/tokio/latest/tokio/signal/unix/fn.signal.html#errors)


### PR DESCRIPTION
📬 *Issue #, if available:*
n/a

✍️ *Description of changes:*
Fix for: https://docs.rs/crate/lambda_runtime/0.14.0/builds/2162130
```
[INFO] [stderr]  Documenting lambda_runtime v0.14.0 (/opt/rustwide/workdir)
[INFO] [stderr] error[E0658]: `#[doc(cfg)]` is experimental
[INFO] [stderr]   --> src/lib.rs:35:20
[INFO] [stderr]    |
[INFO] [stderr] 35 | #[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
[INFO] [stderr]    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[INFO] [stderr]    |
[INFO] [stderr]    = note: see issue #43781 <https://github.com/rust-lang/rust/issues/43781> for more information
[INFO] [stderr]    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
[INFO] [stderr]    = note: this compiler was built on 2025-05-26; consider upgrading it if it is out of date
[INFO] [stderr] 
[INFO] [stderr] For more information about this error, try `rustc --explain E0658`.
[INFO] [stderr] error: could not document `lambda_runtime`
```

We want to display the feature gates on items in `docs.rs`. However, we were missing the crate-level `#![cfg_attr(docsrs, feature(doc_cfg))]` necessary to do so.

This made it through our CI since we don't build/validate docs. Adding that in.

I structured it as a standalone step since docs.rs target only builds on the nightly branch. I just tossed all the crates into it rather than segmenting - there are cross-crate doc linking interdependencies, and anyway it's a quick step.

This required fixing a TON of docs warnings since I have the step configured to fail on warnings (broken doc links, etc).

## Testing

It's passing on my branch's CI: https://github.com/jlizen/aws-lambda-rust-runtime/actions/runs/15281293634/job/42980737800

Also the regular builds are still passing.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
