### PR TITLE
feat(ci): add cargo-semver-checks workflows

### DIFF
--- a/.github/workflows/build-events.yml
+++ b/.github/workflows/build-events.yml
@@ -22,7 +22,6 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - uses: actions/checkout@v3
-
       - name: Build events
         uses: ./.github/actions/rust-build
         with:
@@ -34,6 +33,23 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-
       - name: Test individual event features
         run: make check-event-features
+  semver:
+    name: semver
+    needs: [build, check-event-features]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check `aws_lambda_events` semver with only default features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: stable
+          package: aws_lambda_events
+          feature-group: default-features
+      - name: Check `aws_lambda_events` semver with all features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: stable
+          package: aws_lambda_events
+          feature-group: all-features

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,4 +1,4 @@
-name: Check Lambda Runtime
+name: Check Lambda Extension
 
 on:
   push:
@@ -28,16 +28,31 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - uses: actions/checkout@v3
-
       - name: Build Runtime API Client
         uses: ./.github/actions/rust-build
         with:
           package: lambda_runtime_api_client
           toolchain: ${{ matrix.toolchain}}
-
-
       - name: Build Extensions runtime
         uses: ./.github/actions/rust-build
         with:
           package: lambda-extension
           toolchain: ${{ matrix.toolchain}}
+  semver:
+    name: semver
+    needs: build-runtime
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check `lambda-extension` semver with only default features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: stable
+          package: lambda-extension
+          feature-group: default-features
+      - name: Check `lambda-extension` semver with all features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: stable
+          package: lambda-extension
+          feature-group: all-features

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -27,21 +27,36 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - uses: actions/checkout@v3
-
       - name: Build Runtime API Client
         uses: ./.github/actions/rust-build
         with:
           package: lambda_runtime_api_client
           toolchain: ${{ matrix.toolchain}}
-
       - name: Build Functions runtime
         uses: ./.github/actions/rust-build
         with:
           package: lambda_runtime
           toolchain: ${{ matrix.toolchain}}
-
       - name: Build HTTP layer
         uses: ./.github/actions/rust-build
         with:
           package: lambda_http
           toolchain: ${{ matrix.toolchain}}
+  semver:
+    name: semver
+    needs: build-runtime
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check `lambda_runtime_api_client`, `lambda_runtime`, lambda_http` semver with only default features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: stable
+          package: lambda_runtime_api_client, lambda_runtime, lambda_http
+          feature-group: default-features
+      - name: Check `lambda_runtime_api_client`, `lambda_runtime`, lambda_http` semver with all features
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: stable
+          package: lambda_runtime_api_client, lambda_runtime, lambda_http
+          feature-group: all-features


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

Add cargo semver checks to CI to help capture unintended breaking changes.

This PR itself doesn't contain inputs that will trigger these CI runs, but you can see them green on my fork:
- [lambda-runtime](https://github.com/jlizen/aws-lambda-rust-runtime/actions/runs/15449930436/job/43489374608)
- [lambda-events](https://github.com/jlizen/aws-lambda-rust-runtime/actions/runs/15449930422/job/43489305808)
- [lambda-extension](https://github.com/jlizen/aws-lambda-rust-runtime/actions/runs/15449930418/job/43489282943)

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
