### PR TITLE
Add Basic Concurrent Example for S3

### DIFF
--- a/examples/basic-lambda-concurrent-s3/Cargo.toml
+++ b/examples/basic-lambda-concurrent-s3/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "basic-lambda-concurrent-s3"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = "1"
+lambda_runtime = { path = "../../lambda-runtime", features = ["concurrency-tokio"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["macros"] }

--- a/examples/basic-lambda-concurrent-s3/src/main.rs
+++ b/examples/basic-lambda-concurrent-s3/src/main.rs
@@ -1,0 +1,38 @@
+use aws_config::BehaviorVersion;
+use lambda_runtime::{service_fn, Error, LambdaEvent};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Request {
+    bucket: String,
+    key: String,
+    body: String,
+}
+
+#[derive(Serialize)]
+struct Response {
+    message: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let config = aws_config::load_defaults(BehaviorVersion::latest()).await;
+    let s3_client = aws_sdk_s3::Client::new(&config);
+
+    lambda_runtime::run_concurrent(service_fn(move |event: LambdaEvent<Request>| {
+        let s3_client = s3_client.clone(); // cheap clone, no Arc needed
+        async move {
+            s3_client
+                .put_object()
+                .bucket(&event.payload.bucket)
+                .key(&event.payload.key)
+                .body(event.payload.body.into_bytes().into())
+                .send()
+                .await?;
+            Ok::<Response, Error>(Response {
+                message: "uploaded".into(),
+            })
+        }
+    }))
+    .await
+}


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

Adding a basic concurrent example for S3 call case.

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
