### PR TITLE
Revert change in releaze-plz toml breaking the github action

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,6 @@
 [workspace]
 semver_check = true
 git_release_enable = false
-files_to_ignore = ["examples/**"]
 
 [[package]]
 name = "lambda-integration-tests"


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

This reverts commit https://github.com/aws/aws-lambda-rust-runtime/commit/c4c36d32135d2f593d6b460d44646726bc3b294 breaking `release-plz`.

https://github.com/aws/aws-lambda-rust-runtime/actions/runs/22912635105/job/66606842037

Could not find `files_to_ignore` anywhere.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
