### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-events.yml
+++ b/.github/workflows/build-events.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Build events
         uses: ./.github/actions/rust-build
         with:
@@ -33,7 +33,7 @@ jobs:
   check-event-features:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Test individual event features
@@ -43,7 +43,7 @@ jobs:
     needs: [build, check-event-features]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check `aws_lambda_events` semver with only default features
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Build Runtime API Client
         uses: ./.github/actions/rust-build
         with:
@@ -46,7 +46,7 @@ jobs:
     needs: build-runtime
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check `lambda-extension` semver with only default features
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:

--- a/.github/workflows/build-integration-test.yml
+++ b/.github/workflows/build-integration-test.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Build Integration tests
         uses: ./.github/actions/rust-build

--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Build Runtime API Client
         uses: ./.github/actions/rust-build
         with:
@@ -50,7 +50,7 @@ jobs:
     needs: build-runtime
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check `lambda_runtime_api_client`, `lambda_runtime`, lambda_http` semver with only default features
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
 
       - name: Check documentation

--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ jobs:
     name: Cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -23,7 +23,7 @@ jobs:
     name: Cargo clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run clippy check

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - &checkout
         name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - &install-rust

--- a/.github/workflows/run-integration-test.yml
+++ b/.github/workflows/run-integration-test.yml
@@ -28,7 +28,7 @@ jobs:
           uses: aws-actions/setup-sam@v2
           with:
             use-installer: true
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v6
         - name: configure aws credentials
           uses: aws-actions/configure-aws-credentials@v4.0.2
           with:

--- a/.github/workflows/test-rie.yml
+++ b/.github/workflows/test-rie.yml
@@ -17,7 +17,7 @@ jobs:
         example: [basic-lambda, basic-sqs]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: Build and test ${{ matrix.example }} with RIE
       run: |


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3), [`v4`](https://github.com/actions/checkout/releases/tag/v4), [`v5`](https://github.com/actions/checkout/releases/tag/v5) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build-events.yml, build-extension.yml, build-integration-test.yml, build-runtime.yml, check-docs.yml, check-examples.yml, format.yml, release-plz.yml, run-integration-test.yml, test-rie.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
