### PR TITLE
chore: (lambda-http, lambda-extension): add missing docsrs feature annotations

### DIFF
--- a/lambda-extension/src/lib.rs
+++ b/lambda-extension/src/lib.rs
@@ -26,6 +26,7 @@ pub mod requests;
 
 /// Utilities to initialize and use `tracing` and `tracing-subscriber` in Lambda Functions.
 #[cfg(feature = "tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
 pub use lambda_runtime_api_client::tracing;
 
 /// Execute the given events processor

--- a/lambda-http/src/lib.rs
+++ b/lambda-http/src/lib.rs
@@ -68,6 +68,7 @@ extern crate maplit;
 pub use http::{self, Response};
 /// Utilities to initialize and use `tracing` and `tracing-subscriber` in Lambda Functions.
 #[cfg(feature = "tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
 pub use lambda_runtime::tracing;
 use lambda_runtime::Diagnostic;
 pub use lambda_runtime::{self, service_fn, tower, Context, Error, LambdaEvent, Service};


### PR DESCRIPTION
✍️ *Description of changes:*
Caught a few more public APIs that were missin gfeature gates.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
