### PR TITLE
fix(lambda-runtime): ensure if a client disconnects while streaming, the handler does not panic

### DIFF
--- a/lambda-runtime/src/requests.rs
+++ b/lambda-runtime/src/requests.rs
@@ -3,7 +3,7 @@ use bytes::Bytes;
 use http::{header::CONTENT_TYPE, Method, Request, Uri};
 use lambda_runtime_api_client::{body::Body, build_request};
 use serde::Serialize;
-use std::{fmt::Debug, marker::PhantomData, str::FromStr, time::Duration};
+use std::{fmt::Debug, marker::PhantomData, str::FromStr};
 use tokio_stream::{Stream, StreamExt};
 
 pub(crate) trait IntoRequest {
@@ -221,8 +221,10 @@ mod tests {
     #[tokio::test]
     async fn streaming_send_data_error_is_ignored() {
         use crate::StreamResponse;
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::sync::Arc;
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        };
 
         // Track if a panic occurred in any spawned task
         let panicked = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
✍️ *Description of changes:*
Fixes unwrap causing panic when client disconnects from a streaming response

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
