### PR TITLE
chore(ci): unpin cargo lambda in integration test ci

### DIFF
--- a/.github/workflows/run-integration-test.yml
+++ b/.github/workflows/run-integration-test.yml
@@ -18,8 +18,6 @@ jobs:
             repo: cargo-lambda/cargo-lambda
             platform: linux
             arch: x86_64
-            # TODO: unpin once https://github.com/awslabs/aws-lambda-rust-runtime/issues/1006 is fixed
-            tag: v1.8.1
         - name: install Zig toolchain
           uses: mlugg/setup-zig@v2
           with:


### PR DESCRIPTION
📬 *Issue #, if available:*
Closes: #1006 

✍️ *Description of changes:*

Upstream fix has landed: https://github.com/cargo-lambda/cargo-lambda/issues/865

So we should be good to unpin cargo-lambda in our CI. I'll keep an eye to make sure it succeeds after merge (we don't have a convenient way of triggering this workflow on PR).

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
