### PR TITLE
Fix type for claims_to_add_or_override in CognitoEventUserPoolsPreTokenGenV2

### DIFF
--- a/lambda-events/src/event/cognito/mod.rs
+++ b/lambda-events/src/event/cognito/mod.rs
@@ -551,7 +551,7 @@ pub struct ClaimsAndScopeOverrideDetailsV2 {
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CognitoIdTokenGenerationV2 {
-    pub claims_to_add_or_override: HashMap<String, String>,
+    pub claims_to_add_or_override: HashMap<String, Value>,
     pub claims_to_suppress: Vec<String>,
     /// Catchall to catch any additional fields that were present but not explicitly defined by this struct.
     /// Enabled with Cargo feature `catch-all-fields`.
@@ -569,7 +569,7 @@ pub struct CognitoIdTokenGenerationV2 {
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CognitoAccessTokenGenerationV2 {
-    pub claims_to_add_or_override: HashMap<String, String>,
+    pub claims_to_add_or_override: HashMap<String, Value>,
     pub claims_to_suppress: Vec<String>,
     pub scopes_to_add: Vec<String>,
     pub scopes_to_suppress: Vec<String>,


### PR DESCRIPTION
📬 *Issue #, if available:* #1099

✍️ *Description of changes:*
`claims_to_add_or_override` now has the correct type for overriding complex structure in claims. Pre token generation Lambda trigger `V2_0` allows to pass complex datatypes to ID and access token claim values.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
