### PR TITLE
chore: release

### DIFF
--- a/lambda-extension/Cargo.toml
+++ b/lambda-extension/Cargo.toml
@@ -25,7 +25,7 @@ http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client", "server"] }
 hyper-util = { workspace = true }
-lambda_runtime_api_client = { version = "1.0.2", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "1.0.3", path = "../lambda-runtime-api-client" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "^1"
 tokio = { version = "1.0", features = [

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -59,7 +59,7 @@ features = ["alb", "apigw"]
 axum-core = "0.5.4"
 
 axum-extra = { version = "0.12.5", features = ["query"] }
-lambda_runtime_api_client = { version = "1.0.2", path = "../lambda-runtime-api-client" }
+lambda_runtime_api_client = { version = "1.0.3", path = "../lambda-runtime-api-client" }
 
 log = "^0.4"
 maplit = "1.0"

--- a/lambda-runtime-api-client/CHANGELOG.md
+++ b/lambda-runtime-api-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime_api_client-v1.0.2...lambda_runtime_api_client-v1.0.3) - 2026-03-13
+
+### Other
+
+- release ([#1118](https://github.com/aws/aws-lambda-rust-runtime/pull/1118))
+
 ## [1.0.2](https://github.com/aws/aws-lambda-rust-runtime/compare/v1.0.2...lambda_runtime_api_client-v1.0.2) - 2026-01-06
 
 ### Added

--- a/lambda-runtime-api-client/Cargo.toml
+++ b/lambda-runtime-api-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime_api_client"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 rust-version = "1.84.0"
 authors = [

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -42,7 +42,7 @@ http-body-util = { workspace = true }
 http-serde = { workspace = true }
 hyper = { workspace = true, features = ["http1", "client"] }
 lambda-extension = { version = "1.0", path = "../lambda-extension", default-features = false, optional = true }
-lambda_runtime_api_client = { version = "1.0.2", path = "../lambda-runtime-api-client", default-features = false }
+lambda_runtime_api_client = { version = "1.0.3", path = "../lambda-runtime-api-client", default-features = false }
 miette = { version = "7.2.0", optional = true }
 opentelemetry-semantic-conventions = { version = "0.31", optional = true, features = ["semconv_experimental"] }
 pin-project = "1"


### PR DESCRIPTION



## 🤖 New release

* `aws_lambda_events`: 1.1.0 -> 1.1.1
* `lambda_runtime_api_client`: 1.0.2 -> 1.0.3 (✓ API compatible changes)
* `lambda-extension`: 1.0.2 -> 1.0.3
* `lambda_runtime`: 1.1.0-rc1 -> 1.1.1
* `lambda_http`: 1.1.0-rc1 -> 1.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `aws_lambda_events`

<blockquote>

## [1.1.1](https://github.com/aws/aws-lambda-rust-runtime/compare/aws_lambda_events-v1.0.3...aws_lambda_events-v1.1.1) - 2026-03-11

### Added

- *(lambda-events)* support X509 custom authorizer in IoT events ([#1114](https://github.com/aws/aws-lambda-rust-runtime/pull/1114))
- *(lambda-events)* add Control Tower lifecycle events module ([#1107](https://github.com/aws/aws-lambda-rust-runtime/pull/1107))
- *(lambda-events)* add VPC Lattice event structures ([#1036](https://github.com/aws/aws-lambda-rust-runtime/pull/1036))
- Add builder pattern support for event response types ([#1090](https://github.com/aws/aws-lambda-rust-runtime/pull/1090))

### Fixed

- *(sns)* support SubscriptionConfirmation and UnsubscribeConfirmation message types ([#1102](https://github.com/aws/aws-lambda-rust-runtime/pull/1102))
- *(lambda-events)* `claims_to_add_or_override` type in `CognitoEventUserPoolsPreTokenGenV2` ([#1100](https://github.com/aws/aws-lambda-rust-runtime/pull/1100))

### Other

- *(lambda-events)* deprecate authorizer-specific fields in `ApiGatewayV2httpRequest` ([#1089](https://github.com/aws/aws-lambda-rust-runtime/pull/1089))
</blockquote>

## `lambda_runtime_api_client`

<blockquote>

## [1.0.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime_api_client-v1.0.2...lambda_runtime_api_client-v1.0.3) - 2026-03-13

### Other

- release ([#1118](https://github.com/aws/aws-lambda-rust-runtime/pull/1118))
</blockquote>

## `lambda-extension`

<blockquote>

## [1.0.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda-extension-v1.0.2...lambda-extension-v1.0.3) - 2026-03-12

### Added

- Make Telemetry API log record type generic ([#1098](https://github.com/aws/aws-lambda-rust-runtime/pull/1098))
</blockquote>

## `lambda_runtime`

<blockquote>

## [1.1.1](https://github.com/aws/aws-lambda-rust-runtime/compare/v1.0.2...lambda_runtime-v1.1.1) - 2026-03-11

Thank you to all the contributors who helped make this release possible. We appreciate your time, effort, and passion for the Rust Lambda community. ❤️

### Lambda Managed Instances

The runtime now supports Lambda Managed Instances via the `concurrency-tokio` feature flag (previously `experimental-concurrency`). Lambda Managed Instances allow multiple concurrent requests to be processed within a single execution environment. When `AWS_LAMBDA_MAX_CONCURRENCY` is set, the runtime spawns multiple independent long-poll workers to handle concurrent invocations. If the env var is unset or <= 1, it falls back to sequential behavior automatically — so the same handler works on both classic Lambda and Lambda Managed Instances. ([#1067](https://github.com/aws/aws-lambda-rust-runtime/pull/1067))

```toml
[dependencies]
lambda_runtime = { version = "1.1", features = ["concurrency-tokio"] }
```

```rust
lambda_runtime::run_concurrent(service_fn(my_handler)).await?;
```

For a complete working example, see [examples/basic-lambda-concurrent](https://github.com/aws/aws-lambda-rust-runtime/tree/main/examples/basic-lambda-concurrent). For detailed guidance on building functions for multi-concurrency, including shared state patterns and database connection pools, see the [Rust runtime for Lambda Managed Instances](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances-rust.html) documentation.

We would like also to involve the community in a broader discussion about improving our approach on multiconcurrency. You can find the discussion in ([#1120](https://github.com/aws/aws-lambda-rust-runtime/issues/1120))

### Added

- *(lambda-managed-instances)* log non-2xx Lambda Runtime API responses with status and body ([#1109](https://github.com/aws/aws-lambda-rust-runtime/pull/1109))
- tenant ID propagation for multi-tenant Lambda use cases. The `tenant_id` is available in the `context.tenant_id` field (`Option<String>`) and is automatically extracted from the `lambda-runtime-aws-tenant-id` header when present ([#1082](https://github.com/aws/aws-lambda-rust-runtime/pull/1082))
- Add builder pattern support for event response types ([#1090](https://github.com/aws/aws-lambda-rust-runtime/pull/1090))

### Fixed

- *(test)* fix test_concurrent_structured_logging_isolation ([#1121](https://github.com/aws/aws-lambda-rust-runtime/pull/1121))

### Changed

- MSRV updated from 1.82.0 to 1.84.0, enabled MSRV-aware resolver ([#1078](https://github.com/aws/aws-lambda-rust-runtime/pull/1078))
- X-Ray trace ID now sourced from `Context` instead of environment variables ([#1067](https://github.com/aws/aws-lambda-rust-runtime/pull/1067))

### Other

- *(lambda-managed-instances)* add `tokio_unstable` to known cfgs to avoid linter warns ([#1095](https://github.com/aws/aws-lambda-rust-runtime/pull/1095))
- *(lambda-managed-instances)* verify request-ID isolation in concurrent exec ([#1086](https://github.com/aws/aws-lambda-rust-runtime/pull/1086))
- *(lambda-managed-instances)* warn on `run()` with `AWS_LAMBDA_MAX_CONCURRENCY`, rename feature `experimental-concurrency` to `concurrency-tokio` ([#1095](https://github.com/aws/aws-lambda-rust-runtime/pull/1095))
- Introducing Harness Testing ([#1103](https://github.com/aws/aws-lambda-rust-runtime/pull/1103))
</blockquote>

## `lambda_http`

<blockquote>

## [1.1.1](https://github.com/aws/aws-lambda-rust-runtime/compare/v1.0.2...lambda_http-v1.1.1) - 2026-03-11

### Added

- *(lambda-managed-instances)* Lambda Managed Instances support via `concurrency-tokio` feature flag with `run_concurrent()` and `BoxCloneService` for concurrent streaming responses ([#1067](https://github.com/aws/aws-lambda-rust-runtime/pull/1067))
- Add builder pattern support for event response types ([#1090](https://github.com/aws/aws-lambda-rust-runtime/pull/1090))

### Changed

- MSRV updated from 1.82.0 to 1.84.0, enabled MSRV-aware resolver ([#1078](https://github.com/aws/aws-lambda-rust-runtime/pull/1078))

### Other

- *(lambda-managed-instances)* add `tokio_unstable` to known cfgs to avoid linter warns ([#1095](https://github.com/aws/aws-lambda-rust-runtime/pull/1095))
- *(lambda-managed-instances)* warn on `run()` with `AWS_LAMBDA_MAX_CONCURRENCY`, rename feature `experimental-concurrency` to `concurrency-tokio` ([#1095](https://github.com/aws/aws-lambda-rust-runtime/pull/1095))
- *(lambda-managed-instances)* verify request-ID isolation in concurrent exec ([#1086](https://github.com/aws/aws-lambda-rust-runtime/pull/1086))
- Introducing Harness Testing ([#1103](https://github.com/aws/aws-lambda-rust-runtime/pull/1103))
- disable default features of lambda-runtime ([#1093](https://github.com/aws/aws-lambda-rust-runtime/pull/1093))
- *(deps)* update axum-extra requirement from 0.10.2 to 0.12.5 ([#1079](https://github.com/aws/aws-lambda-rust-runtime/pull/1079))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).