### PR TITLE
Bump all packages versions to release doc updates

### DIFF
--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_lambda_events"
-version = "0.16.0"
+version = "0.16.1"
 rust-version = "1.81.0"
 description = "AWS Lambda event definitions"
 authors = [

--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-extension"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 rust-version = "1.81.0"
 authors = [

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -39,7 +39,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "0.14.1", path = "../lambda-runtime" }
+lambda_runtime = { version = "0.14.2", path = "../lambda-runtime" }
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.15.0"
+version = "0.15.1"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -39,7 +39,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "0.14.0", path = "../lambda-runtime" }
+lambda_runtime = { version = "0.14.1", path = "../lambda-runtime" }
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }
@@ -58,7 +58,7 @@ features = ["alb", "apigw"]
 [dev-dependencies]
 axum-core = "0.4.3"
 axum-extra = { version = "0.9.2", features = ["query"] }
-lambda_runtime_api_client = { version = "0.12.0", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "0.12.1", path = "../lambda-runtime-api-client" }
 log = "^0.4"
 maplit = "1.0"
 tokio = { version = "1.0", features = ["macros"] }

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime_api_client"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 rust-version = "1.81.0"
 authors = [

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "0.14.1"
+version = "0.14.2"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -44,8 +44,8 @@ hyper-util = { workspace = true, features = [
     "http1",
     "tokio",
 ] }
-lambda-extension = { version = "0.12.0", path = "../lambda-extension", default-features = false, optional = true }
-lambda_runtime_api_client = { version = "0.12.1", path = "../lambda-runtime-api-client", default-features = false }
+lambda-extension = { version = "0.12.1", path = "../lambda-extension", default-features = false, optional = true }
+lambda_runtime_api_client = { version = "0.12.2", path = "../lambda-runtime-api-client", default-features = false }
 miette = { version = "7.2.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.29", optional = true, features = ["semconv_experimental"] }
 pin-project = "1"


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

Bump all packages versions to release doc updates

aws_lambda_events: 0.16.1
lambda-extension: 0.12.1
lambda_http: 0.15.1
lambda_runtime_api_client: 0.12.2
lambda_runtime: 0.14.2


🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
