### PR TITLE
chore(lambda-runtime): slightly optimize graceful shutdown helper by using new tokio::try_join biased; api

### DIFF
--- a/examples/extension-internal-flush/Cargo.toml
+++ b/examples/extension-internal-flush/Cargo.toml
@@ -9,4 +9,4 @@ aws_lambda_events = { path = "../../lambda-events" }
 lambda-extension = { path = "../../lambda-extension" }
 lambda_runtime = { path = "../../lambda-runtime" }
 serde = "1.0.136"
-tokio = { version = "1", features = ["macros", "sync"] }
+tokio = { version = "1.46", features = ["macros", "sync"] }

--- a/examples/extension-internal-flush/src/main.rs
+++ b/examples/extension-internal-flush/src/main.rs
@@ -101,9 +101,11 @@ async fn main() -> Result<(), Error> {
 
     let handler = Arc::new(EventHandler::new(request_done_sender));
 
-    // TODO: add biased! to always poll the handler future first, once supported:
-    // https://github.com/tokio-rs/tokio/issues/7304
     tokio::try_join!(
+        // always poll the handler function first before the flush extension,
+        // this results in a smaller future due to not needing to track which was polled first
+        // each time, and also a tiny latency savings
+        biased;
         lambda_runtime::run(service_fn(|event| {
             let handler = handler.clone();
             async move { handler.invoke(event).await }

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -52,7 +52,7 @@ pin-project = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "^1"
 serde_path_to_error = "0.1.11"
-tokio = { version = "1.0", features = [
+tokio = { version = "1.46", features = [
     "macros",
     "io-util",
     "sync",

--- a/lambda-runtime/src/lib.rs
+++ b/lambda-runtime/src/lib.rs
@@ -223,9 +223,11 @@ where
             }
         };
 
-        // TODO: add biased! to always poll the signal handling future first, once supported:
-        // https://github.com/tokio-rs/tokio/issues/7304
-        let _: (_, ()) = tokio::join!(graceful_shutdown_future, async {
+        let _: (_, ()) = tokio::join!(
+            // we always poll the graceful shutdown future first,
+            // which results in a smaller future due to lack of bookkeeping of which was last polled
+            biased;
+            graceful_shutdown_future, async {
             // we suppress extension errors because we don't actually mind if it crashes,
             // all we need to do is kick off the run so that lambda exits the init phase
             let _ = extension.run().await;


### PR DESCRIPTION
✍️ *Description of changes:*
Closing out some minor to-dos. My [tokio PR adding a biased; mode to join/try_join](https://github.com/tokio-rs/tokio/pull/7307) landed. This allows us to skip the bookkeeping of keeping track of which branch of a `join`/`try_join!` statement was polled last, and always just poll in order.

This is a minor optimization for our graceful shutdown handler, since we always want to just poll our graceful shutdown future first before our non-op extension. So we can save a bit of memory on the stack by skipping storing a usize. It also very marginally could impact latency (by micros if not nanos, it's insignificant probably).

Also applying a similar optimization to the internal extension example where we have it the extension wait until after the main handler completes so that it can flush telemetry.

This involved explicitly setting `tokio` to `1.46`. This won't impact our MSRV as our MSRV is set to 1.81 but tokio is 1.70.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
