### PR TITLE
chore: add builder derive for time structs

### DIFF
--- a/lambda-events/src/encodings/time.rs
+++ b/lambda-events/src/encodings/time.rs
@@ -7,7 +7,6 @@ use serde::{
 use std::ops::{Deref, DerefMut};
 
 /// Timestamp with millisecond precision.
-#[non_exhaustive]
 #[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MillisecondTimestamp(
     #[serde(deserialize_with = "deserialize_milliseconds")]
@@ -30,7 +29,6 @@ impl DerefMut for MillisecondTimestamp {
 }
 
 /// Timestamp with second precision.
-#[non_exhaustive]
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SecondTimestamp(
     #[serde(deserialize_with = "deserialize_seconds")]
@@ -53,7 +51,6 @@ impl DerefMut for SecondTimestamp {
 }
 
 /// Duration with second precision.
-#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SecondDuration(
     #[serde(deserialize_with = "deserialize_duration_seconds")]
@@ -76,7 +73,6 @@ impl DerefMut for SecondDuration {
 }
 
 /// Duration with minute precision.
-#[non_exhaustive]
 #[derive(Clone, Default, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MinuteDuration(
     #[serde(deserialize_with = "deserialize_duration_minutes")]


### PR DESCRIPTION
📬 *Issue #, if available: #1137*

✍️ *Description of changes:*

Added `Builder` derive for the time structs (`MillisecondTimestamp`, `SecondTimestamp`, `SecondDuration`, `MinuteDuration`).

🔏 *By submitting this pull request*

- [x] I confirm that I've ran `cargo +nightly fmt`.
- [x] I confirm that I've ran `cargo clippy --fix`.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
