### PR TITLE
Ignore examples from release-plz pr

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 semver_check = true
 git_release_enable = false
+files_to_ignore = ["examples/**"]
 
 [[package]]
 name = "lambda-integration-tests"


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

This commit ignores the examples folder in `release-plz`.

https://github.com/aws/aws-lambda-rust-runtime/actions/runs/20997679292/job/60358722169

🔏 *By submitting this pull request*

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
