### PR TITLE
chore(lambda-extension, lambda-http, lambda-runtime-api-client): bump patch versions for new release

### DIFF
--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-extension"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 rust-version = "1.81.0"
 authors = [
@@ -25,7 +25,7 @@ http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client", "server"] }
 hyper-util = { workspace = true }
-lambda_runtime_api_client = { version = "0.12", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "0.12.3", path = "../lambda-runtime-api-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "^1"
 tokio = { version = "1.0", features = [

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.15.1"
+version = "0.15.2"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -38,7 +38,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "0.14.2", path = "../lambda-runtime" }
+lambda_runtime = { version = "0.14.3", path = "../lambda-runtime" }
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }
@@ -57,7 +57,7 @@ features = ["alb", "apigw"]
 [dev-dependencies]
 axum-core = "0.5.0"
 axum-extra = { version = "0.10.0", features = ["query"] }
-lambda_runtime_api_client = { version = "0.12.1", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "0.12.3", path = "../lambda-runtime-api-client" }
 log = "^0.4"
 maplit = "1.0"
 tokio = { version = "1.0", features = ["macros"] }

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime_api_client"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 rust-version = "1.81.0"
 authors = [

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "0.14.2"
+version = "0.14.3"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -37,8 +37,8 @@ http = { workspace = true }
 http-body-util = { workspace = true }
 http-serde = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client"] }
-lambda-extension = { version = "0.12.1", path = "../lambda-extension", default-features = false, optional = true }
-lambda_runtime_api_client = { version = "0.12.2", path = "../lambda-runtime-api-client", default-features = false }
+lambda-extension = { version = "0.12.2", path = "../lambda-extension", default-features = false, optional = true }
+lambda_runtime_api_client = { version = "0.12.3", path = "../lambda-runtime-api-client", default-features = false }
 miette = { version = "7.2.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.29", optional = true, features = ["semconv_experimental"] }
 pin-project = "1"


### PR DESCRIPTION
📬 *Issue #, if available:*
Closes #1019 

✍️ *Description of changes:*

Bumping patch versions of:
- `lambda_http`
- `lambda-runtime`
- `lambda-runtime-api-client`
- `lambda-extension`

`aws-lambda-events` minor version was already bumped.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
