### PR TITLE
fix(lambda-events): derive Default on KinesisEvent

### DIFF
--- a/lambda-events/src/event/kinesis/event.rs
+++ b/lambda-events/src/event/kinesis/event.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KinesisEvent {
     #[serde(rename = "Records")]
@@ -108,5 +108,12 @@ mod test {
         let output: String = serde_json::to_string(&parsed).unwrap();
         let reparsed: KinesisEvent = serde_json::from_slice(output.as_bytes()).unwrap();
         assert_eq!(parsed, reparsed);
+    }
+
+    #[test]
+    #[cfg(feature = "kinesis")]
+    fn default_kinesis_event() {
+        let event = KinesisEvent::default();
+        assert_eq!(event.records, vec![]);
     }
 }


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

Adds a default implementation for KinesisEvent.

When using `cargo lambda init`, the following test is automatically generated:
```rust
#[cfg(test)]
mod tests {
    use super::*;
    use lambda_runtime::{Context, LambdaEvent};

    #[tokio::test]
    async fn test_event_handler() {
        let event = LambdaEvent::new(KinesisEvent::default(), Context::default());
        let response = function_handler(event).await.unwrap();
        assert_eq!((), response);
    }
}
```

This test fails because `Default` is not implemented on `KinesisEvent`.

This change provides a basic implementation of default by adding `Default` to the existing `#[derive(...)]` attribute.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
