### PR TITLE
chore: release v1.1.3

### DIFF
--- a/lambda-events/CHANGELOG.md
+++ b/lambda-events/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/aws_lambda_events-v1.1.2...aws_lambda_events-v1.1.3) - 2026-04-16
+
+### Other
+
+- remove non exhaustive from time structs ([#1138](https://github.com/aws/aws-lambda-rust-runtime/pull/1138))
+
 ## [1.1.2](https://github.com/aws/aws-lambda-rust-runtime/compare/aws_lambda_events-v1.1.1...aws_lambda_events-v1.1.2) - 2026-03-19
 
 ### Fixed

--- a/lambda-events/Cargo.toml
+++ b/lambda-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_lambda_events"
-version = "1.1.2"
+version = "1.1.3"
 rust-version = "1.84.0"
 description = "AWS Lambda event definitions"
 authors = [

--- a/lambda-http/CHANGELOG.md
+++ b/lambda-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.1.2...lambda_http-v1.1.3) - 2026-04-16
+
+### Other
+
+- updated the following local packages: lambda_runtime
+
 ## [1.1.2](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.1.1...lambda_http-v1.1.2) - 2026-03-19
 
 ### Other

--- a/lambda-http/Cargo.toml
+++ b/lambda-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_http"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",
@@ -39,7 +39,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-lambda_runtime = { version = "1.1.2", path = "../lambda-runtime", default-features = false}
+lambda_runtime = { version = "1.1.3", path = "../lambda-runtime", default-features = false}
 mime = "0.3"
 percent-encoding = "2.2"
 pin-project-lite = { workspace = true }

--- a/lambda-runtime/CHANGELOG.md
+++ b/lambda-runtime/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.1.2...lambda_runtime-v1.1.3) - 2026-04-16
+
+### Other
+
+- remove non exhaustive from time structs ([#1138](https://github.com/aws/aws-lambda-rust-runtime/pull/1138))
+
 ## [1.1.2](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.1.1...lambda_runtime-v1.1.2) - 2026-03-19
 
 ### Fixed

--- a/lambda-runtime/Cargo.toml
+++ b/lambda-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda_runtime"
-version = "1.1.2"
+version = "1.1.3"
 authors = [
     "David Calavera <dcalaver@amazon.com>",
     "Harold Sun <sunhua@amazon.com>",


### PR DESCRIPTION



## 🤖 New release

* `aws_lambda_events`: 1.1.2 -> 1.1.3 (✓ API compatible changes)
* `lambda_runtime`: 1.1.2 -> 1.1.3 (✓ API compatible changes)
* `lambda_http`: 1.1.2 -> 1.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `aws_lambda_events`

<blockquote>

## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/aws_lambda_events-v1.1.2...aws_lambda_events-v1.1.3) - 2026-04-16

### Other

- remove non exhaustive from time structs ([#1138](https://github.com/aws/aws-lambda-rust-runtime/pull/1138))
</blockquote>

## `lambda_runtime`

<blockquote>

## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_runtime-v1.1.2...lambda_runtime-v1.1.3) - 2026-04-16

### Other

- remove non exhaustive from time structs ([#1138](https://github.com/aws/aws-lambda-rust-runtime/pull/1138))
</blockquote>

## `lambda_http`

<blockquote>

## [1.1.3](https://github.com/aws/aws-lambda-rust-runtime/compare/lambda_http-v1.1.2...lambda_http-v1.1.3) - 2026-04-16

### Other

- updated the following local packages: lambda_runtime
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).