### PR TITLE
`lambda-http` - disable default features of lambda-runtime

### DIFF
--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -39,7 +39,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "1.1.0-rc1", path = "../lambda-runtime" }
+lambda_runtime = { version = "1.1.0-rc1", path = "../lambda-runtime", default-features = false}
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }


### PR DESCRIPTION
📬 *Issue #, if available:*
Fixes #1092 
✍️ *Description of changes:*
Removes default dependencies of `lambda_runtime` within `lambda_http` crate's `Cargo.toml`.
🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
