### PR TITLE
Update serde_with feature to include indexmap_2

### DIFF
--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -29,7 +29,7 @@ query_map = { version = "^0.7", features = [
   "url-query",
 ], optional = true }
 serde = { version = "^1", features = ["derive"] }
-serde_with = { version = "^3", features = ["json"], optional = true }
+serde_with = { version = "^3", features = ["json", "indexmap_2"], optional = true }
 serde_json = "^1"
 serde_dynamo = { version = "^4.1", optional = true }
 


### PR DESCRIPTION
✍️ *Description of changes:*

`serde_with` automatically pulls in `indexmap1` rather than `indexmap2`. Since a lot of crates has moved to `indexmap2` this results in duplicate dependencies.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
