### PR TITLE
fix(semver): bump lamda-http to `0.16.0` due to breaking change in dependency, `aws_lambda_events`

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "0.15.2"
+version = "0.16.0"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",


### PR DESCRIPTION
📬 *Issue #, if available:*
Closes: #1023 

✍️ *Description of changes:*
We need to bump to a breaking minor version of `lambda_http`, since it includes a semver-breaking dependency bump on `aws_lambda_events@0.17.0`. Not sure how this made it through our `cargo-semver-checks` CI, I cut #1024 to investigate.

I will also yank the existing release (`0.15.2`) so that the final `0.15` version is non-breaking.

🔏 *By submitting this pull request*

- [ ] I confirm that I've ran `cargo +nightly fmt`.
- [ ] I confirm that I've ran `cargo clippy --fix`.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
