### PR TITLE
chore: stage minor version bump for lambda-events before next release

### DIFF
--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_lambda_events"
-version = "1.0.3"
+version = "1.1.0"
 rust-version = "1.84.0"
 description = "AWS Lambda event definitions"
 authors = [

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -51,7 +51,7 @@ url = "2.2"
 
 [dependencies.aws_lambda_events]
 path = "../lambda-events"
-version = "1.0"
+version = "1.1"
 default-features = false
 features = ["alb", "apigw"]
 


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

We are having persistent CI failures because our next `aws-lambda-events` release should be minor, not patch. Staging that change in tree now so that CI doesn't stay red until our next release.

```
--- failure struct_field_marked_deprecated: pub struct field is now #[deprecated] ---

Description:
A pub field of a pub struct is now marked #[deprecated]. Downstream crates will get a compiler warning when accessing this field.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_field_marked_deprecated.ron

     Summary semver requires new minor version: 0 major and 1 minor checks failed
```
Example: https://github.com/aws/aws-lambda-rust-runtime/actions/runs/22236953957/job/64350031058?pr=1102



🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
