### PR TITLE
feat: mark selected public enums as #[non_exhaustive]

### DIFF
--- a/lambda-events/src/event/dynamodb/mod.rs
+++ b/lambda-events/src/event/dynamodb/mod.rs
@@ -13,6 +13,7 @@ use std::fmt;
 mod attributes;
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum StreamViewType {
     NewImage,
@@ -35,6 +36,7 @@ impl fmt::Display for StreamViewType {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum StreamStatus {
     Enabling,
@@ -57,6 +59,7 @@ impl fmt::Display for StreamStatus {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SharedIteratorType {
     TrimHorizon,
@@ -79,6 +82,7 @@ impl fmt::Display for SharedIteratorType {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum OperationType {
     #[default]
@@ -99,6 +103,7 @@ impl fmt::Display for OperationType {
 }
 
 #[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum KeyType {
     #[default]

--- a/lambda-http/src/ext/request.rs
+++ b/lambda-http/src/ext/request.rs
@@ -13,6 +13,7 @@ use crate::Body;
 ///
 /// Returned by [`RequestPayloadExt::payload()`]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum PayloadError {
     /// Returned when `application/json` bodies fail to deserialize a payload
     Json(serde_json::Error),
@@ -22,6 +23,7 @@ pub enum PayloadError {
 
 /// Indicates a problem processing a JSON payload.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum JsonPayloadError {
     /// Problem deserializing a JSON payload.
     Parsing(serde_json::Error),
@@ -29,6 +31,7 @@ pub enum JsonPayloadError {
 
 /// Indicates a problem processing an x-www-form-urlencoded payload.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum FormUrlEncodedPayloadError {
     /// Problem deserializing an x-www-form-urlencoded payload.
     Parsing(SerdeError),


### PR DESCRIPTION
## Summary
Partially addresses #1016 by marking a small set of public enums as  so that downstream exhaustive matches remain forward-compatible as event shapes evolve.

## Changes
- lambda-events (DynamoDB): , , , , .
- lambda-http: , , .

These types are likely to gain additional variants over time. Making them non-exhaustive reduces semver churn at the cost of requiring a wildcard match in consumers.

This is intentionally a minimal first step to validate appetite and direction; happy to expand the scope across crates in follow-ups or adjust the target set.
