### PR TITLE
fix(lambda-events): derive Default on various Events

### DIFF
--- a/lambda-events/src/encodings/time.rs
+++ b/lambda-events/src/encodings/time.rs
@@ -7,7 +7,7 @@ use serde::{
 use std::ops::{Deref, DerefMut};
 
 /// Timestamp with millisecond precision.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MillisecondTimestamp(
     #[serde(deserialize_with = "deserialize_milliseconds")]
     #[serde(serialize_with = "serialize_milliseconds")]
@@ -73,7 +73,7 @@ impl DerefMut for SecondDuration {
 }
 
 /// Duration with minute precision.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MinuteDuration(
     #[serde(deserialize_with = "deserialize_duration_minutes")]
     #[serde(serialize_with = "serialize_duration_minutes")]

--- a/lambda-events/src/event/activemq/mod.rs
+++ b/lambda-events/src/event/activemq/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::custom_serde::deserialize_lambda_map;
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActiveMqEvent {
     #[serde(default)]
@@ -13,7 +13,7 @@ pub struct ActiveMqEvent {
     pub messages: Vec<ActiveMqMessage>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActiveMqMessage {
     #[serde(default)]
@@ -43,7 +43,7 @@ pub struct ActiveMqMessage {
     pub properties: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ActiveMqDestination {
     #[serde(default)]

--- a/lambda-events/src/event/autoscaling/mod.rs
+++ b/lambda-events/src/event/autoscaling/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use crate::custom_serde::deserialize_lambda_map;
 
 /// `AutoScalingEvent` struct is used to parse the json for auto scaling event types //
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AutoScalingEvent<T1 = Value>
 where

--- a/lambda-events/src/event/chime_bot/mod.rs
+++ b/lambda-events/src/event/chime_bot/mod.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChimeBotEvent {
     #[serde(rename = "Sender")]
@@ -19,7 +19,7 @@ pub struct ChimeBotEvent {
     pub message: Option<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChimeBotEventSender {
     #[serde(default)]
@@ -30,7 +30,7 @@ pub struct ChimeBotEventSender {
     pub sender_id_type: Option<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChimeBotEventDiscussion {
     #[serde(default)]
@@ -41,7 +41,7 @@ pub struct ChimeBotEventDiscussion {
     pub discussion_type: Option<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChimeBotEventInboundHttpsEndpoint {
     #[serde(default)]

--- a/lambda-events/src/event/cloudformation/mod.rs
+++ b/lambda-events/src/event/cloudformation/mod.rs
@@ -19,8 +19,7 @@ where
     Delete(DeleteRequest<P2>),
 }
 
-impl Default for CloudFormationCustomResourceRequest
-{
+impl Default for CloudFormationCustomResourceRequest {
     fn default() -> Self {
         CloudFormationCustomResourceRequest::Create(CreateRequest::default())
     }

--- a/lambda-events/src/event/cloudformation/mod.rs
+++ b/lambda-events/src/event/cloudformation/mod.rs
@@ -19,7 +19,14 @@ where
     Delete(DeleteRequest<P2>),
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+impl Default for CloudFormationCustomResourceRequest
+{
+    fn default() -> Self {
+        CloudFormationCustomResourceRequest::Create(CreateRequest::default())
+    }
+}
+
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateRequest<P2 = Value>
 where
@@ -78,7 +85,7 @@ where
     pub resource_properties: P2,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CloudFormationCustomResourceResponse {
     pub status: CloudFormationCustomResourceResponseStatus,
@@ -91,9 +98,10 @@ pub struct CloudFormationCustomResourceResponse {
     pub data: HashMap<String, String>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CloudFormationCustomResourceResponseStatus {
+    #[default]
     Success,
     Failed,
 }

--- a/lambda-events/src/event/cloudformation/provider.rs
+++ b/lambda-events/src/event/cloudformation/provider.rs
@@ -22,8 +22,7 @@ where
     Delete(DeleteRequest<P2>),
 }
 
-impl Default for CloudFormationCustomResourceRequest
-{
+impl Default for CloudFormationCustomResourceRequest {
     fn default() -> Self {
         CloudFormationCustomResourceRequest::Create(CreateRequest::default())
     }

--- a/lambda-events/src/event/cloudformation/provider.rs
+++ b/lambda-events/src/event/cloudformation/provider.rs
@@ -22,7 +22,14 @@ where
     Delete(DeleteRequest<P2>),
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+impl Default for CloudFormationCustomResourceRequest
+{
+    fn default() -> Self {
+        CloudFormationCustomResourceRequest::Create(CreateRequest::default())
+    }
+}
+
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CreateRequest<P2 = Value>
 where
@@ -60,7 +67,7 @@ where
     pub common: CommonRequestParams<P2>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CommonRequestParams<P2 = Value>
 where
@@ -74,7 +81,7 @@ where
     pub stack_id: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Default)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct CloudFormationCustomResourceResponse<D = Value>
 where

--- a/lambda-events/src/event/cloudwatch_events/mod.rs
+++ b/lambda-events/src/event/cloudwatch_events/mod.rs
@@ -21,7 +21,7 @@ pub mod trustedadvisor;
 
 /// `CloudWatchEvent` is the outer structure of an event sent via CloudWatch Events.
 /// For examples of events that come via CloudWatch Events, see <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html>
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudWatchEvent<T1 = Value>
 where

--- a/lambda-events/src/event/code_commit/mod.rs
+++ b/lambda-events/src/event/code_commit/mod.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::custom_serde::deserialize_nullish_boolean;
 
 /// `CodeCommitEvent` represents a CodeCommit event
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeCommitEvent {
     #[serde(rename = "Records")]

--- a/lambda-events/src/event/codebuild/mod.rs
+++ b/lambda-events/src/event/codebuild/mod.rs
@@ -12,7 +12,7 @@ pub type CodeBuildPhaseType = String;
 
 /// `CodeBuildEvent` is documented at:
 /// <https://docs.aws.amazon.com/codebuild/latest/userguide/sample-build-notifications.html#sample-build-notifications-ref>
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeBuildEvent {
     /// AccountID is the id of the AWS account from which the event originated.
@@ -47,7 +47,7 @@ pub struct CodeBuildEvent {
 }
 
 /// `CodeBuildEventDetail` represents the all details related to the code build event
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeBuildEventDetail {
     #[serde(rename = "build-status")]
@@ -87,7 +87,7 @@ pub struct CodeBuildEventDetail {
 }
 
 /// `CodeBuildEventAdditionalInformation` represents additional information to the code build event
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeBuildEventAdditionalInformation {
     pub artifact: CodeBuildArtifact,
@@ -112,7 +112,7 @@ pub struct CodeBuildEventAdditionalInformation {
 }
 
 /// `CodeBuildArtifact` represents the artifact provided to build
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeBuildArtifact {
     #[serde(default)]
@@ -126,7 +126,7 @@ pub struct CodeBuildArtifact {
 }
 
 /// `CodeBuildEnvironment` represents the environment for a build
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeBuildEnvironment {
     #[serde(default)]
@@ -158,7 +158,7 @@ pub struct CodeBuildEnvironmentVariable {
 }
 
 /// `CodeBuildSource` represent the code source will be build
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeBuildSource {
     #[serde(default)]
@@ -168,7 +168,7 @@ pub struct CodeBuildSource {
 }
 
 /// `CodeBuildLogs` gives the log details of a code build
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeBuildLogs {
     #[serde(default)]

--- a/lambda-events/src/event/codedeploy/mod.rs
+++ b/lambda-events/src/event/codedeploy/mod.rs
@@ -5,7 +5,7 @@ pub type CodeDeployDeploymentState = String;
 
 /// `CodeDeployEvent` is documented at:
 /// <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#acd_event_types>
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeDeployEvent {
     /// AccountID is the id of the AWS account from which the event originated.
@@ -40,7 +40,7 @@ pub struct CodeDeployEvent {
     pub detail: CodeDeployEventDetail,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeDeployEventDetail {
     /// InstanceGroupID is the ID of the instance group.
@@ -65,7 +65,7 @@ pub struct CodeDeployEventDetail {
     pub deployment_group: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct CodeDeployLifecycleEvent {
     pub deployment_id: String,

--- a/lambda-events/src/event/codepipeline_cloudwatch/mod.rs
+++ b/lambda-events/src/event/codepipeline_cloudwatch/mod.rs
@@ -9,7 +9,7 @@ pub type CodePipelineActionState = String;
 
 /// CodePipelineEvent is documented at:
 /// <https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#codepipeline_event_type>
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineCloudWatchEvent {
     /// Version is the version of the event's schema.
@@ -44,7 +44,7 @@ pub struct CodePipelineCloudWatchEvent {
     pub detail: CodePipelineEventDetail,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineEventDetail {
     #[serde(default)]
@@ -64,7 +64,7 @@ pub struct CodePipelineEventDetail {
     pub type_: Option<CodePipelineEventDetailType>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineEventDetailType {
     #[serde(default)]

--- a/lambda-events/src/event/codepipeline_job/mod.rs
+++ b/lambda-events/src/event/codepipeline_job/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// `CodePipelineJobEvent` contains data from an event sent from AWS CodePipeline
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineJobEvent {
     #[serde(rename = "CodePipeline.job")]
@@ -9,7 +9,7 @@ pub struct CodePipelineJobEvent {
 }
 
 /// `CodePipelineJob` represents a job from an AWS CodePipeline event
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineJob {
     #[serde(default)]
@@ -20,7 +20,7 @@ pub struct CodePipelineJob {
 }
 
 /// `CodePipelineData` represents a job from an AWS CodePipeline event
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineData {
     pub action_configuration: CodePipelineActionConfiguration,
@@ -33,14 +33,14 @@ pub struct CodePipelineData {
 }
 
 /// `CodePipelineActionConfiguration` represents an Action Configuration
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineActionConfiguration {
     pub configuration: CodePipelineConfiguration,
 }
 
 /// `CodePipelineConfiguration` represents a configuration for an Action Configuration
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineConfiguration {
     #[serde(default)]
@@ -52,7 +52,7 @@ pub struct CodePipelineConfiguration {
 }
 
 /// `CodePipelineInputArtifact` represents an input artifact
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineInputArtifact {
     pub location: CodePipelineInputLocation,
@@ -62,7 +62,7 @@ pub struct CodePipelineInputArtifact {
 }
 
 /// `CodePipelineInputLocation` represents a input location
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineInputLocation {
     pub s3_location: CodePipelineS3Location,
@@ -72,7 +72,7 @@ pub struct CodePipelineInputLocation {
 }
 
 /// `CodePipelineS3Location` represents an s3 input location
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineS3Location {
     #[serde(default)]
@@ -82,7 +82,7 @@ pub struct CodePipelineS3Location {
 }
 
 /// `CodePipelineOutputArtifact` represents an output artifact
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineOutputArtifact {
     pub location: CodePipelineInputLocation,
@@ -92,7 +92,7 @@ pub struct CodePipelineOutputArtifact {
 }
 
 /// `CodePipelineOutputLocation` represents a output location
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineOutputLocation {
     pub s3_location: CodePipelineS3Location,
@@ -102,7 +102,7 @@ pub struct CodePipelineOutputLocation {
 }
 
 /// `CodePipelineArtifactCredentials` represents CodePipeline artifact credentials
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodePipelineArtifactCredentials {
     #[serde(default)]

--- a/lambda-events/src/event/config/mod.rs
+++ b/lambda-events/src/event/config/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// `ConfigEvent` contains data from an event sent from AWS Config
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigEvent {
     /// The ID of the AWS account that owns the rule

--- a/lambda-events/src/event/connect/mod.rs
+++ b/lambda-events/src/event/connect/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use crate::custom_serde::deserialize_lambda_map;
 
 /// `ConnectEvent` contains the data structure for a Connect event.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectEvent {
     #[serde(rename = "Details")]
@@ -16,7 +16,7 @@ pub struct ConnectEvent {
 }
 
 /// `ConnectDetails` holds the details of a Connect event
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectDetails {
     #[serde(rename = "ContactData")]
@@ -29,7 +29,7 @@ pub struct ConnectDetails {
 }
 
 /// `ConnectContactData` holds all of the contact information for the user that invoked the Connect event.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectContactData {
     /// The custom attributes from Connect that the Lambda function was invoked with.
@@ -65,7 +65,7 @@ pub struct ConnectContactData {
 }
 
 /// `ConnectEndpoint` represents routing information.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectEndpoint {
     #[serde(default)]
@@ -77,7 +77,7 @@ pub struct ConnectEndpoint {
 }
 
 /// `ConnectQueue` represents a queue object.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConnectQueue {
     #[serde(default)]

--- a/lambda-events/src/event/dynamodb/mod.rs
+++ b/lambda-events/src/event/dynamodb/mod.rs
@@ -111,7 +111,7 @@ impl fmt::Display for KeyType {
 
 /// The `Event` stream event handled to Lambda
 /// <http://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-ddb-update>
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 pub struct Event {
     #[serde(rename = "Records")]
     pub records: Vec<EventRecord>,
@@ -141,7 +141,7 @@ pub struct TimeWindowEventResponse {
 }
 
 /// EventRecord stores information about each record of a DynamoDb stream event
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventRecord {
     /// The region in which the GetRecords request was received.
@@ -211,7 +211,7 @@ pub struct UserIdentity {
 
 /// `DynamoDbStreamRecord` represents a description of a single data modification that was performed on an item
 /// in a DynamoDB table.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamRecord {
     /// The approximate date and time when the stream record was created, in UNIX

--- a/lambda-events/src/event/ecr_scan/mod.rs
+++ b/lambda-events/src/event/ecr_scan/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EcrScanEvent {
     #[serde(default)]
@@ -22,7 +22,7 @@ pub struct EcrScanEvent {
     pub detail: EcrScanEventDetailType,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EcrScanEventDetailType {
     #[serde(default)]
@@ -40,7 +40,7 @@ pub struct EcrScanEventDetailType {
     pub image_tags: Vec<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EcrScanEventFindingSeverityCounts {
     #[serde(default)]

--- a/lambda-events/src/event/firehose/mod.rs
+++ b/lambda-events/src/event/firehose/mod.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// `KinesisFirehoseEvent` represents the input event from Amazon Kinesis Firehose. It is used as the input parameter.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KinesisFirehoseEvent {
     #[serde(default)]
@@ -22,7 +22,7 @@ pub struct KinesisFirehoseEvent {
     pub records: Vec<KinesisFirehoseEventRecord>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KinesisFirehoseEventRecord {
     #[serde(default)]

--- a/lambda-events/src/event/iot_1_click/mod.rs
+++ b/lambda-events/src/event/iot_1_click/mod.rs
@@ -5,7 +5,7 @@ use crate::custom_serde::deserialize_lambda_map;
 
 /// `IoTOneClickEvent` represents a click event published by clicking button type
 /// device.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IoTOneClickEvent {
     pub device_event: IoTOneClickDeviceEvent,
@@ -13,13 +13,13 @@ pub struct IoTOneClickEvent {
     pub placement_info: IoTOneClickPlacementInfo,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IoTOneClickDeviceEvent {
     pub button_clicked: IoTOneClickButtonClicked,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IoTOneClickButtonClicked {
     #[serde(default)]
@@ -28,7 +28,7 @@ pub struct IoTOneClickButtonClicked {
     pub reported_time: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IoTOneClickDeviceInfo {
     #[serde(deserialize_with = "deserialize_lambda_map")]
@@ -41,7 +41,7 @@ pub struct IoTOneClickDeviceInfo {
     pub remaining_life: f64,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IoTOneClickPlacementInfo {
     #[serde(default)]

--- a/lambda-events/src/event/iot_button/mod.rs
+++ b/lambda-events/src/event/iot_button/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IoTButtonEvent {
     #[serde(default)]

--- a/lambda-events/src/event/kafka/mod.rs
+++ b/lambda-events/src/event/kafka/mod.rs
@@ -2,7 +2,7 @@ use crate::{custom_serde::deserialize_lambda_map, encodings::MillisecondTimestam
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KafkaEvent {
     #[serde(default)]
@@ -16,7 +16,7 @@ pub struct KafkaEvent {
     pub bootstrap_servers: Option<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KafkaRecord {
     #[serde(default)]

--- a/lambda-events/src/event/kinesis/event.rs
+++ b/lambda-events/src/event/kinesis/event.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KinesisEvent {
     #[serde(rename = "Records")]

--- a/lambda-events/src/event/lex/mod.rs
+++ b/lambda-events/src/event/lex/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::custom_serde::deserialize_lambda_map;
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LexEvent {
     pub message_version: Option<String>,
@@ -30,7 +30,7 @@ pub struct LexBot {
     pub version: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LexCurrentIntent {
     pub name: Option<String>,
@@ -42,7 +42,7 @@ pub struct LexCurrentIntent {
     pub confirmation_status: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LexAlternativeIntents {
     pub name: Option<String>,
@@ -61,7 +61,7 @@ pub struct SlotDetail {
     pub original_value: Option<String>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LexDialogAction {
     pub type_: Option<String>,
@@ -86,7 +86,7 @@ pub struct LexResponse {
     pub dialog_action: Option<LexDialogAction>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LexResponseCard {
     pub version: Option<i64>,

--- a/lambda-events/src/event/rabbitmq/mod.rs
+++ b/lambda-events/src/event/rabbitmq/mod.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::custom_serde::deserialize_lambda_map;
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RabbitMqEvent {
     #[serde(default)]

--- a/lambda-events/src/event/secretsmanager/mod.rs
+++ b/lambda-events/src/event/secretsmanager/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct SecretsManagerSecretRotationEvent {
     pub step: String,

--- a/lambda-events/src/event/ses/mod.rs
+++ b/lambda-events/src/event/ses/mod.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// `SimpleEmailEvent` is the outer structure of an event sent via SES.
-#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SimpleEmailEvent {
     #[serde(rename = "Records")]

--- a/lambda-events/src/event/sns/mod.rs
+++ b/lambda-events/src/event/sns/mod.rs
@@ -7,14 +7,14 @@ use crate::custom_serde::{deserialize_lambda_map, deserialize_nullish_boolean};
 /// The `Event` notification event handled by Lambda
 ///
 /// [https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html](https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html)
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct SnsEvent {
     pub records: Vec<SnsRecord>,
 }
 
 /// SnsRecord stores information about each record of a SNS event
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct SnsRecord {
     /// A string containing the event source.
@@ -31,7 +31,7 @@ pub struct SnsRecord {
 }
 
 /// SnsMessage stores information about each record of a SNS event
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct SnsMessage {
     /// The type of SNS message. For a lambda event, this should always be **Notification**


### PR DESCRIPTION
Issue #1009

Add derive default to various event types. CloudFormationCustomResourceRequest has each enum with a type parameter so manually wrote a default trait implementation that did not need a type parameter.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [skipped this because it changed code outside scope of the issue] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
