### PR TITLE
Fix deployment issue in aws_lambda_event because of dev dep

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,6 +9,10 @@ git_release_name = "v{{ version }}"
 changelog_include = ["lambda_http", "lambda_runtime_api_client", "lambda-extension", "aws_lambda_events"]
 
 [[package]]
+name = "aws_lambda_events"
+publish_no_verify = true # dev-dep on lambda_runtime may not be published yet
+
+[[package]]
 name = "lambda-integration-tests"
 publish = false
 release = false


### PR DESCRIPTION
📬 *Issue #, if available:*

✍️ *Description of changes:*

`aws_lambda_events` have a dev-dependency with `lambda_runtime` that blocks release. Trying to fix this in `release-plz`.

🔏 *By submitting this pull request*

- [ ] I confirm that I've ran `cargo +nightly fmt`.
- [ ] I confirm that I've ran `cargo clippy --fix`.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.
- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
