### PR TITLE
fix(docs): enable all features in docs.rs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ async fn main() -> Result<(), Error> {
     let shutdown_hook = || async move {
       std::mem::drop(log_guard);
     };
-    lambda_runtime::spawn_graceful_shutdown_handler(shutdown_hook);
+    lambda_runtime::spawn_graceful_shutdown_handler(shutdown_hook).await;
 
     lambda_runtime::run(func).await?;
     Ok(())

--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -124,3 +124,6 @@ sqs = ["serde_with"]
 streams = []
 documentdb = []
 eventbridge = ["chrono", "serde_with"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/lambda-events/src/custom_serde/mod.rs
+++ b/lambda-events/src/custom_serde/mod.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 #[cfg(feature = "codebuild")]
 pub(crate) mod codebuild_time;
 #[cfg(feature = "codebuild")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codebuild")))]
 pub type CodeBuildNumber = f32;
 
 #[cfg(any(

--- a/lambda-events/src/encodings/mod.rs
+++ b/lambda-events/src/encodings/mod.rs
@@ -6,10 +6,12 @@ mod time;
 use crate::custom_serde::{deserialize_base64, serialize_base64};
 
 #[cfg(feature = "chrono")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 pub use self::time::*;
 #[cfg(feature = "http")]
 mod http;
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub use self::http::*;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/lambda-events/src/event/mod.rs
+++ b/lambda-events/src/event/mod.rs
@@ -1,162 +1,203 @@
 /// AWS Lambda event definitions for activemq.
 #[cfg(feature = "activemq")]
+#[cfg_attr(docsrs, doc(cfg(feature = "activemq")))]
 pub mod activemq;
 
 /// AWS Lambda event definitions for alb.
 #[cfg(feature = "alb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alb")))]
 pub mod alb;
 /// AWS Lambda event definitions for apigw.
 #[cfg(feature = "apigw")]
+#[cfg_attr(docsrs, doc(cfg(feature = "apigw")))]
 pub mod apigw;
 
 /// AWS Lambda event definitions for appsync.
 #[cfg(feature = "appsync")]
+#[cfg_attr(docsrs, doc(cfg(feature = "appsync")))]
 pub mod appsync;
 
 /// AWS Lambda event definitions for autoscaling.
 #[cfg(feature = "autoscaling")]
+#[cfg_attr(docsrs, doc(cfg(feature = "autoscaling")))]
 pub mod autoscaling;
 
 /// AWS Lambda event definitions for agent for amazon bedrock
 #[cfg(feature = "bedrock_agent_runtime")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bedrock_agent_runtime")))]
 pub mod bedrock_agent_runtime;
 
 /// AWS Lambda event definitions for chime_bot.
 #[cfg(feature = "chime_bot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chime_bot")))]
 pub mod chime_bot;
 
 /// AWS Lambda event definitions for clientvpn.
 #[cfg(feature = "clientvpn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clientvpn")))]
 pub mod clientvpn;
 
 /// AWS Lambda event definitions for cloudformation.
 #[cfg(feature = "cloudformation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cloudformation")))]
 pub mod cloudformation;
 
 /// AWS Lambda event definitions for CloudWatch alarms.
 #[cfg(feature = "cloudwatch_alarms")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cloudwatch_alarms")))]
 pub mod cloudwatch_alarms;
 
 /// AWS Lambda event definitions for CloudWatch events.
 #[cfg(feature = "cloudwatch_events")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cloudwatch_events")))]
 pub mod cloudwatch_events;
 
 /// AWS Lambda event definitions for cloudwatch_logs.
 #[cfg(feature = "cloudwatch_logs")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cloudwatch_logs")))]
 pub mod cloudwatch_logs;
 
 /// AWS Lambda event definitions for code_commit.
 #[cfg(feature = "code_commit")]
+#[cfg_attr(docsrs, doc(cfg(feature = "code_commit")))]
 pub mod code_commit;
 
 /// AWS Lambda event definitions for codebuild.
 #[cfg(feature = "codebuild")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codebuild")))]
 pub mod codebuild;
 
 /// AWS Lambda event definitions for codedeploy.
 #[cfg(feature = "codedeploy")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codedeploy")))]
 pub mod codedeploy;
 
 /// AWS Lambda event definitions for codepipeline_cloudwatch.
 #[cfg(feature = "codepipeline_cloudwatch")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codepipeline_cloudwatch")))]
 pub mod codepipeline_cloudwatch;
 
 /// AWS Lambda event definitions for codepipeline_job.
 #[cfg(feature = "codepipeline_job")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codepipeline_job")))]
 pub mod codepipeline_job;
 
 /// AWS Lambda event definitions for cognito.
 #[cfg(feature = "cognito")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cognito")))]
 pub mod cognito;
 
 /// AWS Lambda event definitions for config.
 #[cfg(feature = "config")]
+#[cfg_attr(docsrs, doc(cfg(feature = "config")))]
 pub mod config;
 
 /// AWS Lambda event definitions for connect.
 #[cfg(feature = "connect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "connect")))]
 pub mod connect;
 
 /// AWS Lambda event definitions for dynamodb.
 #[cfg(feature = "dynamodb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dynamodb")))]
 pub mod dynamodb;
 
 /// AWS Lambda event definitions for ecr_scan.
 #[cfg(feature = "ecr_scan")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecr_scan")))]
 pub mod ecr_scan;
 
 /// AWS Lambda event definitions for firehose.
 #[cfg(feature = "firehose")]
+#[cfg_attr(docsrs, doc(cfg(feature = "firehose")))]
 pub mod firehose;
 
 /// AWS Lambda event definitions for iam.
 #[cfg(feature = "iam")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iam")))]
 pub mod iam;
 
 /// AWS Lambda event definitions for iot.
 #[cfg(feature = "iot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iot")))]
 pub mod iot;
 
 /// AWS Lambda event definitions for iot_1_click.
 #[cfg(feature = "iot_1_click")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iot_1_click")))]
 pub mod iot_1_click;
 
 /// AWS Lambda event definitions for iot_button.
 #[cfg(feature = "iot_button")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iot_button")))]
 pub mod iot_button;
 
 /// AWS Lambda event definitions for iot_deprecated.
 #[cfg(feature = "iot_deprecated")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iot_deprecated")))]
 pub mod iot_deprecated;
 
 /// AWS Lambda event definitions for kafka.
 #[cfg(feature = "kafka")]
+#[cfg_attr(docsrs, doc(cfg(feature = "kafka")))]
 pub mod kafka;
 
 /// AWS Lambda event definitions for kinesis.
 #[cfg(feature = "kinesis")]
+#[cfg_attr(docsrs, doc(cfg(feature = "kinesis")))]
 pub mod kinesis;
 
 /// AWS Lambda event definitions for lambda_function_urls.
 #[cfg(feature = "lambda_function_urls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lambda_function_urls")))]
 pub mod lambda_function_urls;
 
 /// AWS Lambda event definitions for lex.
 #[cfg(feature = "lex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lex")))]
 pub mod lex;
 
 /// AWS Lambda event definitions for rabbitmq.
 #[cfg(feature = "rabbitmq")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rabbitmq")))]
 pub mod rabbitmq;
 
 /// AWS Lambda event definitions for s3.
 #[cfg(feature = "s3")]
+#[cfg_attr(docsrs, doc(cfg(feature = "s3")))]
 pub mod s3;
 
 /// AWS Lambda event definitions for secretsmanager.
 #[cfg(feature = "secretsmanager")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secretsmanager")))]
 pub mod secretsmanager;
 
 /// AWS Lambda event definitions for ses.
 #[cfg(feature = "ses")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ses")))]
 pub mod ses;
 
 /// AWS Lambda event definitions for SNS.
 #[cfg(feature = "sns")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sns")))]
 pub mod sns;
 
 /// AWS Lambda event definitions for SQS.
 #[cfg(feature = "sqs")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqs")))]
 pub mod sqs;
 
 /// AWS Lambda event definitions for streams.
 #[cfg(feature = "streams")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
 pub mod streams;
 
 // AWS Lambda event definitions for DocumentDB
 #[cfg(feature = "documentdb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "documentdb")))]
 pub mod documentdb;
 
 /// AWS Lambda event definitions for EventBridge.
 #[cfg(feature = "eventbridge")]
+#[cfg_attr(docsrs, doc(cfg(feature = "eventbridge")))]
 pub mod eventbridge;

--- a/lambda-events/src/lib.rs
+++ b/lambda-events/src/lib.rs
@@ -1,14 +1,17 @@
 #![deny(rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub use http;
 #[cfg(feature = "query_map")]
+#[cfg_attr(docsrs, doc(cfg(feature = "query_map")))]
 pub use query_map;
 
 mod custom_serde;
 /// Encodings used in AWS Lambda json event values.
 pub mod encodings;
 #[cfg(feature = "chrono")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 pub mod time_window;
 
 /// AWS Lambda event definitions.
@@ -16,168 +19,210 @@ pub mod event;
 
 /// AWS Lambda event definitions for activemq.
 #[cfg(feature = "activemq")]
+#[cfg_attr(docsrs, doc(cfg(feature = "activemq")))]
 pub use event::activemq;
 
 /// AWS Lambda event definitions for alb.
 #[cfg(feature = "alb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alb")))]
 pub use event::alb;
 
 /// AWS Lambda event definitions for apigw.
 #[cfg(feature = "apigw")]
+#[cfg_attr(docsrs, doc(cfg(feature = "apigw")))]
 pub use event::apigw;
 
 /// AWS Lambda event definitions for appsync.
 #[cfg(feature = "appsync")]
+#[cfg_attr(docsrs, doc(cfg(feature = "appsync")))]
 pub use event::appsync;
 
 /// AWS Lambda event definitions for autoscaling.
 #[cfg(feature = "autoscaling")]
+#[cfg_attr(docsrs, doc(cfg(feature = "autoscaling")))]
 pub use event::autoscaling;
 
 /// AWS Lambda event definitions for chime_bot.
 #[cfg(feature = "chime_bot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "chime_bot")))]
 pub use event::chime_bot;
 
 /// AWS Lambda event definitions for clientvpn.
 #[cfg(feature = "clientvpn")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clientvpn")))]
 pub use event::clientvpn;
 
 /// AWS Lambda event definitions for cloudformation
 #[cfg(feature = "cloudformation")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cloudformation")))]
 pub use event::cloudformation;
 
 /// AWS Lambda event definitions for CloudWatch alarms.
 #[cfg(feature = "cloudwatch_alarms")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cloudwatch_alarms")))]
 pub use event::cloudwatch_alarms;
 
 /// AWS Lambda event definitions for CloudWatch events.
 #[cfg(feature = "cloudwatch_events")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cloudwatch_events")))]
 pub use event::cloudwatch_events;
 
 /// AWS Lambda event definitions for cloudwatch_logs.
 #[cfg(feature = "cloudwatch_logs")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cloudwatch_logs")))]
 pub use event::cloudwatch_logs;
 
 /// AWS Lambda event definitions for code_commit.
 #[cfg(feature = "code_commit")]
+#[cfg_attr(docsrs, doc(cfg(feature = "code_commit")))]
 pub use event::code_commit;
 
 /// AWS Lambda event definitions for codebuild.
 #[cfg(feature = "codebuild")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codebuild")))]
 pub use event::codebuild;
 
 /// AWS Lambda event definitions for codedeploy.
 #[cfg(feature = "codedeploy")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codedeploy")))]
 pub use event::codedeploy;
 
 /// AWS Lambda event definitions for codepipeline_cloudwatch.
 #[cfg(feature = "codepipeline_cloudwatch")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codepipeline_cloudwatch")))]
 pub use event::codepipeline_cloudwatch;
 
 /// AWS Lambda event definitions for codepipeline_job.
 #[cfg(feature = "codepipeline_job")]
+#[cfg_attr(docsrs, doc(cfg(feature = "codepipeline_job")))]
 pub use event::codepipeline_job;
 
 /// AWS Lambda event definitions for cognito.
 #[cfg(feature = "cognito")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cognito")))]
 pub use event::cognito;
 
 /// AWS Lambda event definitions for config.
 #[cfg(feature = "config")]
+#[cfg_attr(docsrs, doc(cfg(feature = "config")))]
 pub use event::config;
 
 /// AWS Lambda event definitions for connect.
 #[cfg(feature = "connect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "connect")))]
 pub use event::connect;
 
 /// AWS Lambda event definitions for dynamodb.
 #[cfg(feature = "dynamodb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dynamodb")))]
 pub use event::dynamodb;
 
 /// AWS Lambda event definitions for ecr_scan.
 #[cfg(feature = "ecr_scan")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecr_scan")))]
 pub use event::ecr_scan;
 
 /// AWS Lambda event definitions for firehose.
 #[cfg(feature = "firehose")]
+#[cfg_attr(docsrs, doc(cfg(feature = "firehose")))]
 pub use event::firehose;
 
 /// AWS Lambda event definitions for iam.
 #[cfg(feature = "iam")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iam")))]
 pub use event::iam;
 
 /// AWS Lambda event definitions for iot.
 #[cfg(feature = "iot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iot")))]
 pub use event::iot;
 
 /// AWS Lambda event definitions for iot_1_click.
 #[cfg(feature = "iot_1_click")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iot_1_click")))]
 pub use event::iot_1_click;
 
 /// AWS Lambda event definitions for iot_button.
 #[cfg(feature = "iot_button")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iot_button")))]
 pub use event::iot_button;
 
 /// AWS Lambda event definitions for iot_deprecated.
 #[cfg(feature = "iot_deprecated")]
+#[cfg_attr(docsrs, doc(cfg(feature = "iot_deprecated")))]
 pub use event::iot_deprecated;
 
 /// AWS Lambda event definitions for kafka.
 #[cfg(feature = "kafka")]
+#[cfg_attr(docsrs, doc(cfg(feature = "kafka")))]
 pub use event::kafka;
 
 /// AWS Lambda event definitions for kinesis.
 #[cfg(feature = "kinesis")]
+#[cfg_attr(docsrs, doc(cfg(feature = "kinesis")))]
 pub use event::kinesis;
 
 /// AWS Lambda event definitions for kinesis_analytics.
 #[cfg(feature = "kinesis_analytics")]
+#[cfg_attr(docsrs, doc(cfg(feature = "kinesis_analytics")))]
 pub use event::kinesis::analytics as kinesis_analytics;
 
 /// AWS Lambda event definitions for lambda_function_urls.
 #[cfg(feature = "lambda_function_urls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lambda_function_urls")))]
 pub use event::lambda_function_urls;
 
 /// AWS Lambda event definitions for lex.
 #[cfg(feature = "lex")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lex")))]
 pub use event::lex;
 
 /// AWS Lambda event definitions for rabbitmq.
 #[cfg(feature = "rabbitmq")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rabbitmq")))]
 pub use event::rabbitmq;
 
 /// AWS Lambda event definitions for s3.
 #[cfg(feature = "s3")]
+#[cfg_attr(docsrs, doc(cfg(feature = "s3")))]
 pub use event::s3;
 
 /// AWS Lambda event definitions for s3_batch_job.
 #[cfg(feature = "s3")]
+#[cfg_attr(docsrs, doc(cfg(feature = "s3")))]
 pub use event::s3::batch_job as s3_batch_job;
 
 /// AWS Lambda event definitions for secretsmanager.
 #[cfg(feature = "secretsmanager")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secretsmanager")))]
 pub use event::secretsmanager;
 
 /// AWS Lambda event definitions for ses.
 #[cfg(feature = "ses")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ses")))]
 pub use event::ses;
 
 /// AWS Lambda event definitions for SNS.
 #[cfg(feature = "sns")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sns")))]
 pub use event::sns;
 
 /// AWS Lambda event definitions for SQS.
 #[cfg(feature = "sqs")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqs")))]
 pub use event::sqs;
 
 /// AWS Lambda event definitions for streams.
 #[cfg(feature = "streams")]
+#[cfg_attr(docsrs, doc(cfg(feature = "streams")))]
 pub use event::streams;
 
 /// AWS Lambda event definitions for documentdb.
 #[cfg(feature = "documentdb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "documentdb")))]
 pub use event::documentdb;
 
 /// AWS Lambda event definitions for EventBridge.
 #[cfg(feature = "eventbridge")]
+#[cfg_attr(docsrs, doc(cfg(feature = "eventbridge")))]
 pub use event::eventbridge;

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -38,3 +38,6 @@ tokio = { version = "1.0", features = [
 tokio-stream = "0.1.2"
 tower = { workspace = true, features = ["make", "util"] }
 tracing = { version = "0.1", features = ["log"] }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -62,3 +62,6 @@ lambda_runtime_api_client = { version = "0.12.0", path = "../lambda-runtime-api-
 log = "^0.4"
 maplit = "1.0"
 tokio = { version = "1.0", features = ["macros"] }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -37,3 +37,6 @@ tower-service = { workspace = true }
 tokio = { version = "1.0", features = ["io-util"] }
 tracing = { version = "0.1", features = ["log"], optional = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "json", "env-filter"], optional = true }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -80,3 +80,6 @@ idna_adapter = "=1.2.0"
 lambda_runtime = { path = ".", features = ["tracing", "graceful-shutdown"] }
 pin-project-lite = { workspace = true }
 tracing-appender = "0.2"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/lambda-runtime/src/diagnostic.rs
+++ b/lambda-runtime/src/diagnostic.rs
@@ -119,6 +119,7 @@ impl From<std::io::Error> for Diagnostic {
 }
 
 #[cfg(feature = "anyhow")]
+#[cfg_attr(docsrs, doc(cfg(feature = "anyhow")))]
 impl From<anyhow::Error> for Diagnostic {
     fn from(value: anyhow::Error) -> Diagnostic {
         Diagnostic {
@@ -129,6 +130,7 @@ impl From<anyhow::Error> for Diagnostic {
 }
 
 #[cfg(feature = "eyre")]
+#[cfg_attr(docsrs, doc(cfg(feature = "eyre")))]
 impl From<eyre::Report> for Diagnostic {
     fn from(value: eyre::Report) -> Diagnostic {
         Diagnostic {
@@ -139,6 +141,7 @@ impl From<eyre::Report> for Diagnostic {
 }
 
 #[cfg(feature = "miette")]
+#[cfg_attr(docsrs, doc(cfg(feature = "miette")))]
 impl From<miette::Report> for Diagnostic {
     fn from(value: miette::Report) -> Diagnostic {
         Diagnostic {

--- a/lambda-runtime/src/layers/mod.rs
+++ b/lambda-runtime/src/layers/mod.rs
@@ -14,4 +14,5 @@ pub use trace::TracingLayer;
 #[cfg(feature = "opentelemetry")]
 mod otel;
 #[cfg(feature = "opentelemetry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
 pub use otel::{OpenTelemetryFaasTrigger, OpenTelemetryLayer};

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -178,7 +178,7 @@ where
 /// }
 /// ```
 #[cfg(all(unix, feature = "graceful-shutdown"))]
-#[cfg_attr(docsrs, doc(cfg(all(unix, feature = "tokio-rt"))))]
+#[cfg_attr(docsrs, doc(cfg(all(unix, feature = "graceful-shutdown"))))]
 pub async fn spawn_graceful_shutdown_handler<Fut>(shutdown_hook: impl FnOnce() -> Fut + Send + 'static)
 where
     Fut: Future<Output = ()> + Send + 'static,


### PR DESCRIPTION
📬 *Issue #, if available:*
n/a

✍️ *Description of changes:*

I noticed that our docs.rs docs were only showing default features. Adding the [metadata tag](https://docs.rs/about/metadata) to all crates. (Unfortunately these settings are [not supported](https://github.com/rust-lang/docs.rs/issues/2226) in workspace `Cargo.toml`.

As best as I can tell, we have no directly conflicting features, so I enabled all features to help future-proof. This is most relevant to `lambda_events`.

I didn't directly test the docs.rs build since it's a bit annoying, you have to spin up their server locally. I can if the reviewer prefers though, not a big deal. 


🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
