### PR TITLE
fix(lambda-events): impl Default for all Kinesis Event structs

### DIFF
--- a/lambda-events/src/encodings/time.rs
+++ b/lambda-events/src/encodings/time.rs
@@ -29,7 +29,7 @@ impl DerefMut for MillisecondTimestamp {
 }
 
 /// Timestamp with second precision.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SecondTimestamp(
     #[serde(deserialize_with = "deserialize_seconds")]
     #[serde(serialize_with = "serialize_seconds")]

--- a/lambda-events/src/event/kinesis/event.rs
+++ b/lambda-events/src/event/kinesis/event.rs
@@ -13,7 +13,7 @@ pub struct KinesisEvent {
 
 /// `KinesisTimeWindowEvent` represents an Amazon Dynamodb event when using time windows
 /// ref. <https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-windows>
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KinesisTimeWindowEvent {
     #[serde(rename = "KinesisEvent")]
@@ -34,7 +34,7 @@ pub struct KinesisTimeWindowEventResponse {
     // pub batch_item_failures: Vec<KinesisBatchItemFailure>,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KinesisEventRecord {
     /// nolint: stylecheck
@@ -59,7 +59,7 @@ pub struct KinesisEventRecord {
     pub kinesis: KinesisRecord,
 }
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KinesisRecord {
     pub approximate_arrival_timestamp: SecondTimestamp,
@@ -110,10 +110,16 @@ mod test {
         assert_eq!(parsed, reparsed);
     }
 
+    /// `cargo lambda init` autogenerates code that relies on `Default` being implemented for event structs.
+    ///
+    /// This test validates that `Default` is implemented for each KinesisEvent struct.
     #[test]
     #[cfg(feature = "kinesis")]
-    fn default_kinesis_event() {
-        let event = KinesisEvent::default();
-        assert_eq!(event.records, vec![]);
+    fn test_ensure_default_implemented_for_structs() {
+        let _kinesis_event = KinesisEvent::default();
+        let _kinesis_time_window_event = KinesisTimeWindowEvent::default();
+        let _kinesis_event_record = KinesisEventRecord::default();
+        let _kinesis_record = KinesisRecord::default();
+        let _kinesis_encryption_type = KinesisEncryptionType::default();
     }
 }


### PR DESCRIPTION
📬 *Issue #, if available:*
I chatted with @jlizen after she opened https://github.com/awslabs/aws-lambda-rust-runtime/issues/1009.

For testing ergonomics, it makes sense to implement `Default` on all of the structs in Kinesis Events. This PR is a follow up to https://github.com/awslabs/aws-lambda-rust-runtime/pull/1008, and implements `Default` for all the KinesisEvent-related structs.
  
✍️ *Description of changes:*
Implement `Default` on all `KinesisEvent`-related structs.

I also changed the test that I merged in in the last PR. At first glance, this test feels unnecessary because it is not actually making any assertions. However, because `cargo lambda init` generates code that inherently relies on `Default` being implemented on these structs, I think a unit test that attempts to exercise that code path is worthwhile. Theoretically, the test can never fail at runtime, only compile time.

This test will protect against breaking `cargo lambda init`'s autogenerated code in the absence of E2E tests.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
